### PR TITLE
Fix satisfactory publish workflow name

### DIFF
--- a/.github/workflows/publish-satisfactory.yml
+++ b/.github/workflows/publish-satisfactory.yml
@@ -1,4 +1,4 @@
-name: Publish Zipline Helm Chart
+name: Publish Satisfactory Helm Chart
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
The workflow file `.github/workflows/publish-satisfactory.yml` was copied from the Zipline workflow and kept its top-level `name: Publish Zipline Helm Chart`, so the satisfactory publish runs showed up under the wrong workflow name in the Actions UI. This changes it to `Publish Satisfactory Helm Chart`.

All other publish workflows were checked for the same copy-paste bug; their names are correct.

No chart directory is touched, so no version bump is needed and no publish is triggered.

Part of #32