### PR TITLE
Add missing serviceName to calibre-web-automated StatefulSet

### DIFF
--- a/calibre-web-automated/Chart.yaml
+++ b/calibre-web-automated/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 name: calibre-web-automated
 description: A Helm chart to deploy calibere-web-automated
 
-version: 2.0.0+upv4.0.6
+version: 2.0.1+upv4.0.6
 appVersion: v4.0.6
 
 maintainers:

--- a/calibre-web-automated/templates/calibre-web-automated.sfs.yaml
+++ b/calibre-web-automated/templates/calibre-web-automated.sfs.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: {{ .Chart.Name }}-{{ .Release.Name }}
 spec:
+  serviceName: {{ .Chart.Name }}-{{ .Release.Name }}-cwa-service
   replicas: 1
   selector:
     matchLabels:


### PR DESCRIPTION
## Summary

The `calibre-web-automated` StatefulSet template was the only one in the repo missing the mandatory `spec.serviceName` field. This caused permanent drift reporting in Fleet:

```
Statefulset.apps calibre-web/calibre-web-automated-calibre-web-automated-cwa-sfs modified {"spec":{"serviceName":null}, ...}
```

The fix sets `serviceName` to the chart's existing service (`<chart>-<release>-cwa-service`) and bumps the chart to `2.0.1+upv4.0.6`.

## ⚠️ Migration required on existing installations

`spec.serviceName` is **immutable** on StatefulSets — a plain `helm upgrade` / Fleet apply against the existing object will be rejected by the API server. One-time migration for the running installation:

```bash
kubectl -n calibre-web delete statefulset calibre-web-automated-calibre-web-automated-cwa-sfs --cascade=orphan
```

The pod keeps running (orphaned); the next sync/upgrade recreates the StatefulSet with the correct `serviceName` and re-adopts the pod on the next rollout.

## Validation

- `helm lint --strict` passes; rendered StatefulSet contains `serviceName: <chart>-<release>-cwa-service`.
- `helm package` succeeds (2.0.1+upv4.0.6).
- All other StatefulSet templates in the repo were checked and already set `serviceName` — cwa was the only gap.