### PR TITLE
Update app versions (batch): tika, gotenberg, synapse, rallly, samba, urlaubsverwaltung, voucher-vault, zipline, teamspeak

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Fixtures live at the **repo root** under `ci/` (deliberately *not* inside the ch
 - `ci/<chart>/test-values.yaml` — values for the CI install (required for every installable chart)
 - `ci/<chart>/fixtures.yaml` — dummy secrets with in-cluster connection data, throwaway infrastructure (postgres/redis/dex), static hostPath PVs/StorageClasses where the chart pins a storage class or needs RWX, and seed jobs (e.g. `synapse generate`)
 - `ci/<chart>/settings.env` — optional overrides (e.g. `INSTALL_TIMEOUT` for slow starters)
-- `ci/excluded-charts.txt` — charts that cannot run in CI, each with a justification. Currently: `satisfactory` (multi-GB image + 10GB+ Steam download), `teamspeak-server` (the TS6 v6.0.0-beta8 image crashes with "The default license has expired" until the appVersion is bumped), `template-chart` (scaffold with placeholder image)
+- `ci/excluded-charts.txt` — charts that cannot run in CI, each with a justification. Currently: `satisfactory` (multi-GB image + 10GB+ Steam download), `template-chart` (scaffold with placeholder image)
 
 Fixture images avoid Docker Hub where possible (`public.ecr.aws`/`ghcr.io`) to dodge runner rate limits. The job currently runs with `continue-on-error: true` (stabilization phase); it will be promoted to a required check once it has proven stable across several chart PRs. When adding a new chart, add its `ci/<chart>/` fixtures (or an entry in `ci/excluded-charts.txt`) — the install-test fails if both are missing. The script also runs locally against any existing cluster: `k3d cluster create t && ci/run-install-test.sh <chart> && k3d cluster delete t`.
 

--- a/apache-tika/Chart.yaml
+++ b/apache-tika/Chart.yaml
@@ -4,5 +4,5 @@ description: A Helm chart to deploy Apache Tika on Kubernetes
 
 type: application
 
-version: 7.1.0+up3.2.3.0.full
-appVersion: "3.2.3.0-full"
+version: 7.1.1+up3.3.1.0.full
+appVersion: "3.3.1.0-full"

--- a/ci/excluded-charts.txt
+++ b/ci/excluded-charts.txt
@@ -1,5 +1,4 @@
 # Charts excluded from the PR install-test, one per line: <chart> <reason>.
 # ci/run-install-test.sh skips these with the given reason.
 satisfactory the game-server image is multiple GB and Steam downloads 10GB+ game files on first start - impractical on a CI runner
-teamspeak-server the TS6 v6.0.0-beta8 image crashes on start ("The default license has expired. Please use the latest server version.", re-verified 2026-08-21); nothing to test until the appVersion is bumped
 template-chart scaffold with placeholder image "registry/image:xxx", never published

--- a/ci/teamspeak-server/test-values.yaml
+++ b/ci/teamspeak-server/test-values.yaml
@@ -1,0 +1,6 @@
+# CI install-test values for teamspeak-server: the chart needs no secrets or
+# throwaway infrastructure (no fixtures.yaml), only a storage class that
+# exists in the k3d cluster and a small volume.
+storage:
+  size: 1Gi
+  storageClass: local-path

--- a/gotenberg/Chart.yaml
+++ b/gotenberg/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart to deploy Gotenberg on Kubernetes
 
 type: application
 
-version: 4.1.0+up8.26.0
-appVersion: "8.26.0"
+version: 4.1.1+up8.36.0
+appVersion: "8.36.0"
 
 maintainers:
   - name: jklein

--- a/matrix-synapse/Chart.yaml
+++ b/matrix-synapse/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: matrix-synapse
 description: A Helm chart to deploy a Matrix Synapse server on Kubernetes
 type: application
-version: 4.1.0+upv1.149.1
-appVersion: "v1.149.1"
+version: 4.1.1+upv1.159.0
+appVersion: "v1.159.0"
 maintainers:
   - name: jklein

--- a/rallly/Chart.yaml
+++ b/rallly/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart to deploy Rallly on Kubernetes
 
 type: application
 
-version: 3.1.0+up4.8.1
-appVersion: "4.8.1"
+version: 3.1.1+up4.12.3
+appVersion: "4.12.3"
 
 maintainers:
   - name: jklein

--- a/samba/Chart.yaml
+++ b/samba/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Samba
 
 type: application
 
-version: 3.1.0+up4.23.5
+version: 3.1.1+up4.23.10
 
-appVersion: 4.23.5
+appVersion: 4.23.10

--- a/teamspeak-server/Chart.yaml
+++ b/teamspeak-server/Chart.yaml
@@ -4,5 +4,5 @@ description: A Helm chart for deploying a teamspeak-server on Kubernetes
 
 type: application
 
-version: 3.1.0+upv6.0.0.beta8
-appVersion: "v6.0.0-beta8"
+version: 3.1.1+up6.0.0.beta12.1
+appVersion: "6.0.0-beta12.1"

--- a/urlaubsverwaltung/Chart.yaml
+++ b/urlaubsverwaltung/Chart.yaml
@@ -3,5 +3,5 @@ name: urlaubsverwaltung
 description: A Helm chart to deploy urlaubsverwaltung on Kubernetes
 type: application
 
-version: 4.1.0+up6.5.0
-appVersion: 6.5.0
+version: 4.1.1+up6.7.0
+appVersion: 6.7.0

--- a/voucher-vault/Chart.yaml
+++ b/voucher-vault/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart to deploy VoucherVault on Kubernetes
 
 type: application
 
-version: 3.1.0+up1.27.4
-appVersion: "1.27.4"
+version: 3.1.1+up1.30.1
+appVersion: "1.30.1"
 
 maintainers:
   - name: jklein

--- a/zipline/Chart.yaml
+++ b/zipline/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.1.0+up4.6.4
+version: 4.1.1+up4.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 4.6.4
+appVersion: 4.7.0


### PR DESCRIPTION
Part of #24

Nine non-critical app-version updates in one batch, each with a **patch bump** of the chart semver and the matching `+up<appVersion>` suffix. Every target image tag was verified against its registry (Docker Hub / GHCR manifest check); all nine targets are still the newest release of their major line.

## Version bumps

| Chart | App version (old → new) | Chart version (old → new) |
|---|---|---|
| apache-tika | `3.2.3.0-full` → `3.3.1.0-full` | `7.1.0+up3.2.3.0.full` → `7.1.1+up3.3.1.0.full` |
| gotenberg | `8.26.0` → `8.36.0` | `4.1.0+up8.26.0` → `4.1.1+up8.36.0` |
| matrix-synapse | `v1.149.1` → `v1.159.0` | `4.1.0+upv1.149.1` → `4.1.1+upv1.159.0` |
| rallly | `4.8.1` → `4.12.3` | `3.1.0+up4.8.1` → `3.1.1+up4.12.3` |
| samba | `4.23.5` → `4.23.10` | `3.1.0+up4.23.5` → `3.1.1+up4.23.10` |
| urlaubsverwaltung | `6.5.0` → `6.7.0` | `4.1.0+up6.5.0` → `4.1.1+up6.7.0` |
| voucher-vault | `1.27.4` → `1.30.1` | `3.1.0+up1.27.4` → `3.1.1+up1.30.1` |
| zipline | `4.6.4` → `4.7.0` | `4.1.0+up4.6.4` → `4.1.1+up4.7.0` |
| teamspeak-server | `v6.0.0-beta8` → `6.0.0-beta12.1` | `3.1.0+upv6.0.0.beta8` → `3.1.1+up6.0.0.beta12.1` |

Note: the new teamspeak tag format has **no `v` prefix** (upstream switched with beta10); apache-tika 4.0.0 is beta and was deliberately skipped, and the tika `3.3.2` source tag exists but has no published Docker image yet.

## Env check per chart (release notes / upgrade notes reviewed)

| Chart | Result |
|---|---|
| apache-tika | Env checked, no change needed — the chart sets no env vars; 3.3.x is a compatible minor line. |
| gotenberg | Env checked, no change needed — the chart sets no env vars or flags. FYI: 8.31.0's breaking SSRF defaults were reverted in 8.32.0; the stricter posture is opt-in via new flags. New optional OTEL envs and proxy flags are available. |
| matrix-synapse | Env checked, no change needed — upgrade notes v1.150–v1.159 reviewed: MSC3861 removal, worker stream-writer and systemd-logging changes do not apply (chart uses neither); the `SYNAPSE_*` entrypoint vars are unchanged. |
| rallly | Env checked, no change needed — v4.12.0 breaking changes are app-level (legacy `/p/<id>` links removed, DB migrations run automatically on start); `MAINTENANCE_MODE`/`MAINTENANCE_BYPASS_TOKEN` are new optional vars. |
| samba | Env checked, no change needed — upstream moved the default share from `/storage` to `/shared` and renamed the default `NAME` to `Shared`, but the chart ships its own `smb.conf`/`users.conf` (shares under `/shares/<name>`), and the entrypoint keeps a legacy `/storage` fallback. |
| urlaubsverwaltung | Env checked, no change needed — 6.6.0/6.7.0 contain features, bug fixes and dependency bumps only; no Spring property or env changes. |
| voucher-vault | Env checked, no change needed — 1.28.x adds optional multi-currency support (fixer.io API key), no new required vars; 1.29/1.30 are features/fixes only. |
| zipline | Env checked, no change needed — v4.7.0 removes `FEATURES_VERSION_API`, which the chart never set; the chart's `DATABASE_URL`/`CORE_*` vars are unchanged. |
| teamspeak-server | Env checked, no change needed — beta12.1 adds the optional `TSSERVER_LOG_TIMEZONE` (UTC remains default); `TSSERVER_LICENSE_ACCEPTED`/`TSSERVER_DEFAULT_PORT` unchanged. |

## teamspeak-server install-test reactivated

- beta12.1 ships an updated default license, fixing the "The default license has expired" startup crash that justified the exclusion.
- Removed the `teamspeak-server` entry from `ci/excluded-charts.txt` and updated the README's excluded-charts list accordingly.
- Added `ci/teamspeak-server/test-values.yaml` (small `local-path` volume). No `fixtures.yaml`: the chart needs no secrets or throwaway infrastructure, same as apache-tika/gotenberg/cyberchef.
- Verified locally in a throwaway k3d cluster via `ci/run-install-test.sh teamspeak-server`: pod becomes Ready, log shows a valid default license (valid until 2026-10-01) and the server listening on 30987/30033. Heads-up: the bundled default license expires 2026-10-01, so the beta image will need another bump before then.

## Validation

- `helm lint --strict` and `helm template` (with required values / CI test values) pass for all nine charts.
- Local k3d install-test for teamspeak-server: pass (see above).
