### PR TITLE
Keep CLAUDE.md workflow and README repo info current

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,15 +7,22 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 The main Claude session acts as the **task manager** and does not implement issues itself:
 
 1. **Plan first, get approval**: The manager presents a plan for the issue and waits for the user's explicit approval. No implementation before approval.
-2. **Delegate implementation**: After approval, the manager launches a dedicated **development agent**. The agent implements the issue completely on its own branch and opens a PR.
-3. **PR comment handling by the agent**: After opening the PR, the development agent watches it for review comments. New comments are addressed automatically (code changes, reply on the thread), and addressed threads are marked as **resolved**.
-4. **Agent lifetime**: The development agent terminates itself once its PR has been merged (or closed).
-5. Only after the PR has been **merged by the user** may work on the next issue begin. The user merges; never merge yourself.
-6. **After the merge, verify the linked issue was closed** (auto-close via "Fixes #n"); close it manually if not.
+2. **Document the final plan on the issue**: Once approved, the plan is posted as a comment on the GitHub issue before implementation starts (skip if the issue body already contains the full plan; later decisions go there as comments too).
+3. **Delegate implementation**: After approval, the manager launches a dedicated **development agent**. The agent implements the issue completely on its own branch and opens a PR.
+4. **PR comment handling by the agent**: After opening the PR, the development agent watches it for review comments. New comments are addressed automatically (code changes, reply on the thread), and addressed threads are marked as **resolved**.
+5. **Agent lifetime**: The development agent terminates itself once its PR has been merged (or closed).
+6. Only after the PR has been **merged by the user** may work on the next issue begin. The user merges; never merge yourself.
+7. **After the merge, verify the linked issue was closed** (auto-close via "Fixes #n"); close it manually if not.
 
 Additional rules for all commits, PRs, issues, and comments:
 
 - Do **not** add a `Co-Authored-By` trailer and do **not** append "Generated with Claude Code" footers.
+
+## Keep the docs current
+
+- Changes to this issue workflow always go into this CLAUDE.md file.
+- General repository information (charts, CI pipelines, conventions, tooling) always lives in README.md. Any PR that changes repo-wide behavior must update README.md in the same PR.
+- Runtime verification of chart changes is done in a local, throwaway k3d cluster (k3d is installed on the maintainer's machine): stub CRD for `OnePasswordItem`, dummy secrets, throwaway infrastructure (postgres/redis) where needed.
 
 ## What this repo is
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,10 @@ Collection of some self-made helm-charts. Each top-level directory is a standalo
 
 ## CI/CD (GitHub Actions)
 
-- `publish-<chart>.yml` — one thin workflow per chart; triggers on any push touching `<chart>/**` (or manually) and calls the reusable workflow below. **A push to a chart directory on `main` publishes that chart**, so the chart version must be bumped in the same change.
+- `publish-<chart>.yml` — one thin workflow per chart; triggers on pushes to `main` touching `<chart>/**` (or manually) and calls the reusable workflow below. **A push to a chart directory on `main` publishes that chart**, so the chart version must be bumped in the same change.
 - `publish-helm-chart.yml` — reusable workflow: `helm package`, then `helm push` to the private JK-Registry. Registry credentials come from 1Password Connect (`OP_CONNECT_TOKEN` secret, items under `op://GitHub-Actions/`).
 - `change-app-version.yml` — manually dispatched app-version bump; the chart must be listed in its `chart-name` choice list.
+- `validate-charts.yml` — PR pipeline: detects which charts a PR touches and, for exactly those, runs `helm lint --strict`, `helm package`, and a chart-version bump check (`template-chart` is exempt from the version check). PRs without chart changes skip the build matrix.
 
 ## Creating a new chart
 
@@ -46,11 +47,13 @@ Collection of some self-made helm-charts. Each top-level directory is a standalo
 Validate locally with:
 
 ```bash
-helm lint <chart-name>
+helm lint --strict <chart-name>
 helm template <chart-name> --set ingress.domain=example.com --set ingress.clusterIssuer=letsencrypt
 ```
 
 (required values vary per chart)
+
+For runtime verification (do the workloads actually start, do probes/security settings hold?), use a throwaway local [k3d](https://k3d.io) cluster: `k3d cluster create <name>`, apply a stub CRD for `OnePasswordItem` plus dummy secrets (and throwaway postgres/redis pods where the app needs them), `helm install` the chart, watch pod readiness/events, then `k3d cluster delete <name>`.
 
 ## Chart conventions
 


### PR DESCRIPTION
## Summary

Maintainer directive: the issue workflow always lives in CLAUDE.md, general repository information always in README.md — this PR brings both up to date with what changed recently.

**CLAUDE.md**
- New workflow step: the approved final plan is posted as a comment on the issue before implementation starts.
- New "Keep the docs current" section: workflow changes go into CLAUDE.md; repo-wide changes must update README.md in the same PR; runtime verification happens in a throwaway local k3d cluster.

**README.md**
- Documents the `validate-charts.yml` PR pipeline (changed-charts detection, strict lint, package, version-bump check).
- Publish-workflow description now reflects the `main`-only branch filter from #13.
- Local validation section: `--strict` lint and the k3d runtime-verification approach.