### PR TITLE
Update paperless-ngx to 2.20.15

### DIFF
--- a/paperless-ngx/Chart.yaml
+++ b/paperless-ngx/Chart.yaml
@@ -4,9 +4,9 @@ description: A Helm chart to deploy Paperless-NGX on Kubernetes
 
 type: application
 
-version: 7.1.0+up2.20.13
+version: 7.1.1+up2.20.15
 
-appVersion: 2.20.13
+appVersion: 2.20.15
 
 maintainers:
   - name: jklein


### PR DESCRIPTION
Updates paperless-ngx from **2.20.13** to **2.20.15** (chart `7.1.0+up2.20.13` → `7.1.1+up2.20.15`).

Part of #24 — **Stufe 1 des gestuften Updates auf 3.0.5** (siehe Plan). Der Sprung auf 3.0.5 folgt nach Merge und Publish dieses PRs als separater PR.

## Details

- 2.20.15 ist das letzte 2.x-Release (per Registry und GitHub-Releases verifiziert; Image-Tag `ghcr.io/paperless-ngx/paperless-ngx:2.20.15` existiert).
- **2.20.14**: reine Bugfixes (Permissions, Tags, Workflows, Share-Links, Sortierung, Mail-Matching, Custom-Field-Validierung).
- **2.20.15**: Security-Release (GHSA-8c6x-pfjq-9gr7, allauth Login/Logout-Endpoints, Mail-Account-Enumeration) plus zwei weitere Bugfixes — für alle Nutzer empfohlen.

## Env-Prüfung

Release Notes 2.20.14 und 2.20.15 gesichtet: keine neuen, umbenannten oder entfernten Umgebungsvariablen, keine geänderten Defaults. Weder das Webserver-StatefulSet noch der Consume-CronJob benötigen Anpassungen — **geprüft, keine Änderung nötig**.

## Validierung

- `helm lint --strict paperless-ngx` ✔
- `helm template paperless-ngx -f ci/paperless-ngx/test-values.yaml` rendert sauber mit Image-Tag `2.20.15` ✔
