### PR TITLE
Add resource requests/limits to paperless consume cronjob

### DIFF
--- a/paperless-ngx/Chart.yaml
+++ b/paperless-ngx/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to deploy Paperless-NGX on Kubernetes
 
 type: application
 
-version: 4.4.0+up2.20.13
+version: 4.4.1+up2.20.13
 
 appVersion: 2.20.13
 

--- a/paperless-ngx/templates/paperless-consume.cronjob.yaml
+++ b/paperless-ngx/templates/paperless-consume.cronjob.yaml
@@ -24,6 +24,15 @@ spec:
                 - name: consume-folder
                   mountPath: "/mnt/consume"
                   readOnly: false
+              resources:
+                requests:
+                  memory: "{{ .Values.smbConnection.cron.resources.requests.memory }}"
+                  cpu: "{{ .Values.smbConnection.cron.resources.requests.cpu }}"
+                  ephemeral-storage: "{{ .Values.smbConnection.cron.resources.requests.ephemeralStorage }}"
+                limits:
+                  memory: "{{ .Values.smbConnection.cron.resources.limits.memory }}"
+                  cpu: "{{ .Values.smbConnection.cron.resources.limits.cpu }}"
+                  ephemeral-storage: "{{ .Values.smbConnection.cron.resources.limits.ephemeralStorage }}"
           restartPolicy: Never
           volumes:
             - name: smb-share

--- a/paperless-ngx/values.yaml
+++ b/paperless-ngx/values.yaml
@@ -46,6 +46,16 @@ smbConnection:
   enabled: false
   server: null
   cronJob: "0 0,12 * * *"
+  cron:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 16Mi
+        ephemeralStorage: 10Mi
+      limits:
+        cpu: 100m
+        memory: 32Mi
+        ephemeralStorage: 50Mi
 oidc:
   enabled: false
   autoLoginWithProvider: false


### PR DESCRIPTION
## Summary

Fixes #10

The paperless-consume CronJob (busybox container moving PDFs from the SMB share to the consume folder) was the last workload without resource requests/limits — `music-assistant-skill`, the other affected workload from the issue, was already removed in #15.

- Adds a `resources` block to the CronJob container, configurable via `smbConnection.cron.resources` (naming as requested by the maintainer), following the chart's existing camelCase `ephemeralStorage` values convention.
- Minimal defaults for the busybox job: requests `10m` CPU / `16Mi` memory / `10Mi` ephemeral-storage, limits `100m` / `32Mi` / `50Mi`.
- Chart version bumped `4.4.0+up2.20.13` → `4.4.1+up2.20.13` (app version unchanged). Merging publishes the new chart version as intended.

## Validation

- `helm lint --strict paperless-ngx` passes.
- `helm template` with `smbConnection.enabled=true` renders the CronJob with the new resources block exactly as expected.
- `helm package` succeeds (`paperless-ngx-4.4.1+up2.20.13.tgz`).