### PR TITLE
Restrict publish workflows to pushes on main

### DIFF
--- a/.github/workflows/publish-apache-tika.yml
+++ b/.github/workflows/publish-apache-tika.yml
@@ -2,6 +2,8 @@ name: Publish Apache Tika Helm Chart
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
     paths:
       - apache-tika/**
 jobs:

--- a/.github/workflows/publish-calibre-web-automated.yml
+++ b/.github/workflows/publish-calibre-web-automated.yml
@@ -2,6 +2,8 @@ name: Publish Calibre Web Automated Helm Chart
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
     paths:
       - calibre-web-automated/**
 jobs:

--- a/.github/workflows/publish-cyberchef.yml
+++ b/.github/workflows/publish-cyberchef.yml
@@ -2,6 +2,8 @@ name: Publish Cyberchef Helm Chart
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
     paths:
       - cyberchef/**
 jobs:

--- a/.github/workflows/publish-gotenberg.yml
+++ b/.github/workflows/publish-gotenberg.yml
@@ -2,6 +2,8 @@ name: Publish Gotenberg Helm Chart
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
     paths:
       - gotenberg/**
 jobs:

--- a/.github/workflows/publish-homeassistant.yml
+++ b/.github/workflows/publish-homeassistant.yml
@@ -2,6 +2,8 @@ name: Publish Homeassistant Helm Chart
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
     paths:
       - homeassistant/**
 jobs:

--- a/.github/workflows/publish-matrix-synapse.yml
+++ b/.github/workflows/publish-matrix-synapse.yml
@@ -2,6 +2,8 @@ name: Publish Matrix Synapse Helm Chart
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
     paths:
       - matrix-synapse/**
 jobs:

--- a/.github/workflows/publish-music-assistant-skill.yml
+++ b/.github/workflows/publish-music-assistant-skill.yml
@@ -2,6 +2,8 @@ name: Publish Music-Assistant Skill Helm Chart
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
     paths:
       - music-assistant-skill/**
 jobs:

--- a/.github/workflows/publish-outline.yml
+++ b/.github/workflows/publish-outline.yml
@@ -2,6 +2,8 @@ name: Publish Outline Helm Chart
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
     paths:
       - outline/**
 jobs:

--- a/.github/workflows/publish-paperless-ngx.yml
+++ b/.github/workflows/publish-paperless-ngx.yml
@@ -2,6 +2,8 @@ name: Publish Paperless-NGX Helm Chart
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
     paths:
       - paperless-ngx/**
 jobs:

--- a/.github/workflows/publish-patchmon.yml
+++ b/.github/workflows/publish-patchmon.yml
@@ -2,6 +2,8 @@ name: Publish Patchmon Helm Chart
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
     paths:
       - patchmon/**
 jobs:

--- a/.github/workflows/publish-rallly.yml
+++ b/.github/workflows/publish-rallly.yml
@@ -2,6 +2,8 @@ name: Publish Rallly Helm Chart
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
     paths:
       - rallly/**
 jobs:

--- a/.github/workflows/publish-samba.yml
+++ b/.github/workflows/publish-samba.yml
@@ -2,6 +2,8 @@ name: Publish Samba Helm Chart
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
     paths:
       - samba/**
 jobs:

--- a/.github/workflows/publish-satisfactory.yml
+++ b/.github/workflows/publish-satisfactory.yml
@@ -2,6 +2,8 @@ name: Publish Zipline Helm Chart
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
     paths:
       - satisfactory/**
 jobs:

--- a/.github/workflows/publish-teamspeak-server.yml
+++ b/.github/workflows/publish-teamspeak-server.yml
@@ -2,6 +2,8 @@ name: Publish TeamSpeak Server Helm Chart
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
     paths:
       - teamspeak-server/**
 jobs:

--- a/.github/workflows/publish-urlaubsverwaltung.yml
+++ b/.github/workflows/publish-urlaubsverwaltung.yml
@@ -2,6 +2,8 @@ name: Publish Urlaubsverwaltung Helm Chart
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
     paths:
       - urlaubsverwaltung/**
 jobs:

--- a/.github/workflows/publish-voucher-vault.yml
+++ b/.github/workflows/publish-voucher-vault.yml
@@ -2,6 +2,8 @@ name: Publish VoucherVault Helm Chart
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
     paths:
       - voucher-vault/**
 jobs:

--- a/.github/workflows/publish-zipline.yml
+++ b/.github/workflows/publish-zipline.yml
@@ -2,6 +2,8 @@ name: Publish Zipline Helm Chart
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
     paths:
       - zipline/**
 jobs:


### PR DESCRIPTION
## Summary

Fixes #4

Adds a `branches: [main]` filter to the `on.push` trigger of all 17 `publish-<chart>.yml` workflows. Previously, a push to **any** branch touching a chart directory packaged and published that chart to the JK-Registry.

- Only pushes to `main` trigger a publish now; manual `workflow_dispatch` remains available on every workflow.
- The reusable `publish-helm-chart.yml` is untouched (runs only via `workflow_call`/`workflow_dispatch`).
- No chart directories are touched, so this PR itself triggers no publishes.

## Validation

- `git diff` reviewed: exactly two lines (`branches:` / `- main`) added per file, nothing else.
- All workflow files parsed as YAML and checked programmatically: every publish workflow has `branches == ["main"]` and its `paths` filter intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)