### PR TITLE
Make delegation nginx image configurable in matrix-synapse

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ For runtime verification (do the workloads actually start, do probes/security se
 
 - Resources are named `{{ .Release.Name }}-{{ .Chart.Name }}-<kind>`; template files are named `<app>.<kind>.yaml` (StatefulSets use `.sfs.yaml`).
 - Image tags come from `{{ .Chart.AppVersion }}`.
+- Auxiliary/sidecar images (images other than the app image, currently only the delegation nginx in matrix-synapse) are pinned via values (`<workload>.image.repository` / `<workload>.image.tag`) instead of being hardcoded in templates, and their pinned versions are reviewed alongside every app-version update round.
 - Secrets are **1Password `OnePasswordItem` CRs**: values expose `secrets.<name>SecretRef` holding an `op://` item path; the 1Password operator materializes the Kubernetes Secret in-cluster.
 - Ingress assumes ingress-nginx (`ingressClassName: nginx`) and cert-manager: `ingress.clusterIssuer` and `ingress.domain` are required values; the TLS secret is named `tls-<release>-<chart>-ingress`.
 - `env` entries in `values.yaml` are rendered through `tpl`, so values may contain Helm templating; `value`, `secretKeyRef` and `configMapKeyRef` forms are supported.

--- a/matrix-synapse/Chart.yaml
+++ b/matrix-synapse/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: matrix-synapse
 description: A Helm chart to deploy a Matrix Synapse server on Kubernetes
 type: application
-version: 4.1.1+upv1.159.0
+version: 4.2.0+upv1.159.0
 appVersion: "v1.159.0"
 maintainers:
   - name: jklein

--- a/matrix-synapse/templates/matrix-delegation-nginx.deployment.yaml
+++ b/matrix-synapse/templates/matrix-delegation-nginx.deployment.yaml
@@ -20,7 +20,7 @@ spec:
         {{- toYaml .Values.matrix.delegation.securityContext.pod | nindent 8 }}
       containers:
         - name: {{ .Release.Name }}-{{ .Chart.Name }}-delegation-nginx
-          image: "nginx:1.28.3"
+          image: "{{ .Values.matrix.delegation.image.repository }}:{{ .Values.matrix.delegation.image.tag }}"
           securityContext:
             {{- toYaml .Values.matrix.delegation.securityContext.container | nindent 12 }}
           ports:

--- a/matrix-synapse/values.yaml
+++ b/matrix-synapse/values.yaml
@@ -17,6 +17,11 @@ matrix:
     replicas: 1
     enabled: false
     serverUrl: null
+    # Auxiliary image, pinned independently of appVersion (which tracks
+    # Synapse). Reviewed alongside every app-version update round.
+    image:
+      repository: nginx
+      tag: 1.30.4
     # The delegation nginx runs as the image's unprivileged nginx user
     # (uid 101) and listens on the unprivileged port 8080; pid file and temp
     # paths are redirected to the /tmp emptyDir by the mounted nginx.conf.


### PR DESCRIPTION
## What

The delegation nginx image in the matrix-synapse chart was hardcoded as `nginx:1.28.3` in `matrix-delegation-nginx.deployment.yaml`. It is now configurable via values and rendered as `"{{ .Values.matrix.delegation.image.repository }}:{{ .Values.matrix.delegation.image.tag }}"`.

## Changes

- **New values** `matrix.delegation.image.repository` (default `nginx`) and `matrix.delegation.image.tag` (default `1.30.4`). The approved plan sketched a top-level `delegationNginx` block, but the chart already groups everything delegation-related under `matrix.delegation`, so the new values live there to stay consistent with the existing structure.
- **Default tag `1.30.4`** (was hardcoded `1.28.3`): current release of the nginx **stable** line per nginx.org. Stable is the right line for a pinned infra sidecar — it only receives critical fixes, while mainline (1.31.x) carries new feature development. The exact tag was verified against the Docker Hub registry API (`library/nginx`, tag `1.30.4`, pushed 2026-08-05).
- **README**: chart conventions now document that auxiliary/sidecar images (currently only this one) are pinned via values and reviewed alongside every app-version update round.
- **Chart version**: `4.1.1+upv1.159.0` → `4.2.0+upv1.159.0` (minor: additive, backward-compatible values change; the nginx bump itself is patch-level).

## Verification

- `helm lint --strict matrix-synapse` passes.
- `helm template` with the CI test values renders `image: "nginx:1.30.4"`; an override (`--set matrix.delegation.image.repository=... --set ...tag=...`) renders correctly as well.
- Runtime startability is covered by the PR install-test in k3d (delegation enabled in `ci/matrix-synapse/test-values.yaml`); the mounted nginx.conf and the unprivileged uid-101/port-8080 setup are unchanged and compatible with the official 1.30.x image.

Fixes #11
