### PR TITLE
Upgrade actions/checkout from v2 to v4

### DIFF
--- a/.github/workflows/change-app-version.yml
+++ b/.github/workflows/change-app-version.yml
@@ -64,7 +64,7 @@ jobs:
           JK_CLUSTER_BOT_TOKEN: op://GitHub-Actions/github-helm-charts-push-token/credential
           JK_CLUSTER_USERNAME: op://GitHub-Actions/github-helm-charts-push-token/username
           JK_CLUSTER_EMAIL: op://GitHub-Actions/github-helm-charts-push-token/email
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           token: ${{ env.JK_CLUSTER_BOT_TOKEN }}
       - name: "Get Chart Version"

--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Repository"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: "Install Helm"
         uses: azure/setup-helm@v4
       - name: "Configure OP-Connect"


### PR DESCRIPTION
## Summary

Fixes #6

Upgrades the deprecated `actions/checkout@v2` (Node 12) to `actions/checkout@v4` in the only two places it is used:

- `.github/workflows/publish-helm-chart.yml`
- `.github/workflows/change-app-version.yml` (the `token:` parameter works unchanged with v4)

Other action versions (`azure/setup-helm@v4`, `1password/load-secrets-action@v2`) are current and untouched.

## Validation

- Diff contains exactly the two version-string changes.
- Both workflow files parse as valid YAML.
- No chart directories touched, so no publishes are triggered.