### PR TITLE
Update paperless-ngx to 3.0.5

### DIFF
--- a/paperless-ngx/Chart.yaml
+++ b/paperless-ngx/Chart.yaml
@@ -4,9 +4,9 @@ description: A Helm chart to deploy Paperless-NGX on Kubernetes
 
 type: application
 
-version: 7.1.1+up2.20.15
+version: 8.0.0+up3.0.5
 
-appVersion: 2.20.15
+appVersion: 3.0.5
 
 maintainers:
   - name: jklein

--- a/paperless-ngx/templates/paperless-server.sfs.yaml
+++ b/paperless-ngx/templates/paperless-server.sfs.yaml
@@ -126,6 +126,8 @@ spec:
               value: "{{ .Values.paperless.ocr.languages }}"
             - name: PAPERLESS_OCR_MODE
               value: "{{ .Values.paperless.ocr.mode }}"
+            - name: PAPERLESS_ARCHIVE_FILE_GENERATION
+              value: "{{ .Values.paperless.ocr.archiveFileGeneration }}"
             - name: PAPERLESS_OCR_ROTATE_PAGES
               value: "{{ .Values.paperless.ocr.rotate_pages }}"
             - name: PAPERLESS_OCR_OUTPUT_TYPE
@@ -142,8 +144,8 @@ spec:
               value: "{{ .Values.paperless.files.barcodes.barcodeString }}"
             - name: PAPERLESS_CONSUMER_BARCODE_RETAIN_SPLIT_PAGES
               value: "{{ .Values.paperless.files.barcodes.retainBarcodePage }}"
-            - name: PAPERLESS_CONSUMER_BARCODE_SCANNER
-              value: "{{ .Values.paperless.files.barcodes.scanner }}"
+            - name: PAPERLESS_CONSUMER_DELETE_DUPLICATES
+              value: "{{ .Values.paperless.files.deleteDuplicates }}"
             {{- if .Values.paperless.files.tikaGotenberg.enabled }}
             - name:  PAPERLESS_TIKA_ENABLED
               value: "{{ .Values.paperless.files.tikaGotenberg.enabled }}"
@@ -169,6 +171,9 @@ spec:
                           "fetch_userinfo": true,
                           "oauth_pkce_enabled": true,
                           "server_url": "{{ required "A OIDC-discovery-document-url must be provided" .Values.oidc.provider.discoveryUrl }}",
+                          {{- if .Values.oidc.provider.tokenAuthMethod }}
+                          "token_auth_method": "{{ .Values.oidc.provider.tokenAuthMethod }}",
+                          {{- end }}
                           "uid_field": "sub"
                         }
                       }
@@ -217,13 +222,15 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
           # The startup probe gates liveness/readiness. Paperless runs database
-          # migrations and index checks on startup: budget 10s * 30 = 300s.
+          # migrations on startup, and since 3.0 the first start after an
+          # upgrade also rebuilds the search index from scratch (Whoosh ->
+          # Tantivy): budget 10s * 60 = 600s.
           startupProbe:
             httpGet:
               path: /
               port: 8000
             periodSeconds: 10
-            failureThreshold: 30
+            failureThreshold: 60
             timeoutSeconds: 5
       restartPolicy: Always
       volumes:

--- a/paperless-ngx/values.yaml
+++ b/paperless-ngx/values.yaml
@@ -21,20 +21,31 @@ paperless:
   replicas: 1
   ocr:
     languages: "eng"
-    mode: "skip"
+    # Paperless-ngx 3.x modes: auto (default, skips OCR when embedded text
+    # exists), redo, force, off. The 2.x values "skip"/"skip_noarchive" were
+    # removed upstream; "skip" maps to "auto".
+    mode: "auto"
+    # Archive (PDF/A) generation, decoupled from OCR in 3.0: auto (default,
+    # skip archive for born-digital PDFs), always (2.x behavior), never.
+    archiveFileGeneration: "auto"
     rotate_pages: "true"
     output_type: "pdfa"
   files:
     filenameFormat: "{{ created_year }}/{{ correspondent }}/{{ title }}"
     storage: 20Gi
     maxUploadFileSize: 10m
+    # The barcode scanner backend is no longer configurable: paperless-ngx 3.0
+    # removed pyzbar and PAPERLESS_CONSUMER_BARCODE_SCANNER; zxing-cpp is the
+    # only backend now.
     barcodes:
       enabled: true
       barcodeString: "PATCHT"
       retainBarcodePage: false
       asn:
         enabled: true
-      scanner: PYZBAR
+    # Paperless-ngx 3.0 no longer rejects duplicate documents by default; set
+    # to true to restore the 2.x behavior of deleting duplicates on consume.
+    deleteDuplicates: false
     tikaGotenberg:
       enabled: false
       tikaEndpoint: null
@@ -112,3 +123,7 @@ oidc:
     name: null
     clientId: null
     discoveryUrl: null
+    # Optional: explicit token endpoint auth method (e.g. client_secret_basic).
+    # Some providers need this since the allauth update in paperless-ngx 3.0
+    # (login fails at the callback with invalid_client otherwise).
+    tokenAuthMethod: null


### PR DESCRIPTION
Part of #24 — Stufe 2 des gestuften paperless-ngx-Updates (Stufe 1: #37, 2.20.13 → 2.20.15, gemergt und published).

## Update

- **App:** paperless-ngx 2.20.15 → **3.0.5** (Major 2 → 3; 3.0.5 ist zum Zeitpunkt des PRs weiterhin das neueste Release, Image-Tag `3.0.5` auf ghcr.io verifiziert)
- **Chart:** `7.1.1+up2.20.15` → **`8.0.0+up3.0.5`** (Major-Bump, Begründung unten)

## Breaking Changes 3.0.0–3.0.5 (Review nach offiziellem [v3-Migrationsguide](https://github.com/paperless-ngx/paperless-ngx/blob/v3.0.5/docs/migration-v3.md) und Release Notes)

| Breaking Change | Auswirkung auf das Chart |
|---|---|
| Upgrade nur von 2.20.15 möglich | ✅ erfüllt durch Stufe 1 (#37) |
| `PAPERLESS_SECRET_KEY` jetzt Pflicht | ✅ Chart setzt ihn schon immer aus dem 1Password-Secret — keine Änderung |
| `PAPERLESS_DBENGINE` für PostgreSQL jetzt Pflicht | ✅ Chart setzt bereits `postgresql` (korrekter Wert, vgl. upstream-Fix in 3.0.1) — keine Änderung |
| `PAPERLESS_CONSUMER_BARCODE_SCANNER` entfernt (pyzbar raus, zxing-cpp einziges Backend) | ⚠️ Env-Var und Value `paperless.files.barcodes.scanner` (Default war `PYZBAR`) **entfernt** |
| `PAPERLESS_OCR_MODE=skip`/`skip_noarchive` entfernt; neuer Default `auto`; Archiv-Erzeugung in `PAPERLESS_ARCHIVE_FILE_GENERATION` ausgekoppelt | ⚠️ Default von `paperless.ocr.mode` von `skip` auf **`auto`** geändert (upstream-Mapping für `skip`); neues Value `paperless.ocr.archiveFileGeneration` (Default `auto`; `always` = exaktes 2.x-Verhalten, siehe unten) |
| Duplikate werden nicht mehr abgelehnt (neuer Default: erlauben + im UI kennzeichnen) | Neues Value `paperless.files.deleteDuplicates` (Default `false` = upstream-Default; `true` stellt 2.x-Verhalten wieder her) → `PAPERLESS_CONSUMER_DELETE_DUPLICATES` |
| Whoosh → Tantivy: Suchindex wird beim ersten Start nach dem Upgrade **komplett neu gebaut** | Startup-Probe-Budget von 300s auf **600s** erhöht (10s × 60), Kommentar im Template aktualisiert |
| OIDC: einige Provider brauchen jetzt explizites `token_auth_method` (sonst `invalid_client` im Callback) | Neues optionales Value `oidc.provider.tokenAuthMethod` (Default unset) im `PAPERLESS_SOCIALACCOUNT_PROVIDERS`-JSON |
| Pre-/Post-Consume-Skripte: Positionsargumente entfernt, nur noch Env-Vars (`DOCUMENT_*`) | Kein Render-Impact: das Skript-ConfigMap-Template ist mit `{{- if false }}` deaktiviert, `scripts.*`-Defaults leer. Das auskommentierte Beispielskript nutzte bereits `DOCUMENT_WORKING_PATH` |
| Consumer-Settings umbenannt (`CONSUMER_POLLING*` → `CONSUMER_POLLING_INTERVAL`/`CONSUMER_STABILITY_DELAY`, `IGNORE_PATTERNS` jetzt regex) | Chart setzt keine davon — keine Änderung |
| Verschlüsselung von Dokumenten/Thumbnails entfernt | Chart nutzt keine — keine Änderung |
| API v1 und API-Versionen < 9 entfernt; Python 3.10-Support entfernt; Task-Historie wird beim Upgrade geleert; NumPy-x86-64-v2-Baseline (SSE4.2) | Rein appseitig, kein Chart-Impact; im Betrieb ggf. relevant für API-Clients |
| Login-Rate-Limiting hinter Reverse Proxy (`PAPERLESS_TRUSTED_PROXIES` / `PAPERLESS_ALLAUTH_TRUSTED_PROXY_COUNT`) | Nicht vorkonfiguriert; bei `403` am Login hinter ingress-nginx wären die Variablen zu setzen (bisher kein generisches `env`-Passthrough im Chart) |
| DB-Advanced-Options (`PAPERLESS_DBSSLMODE` etc.) → `PAPERLESS_DB_OPTIONS` (deprecated, noch funktional) | Chart setzt keine davon — keine Änderung |

**Migrationspfad/DB:** Kein neues Mindest-Postgres/Redis (Fixture: postgres:16, redis:7 — kompatibel; Redis ist ab 3.0.2 zusätzlich Celery-Result-Backend). DB-Migrationen laufen automatisch beim ersten Start (3.0.1 hatte eine defekte Migration, in 3.0.2 gefixt — 3.0.5 ist unbetroffen). `MailRule.maximum_age` wird ggf. auf 32767 geklemmt. Ports (8000), Healthcheck (`GET /`), s6-overlay, uid 1000 und Root-Init-Container für `/run` bleiben unverändert.

## Begründung Chart-Major (7.1.1 → 8.0.0)

- **Breaking Values-Änderung:** `paperless.files.barcodes.scanner` entfernt.
- **Verhaltens-/Default-Änderung:** `paperless.ocr.mode`-Default `skip` → `auto`; zusätzlich erzeugt der neue Archiv-Default `auto` (statt implizit „immer") für born-digital-PDFs keine Archivdatei mehr — wer das 2.x-Verhalten exakt behalten will, setzt `paperless.ocr.archiveFileGeneration: always`.
- **Probe-Änderung:** Startup-Budget 300s → 600s.
- Additiv (allein wäre das Minor): `archiveFileGeneration`, `deleteDuplicates`, `tokenAuthMethod`.

## Verifikation

- `helm lint --strict paperless-ngx` ✅
- `helm template` mit CI-Values sowie mit `smbConnection` + `oidc` (inkl./exkl. `tokenAuthMethod`) ✅ — CronJob rendert, OIDC-JSON in beiden Varianten valide (per `json.loads` geprüft)
- **k3d-Upgrade-Test** (Wegwerf-Cluster, `ci/paperless-ngx/`-Fixtures): Chart `7.1.1+up2.20.15` von `origin/main` installiert → Ready; anschließend `helm upgrade` auf diesen Stand → alle v3-Migrationen angewendet (u. a. `documents.0017_migrate_fulltext_query_field_prefixes`), Index-Check durchgelaufen, granian lauscht auf 8000, Pod Ready ohne Restarts, `GET /` → HTTP 302 (Login-Redirect). Keine Deprecation-/Removed-Setting-Warnungen in den Logs. Cluster danach gelöscht.
