### PR TITLE
Update cyberchef to 11.4.0

### DIFF
--- a/cyberchef/Chart.yaml
+++ b/cyberchef/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart to deploy Cyberchef on Kubernetes
 
 type: application
 
-version: 4.1.0+up10.22.1
-appVersion: "10.22.1"
+version: 5.0.0+up11.4.0
+appVersion: "11.4.0"
 
 maintainers:
   - name: jklein

--- a/cyberchef/templates/cyberchef.deployment.yaml
+++ b/cyberchef/templates/cyberchef.deployment.yaml
@@ -25,14 +25,12 @@ spec:
           securityContext:
             {{- toYaml .Values.cyberchef.securityContext.container | nindent 12 }}
           volumeMounts:
-            # nginx needs writable cache/temp dirs and a writable pid file
-            # location when the root filesystem is read-only.
-            - name: nginx-cache
-              mountPath: /var/cache/nginx
-            - name: nginx-run
-              mountPath: /run
+            # nginx-unprivileged keeps its pid file and temp/cache dirs under
+            # /tmp, which needs to be writable with a read-only root filesystem.
+            - name: tmp
+              mountPath: /tmp
           ports:
-            - containerPort: 80
+            - containerPort: 8080
               protocol: TCP
               name: http
           livenessProbe:
@@ -44,8 +42,6 @@ spec:
           resources:
             {{- include "cyberchef.resources" .Values.cyberchef.resources | nindent 12 }}
       volumes:
-        - name: nginx-cache
-          emptyDir: {}
-        - name: nginx-run
+        - name: tmp
           emptyDir: {}
       restartPolicy: Always

--- a/cyberchef/values.yaml
+++ b/cyberchef/values.yaml
@@ -8,18 +8,14 @@ cyberchef:
   # Replica count for this workload; 0 is allowed and scales it down.
   # The chart-global scaleDown flag takes precedence.
   replicas: 1
-  # The upstream image is stock nginx (root, listening on port 80). To still
-  # run fully non-root, the pod runs as the image's nginx user (uid 101) and
-  # the safe sysctl net.ipv4.ip_unprivileged_port_start=80 lets the unprivileged
-  # nginx bind port 80 without NET_BIND_SERVICE.
+  # Since 11.0.0 the upstream image is nginxinc/nginx-unprivileged: nginx runs
+  # as its nginx user (uid 101) and listens on the unprivileged port 8080, so
+  # no sysctl tweaks are needed to run fully non-root.
   securityContext:
     pod:
       runAsNonRoot: true
       runAsUser: 101
       runAsGroup: 101
-      sysctls:
-        - name: net.ipv4.ip_unprivileged_port_start
-          value: "80"
     container:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true


### PR DESCRIPTION
Part of #24 (Schritt 3 des freigegebenen Plans; per Maintainer-Entscheidung direkt auf 11.4.0, ohne Zwischenschritt über 10.24.0).

## Update

| | alt | neu |
|---|---|---|
| appVersion | 10.22.1 | 11.4.0 |
| Chart | 4.1.0+up10.22.1 | **5.0.0**+up11.4.0 |

Tag `11.4.0` auf `ghcr.io/gchq/cyberchef` verifiziert; es ist der neueste 11.x-Tag.

## Major-Änderungen 10 → 11 und Chart-Anpassungen

Breaking Changes laut [CHANGELOG 11.0.0](https://github.com/gchq/CyberChef/blob/master/CHANGELOG.md):

- **Image-Basis gewechselt zu `nginxinc/nginx-unprivileged`** (gchq/CyberChef#1922): Serving-Port jetzt **8080** statt 80, nginx läuft im Image bereits unprivilegiert als uid 101, pid-File und Temp-/Cache-Verzeichnisse liegen unter `/tmp`.
- Minimum-Node-Version v24 — nur Build-Zeit, für das Chart irrelevant.

Chart-Anpassungen:

- `containerPort` 80 → 8080 (Service/Ingress unverändert, sie referenzieren den benannten Port `http`; Service-Port bleibt 80).
- Writable-Mounts `/var/cache/nginx` + `/run` ersetzt durch ein einzelnes `emptyDir` auf `/tmp` (dorthin schreibt nginx-unprivileged bei `readOnlyRootFilesystem: true`).
- Pod-SecurityContext: der Sysctl `net.ipv4.ip_unprivileged_port_start=80` entfällt (kein privilegierter Port mehr nötig); `runAsUser/runAsGroup: 101` bleibt (entspricht dem nginx-User des Images).

**Chart-Major-Bump statt Patch:** Die Änderungen an Container-Port, Volumes und Security-Context-Defaults sind Laufzeitverhaltens-/Default-Änderungen; nach den Semver-Konventionen des Repos (CLAUDE.md) ist das ein Major → 5.0.0.

## Env-Prüfung

Release Notes 11.0.0–11.4.0 gesichtet: keine neuen, umbenannten oder entfernten Umgebungsvariablen (statische Web-App, das Chart setzt keine Env-Variablen). **Geprüft, keine Änderung nötig.**

## k3d-Upgrade-Test

Wegwerf-Cluster (k3d v5.9.0, k3s v1.35.5), Values analog `ci/cyberchef/`:

1. 4.1.0+up10.22.1 von `origin/main` installiert → Pod Ready.
2. `helm upgrade` auf diesen Stand (11.4.0) → Rollout erfolgreich, Pod Ready, alle drei Probes (Port `http` = 8080) greifen.
3. Smoke-Test über den Service: HTTP 200, CyberChef-Index wird ausgeliefert.

Cluster anschließend gelöscht.
