### PR TITLE
Update homeassistant to 2026.8.3

### DIFF
--- a/homeassistant/Chart.yaml
+++ b/homeassistant/Chart.yaml
@@ -3,9 +3,9 @@ name: homeassistant
 description: A Helm chart to deploy Home Assistant on Kubernetes
 type: application
 
-version: 4.1.0+up2026.2.3
+version: 4.1.1+up2026.8.3
 
-appVersion: "2026.2.3"
+appVersion: "2026.8.3"
 
 maintainers:
   - name: jklein


### PR DESCRIPTION
Updates Home Assistant **2026.2.3 → 2026.8.3** (direct, no stepping — HA supports multi-version upgrades). Chart version `4.1.0+up2026.2.3` → `4.1.1+up2026.8.3` (patch bump).

**Note on the target version:** The plan named 2026.8.2; since then the patch release **2026.8.3** has been published on ghcr.io (verified: `ghcr.io/home-assistant/home-assistant:2026.8.3` exists, no 2026.8.4 yet), so this PR targets 2026.8.3 as agreed in the plan ("newest patch of the target line").

## Breaking-changes review (2026.3 – 2026.8)

Reviewed the official release notes ("Backward-incompatible changes") of every skipped monthly release for points relevant to a Kubernetes deployment or this chart:

- **2026.3**: Container images are now compressed with **zstd** instead of gzip — requires Docker ≥ 23 / containerd ≥ 1.5. k3s/containerd in the cluster and CI are well beyond that; no action. Everything else is integration-level (LIFX, Tado, Snapcast, light mireds attributes, …) — not chart-relevant.
- **2026.4**: Integration-level only (MQTT `object_id`, pyLoad, Tuya, Z-Wave installer panel). No deployment-relevant changes.
- **2026.5**: Automation/webhook-level (`local_only` must be a strict boolean, purpose-specific triggers removed, pilight disabled). No deployment-relevant changes.
- **2026.6**: Legacy template platform syntax removed, Bluetooth scan default changed, Konnected removed. No deployment-relevant changes.
- **2026.7**: Trigger renames, zwave-js-server ≥ 3.9.0 required (not part of this chart). No deployment-relevant changes.
- **2026.8**: The "port 80 by default" change applies to **new Home Assistant OS installations only** — the container image keeps serving on **8123**, existing installs are unchanged; chart `containerPort`/probes stay correct. New in 2026.8: web server settings (port, listen interface, trusted proxies) are configurable via UI, and existing YAML `http:` config is **auto-imported into the UI on first startup**. The chart passes `http:` config through the user-provided secret (`use_x_forwarded_for`, `trusted_proxies`), which continues to work — operators may see a one-time import/repair notice, nothing to change in the chart. Rest is integration-level (paperless-ngx ≥ 2.19 server, UniFi Protect ≥ 7.1, Volvo On Call removed).

## Env check

The chart only sets `TZ`. No release in 2026.3–2026.8 introduces, renames, or removes container environment variables or changes their defaults. **Checked, no chart change needed.**

## Root/s6-overlay deviation

The documented deviation (container starts as root via s6-overlay, no non-root support in the official image) is unchanged in 2026.3–2026.8 — no rootless support was introduced; the values.yaml comment stays accurate.

## Verification

- `helm lint --strict homeassistant` clean, `helm template` renders with image tag `2026.8.3`.
- **k3d before/after upgrade test** (throwaway cluster, stub OnePasswordItem CRD + dummy config secret from `ci/homeassistant/`): installed chart from `main` (2026.2.3), StatefulSet Ready; upgraded to this branch (2026.8.3), rollout completed and pod Ready again within ~2 minutes (DB migrations on first start covered by the 300s startup-probe budget; only a harmless Python `SyntaxWarning` in the logs). Cluster deleted afterwards.

Part of #24
