### PR TITLE
Outline chart: security hardening, configurable probes, flexible ingress (conventions batch 3)

### DIFF
--- a/outline/Chart.yaml
+++ b/outline/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://raw.githubusercontent.com/outline/outline/main/public/images/icon-
 
 type: application
 
-version: 3.1.1+up1.9.2
+version: 4.0.0+up1.9.2
 appVersion: 1.9.2
 
 maintainers:

--- a/outline/templates/outline.ingress.yaml
+++ b/outline/templates/outline.ingress.yaml
@@ -1,13 +1,17 @@
+{{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-{{ .Chart.Name }}-ingress
   annotations:
-    cert-manager.io/cluster-issuer: {{ required "A Cluster-Issuer must be provided" .Values.ingress.clusterIssuer}}
+    cert-manager.io/cluster-issuer: {{ required "A Cluster-Issuer must be provided" .Values.ingress.clusterIssuer }}
     nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.ingress.maxUploadFileSize }}
     nginx.org/client-max-body-size: {{ .Values.ingress.maxUploadFileSize }}
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
-  ingressClassName: nginx
+  ingressClassName: {{ .Values.ingress.className }}
   rules:
     - host: {{ required "A Domain/Host must be provided" .Values.ingress.domain }}
       http:
@@ -23,3 +27,4 @@ spec:
     - hosts:
         - {{ required "A Domain/Host must be provided" .Values.ingress.domain }}
       secretName: tls-{{ .Release.Name }}-{{ .Chart.Name }}-ingress
+{{- end }}

--- a/outline/templates/outline.sfs.yaml
+++ b/outline/templates/outline.sfs.yaml
@@ -18,8 +18,7 @@ spec:
     spec:
       automountServiceAccountToken: false
       securityContext:
-        fsGroup: 1001
-        fsGroupChangePolicy: Always
+        {{- toYaml .Values.outline.securityContext.pod | nindent 8 }}
       containers:
         - name: {{ .Release.Name }}-{{ .Chart.Name }}-sfs
           image: "outlinewiki/outline:{{ .Chart.AppVersion }}"
@@ -76,45 +75,52 @@ spec:
               value: "{{ .Values.outline.maxUploadSize }}"
             - name: FORCE_HTTPS
               value: "{{ .Values.outline.forceHttps }}"
+            {{- range $value := .Values.outline.env }}
+            {{- if $value.value }}
+            - name: {{ $value.name | quote }}
+              value: {{ tpl $value.value $ | quote }}
+            {{- else if $value.valueFrom }}
+            {{- if $value.valueFrom.secretKeyRef }}
+            - name: {{ $value.name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ tpl $value.valueFrom.secretKeyRef.name $ | quote }}
+                  key: {{ tpl $value.valueFrom.secretKeyRef.key $ | quote }}
+            {{- else if $value.valueFrom.configMapKeyRef }}
+            - name: {{ $value.name }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ tpl $value.valueFrom.configMapKeyRef.name $ | quote }}
+                  key: {{ tpl $value.valueFrom.configMapKeyRef.key $ | quote }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
           ports:
             - containerPort: 3000
               protocol: TCP
               name: http
-          # Outline exposes a dedicated health endpoint at /_health (also used
-          # by the upstream Docker HEALTHCHECK). It checks Postgres and Redis;
-          # there is no dependency-free HTTP endpoint ("/" returns 500 too when
-          # the database is down), so all three probes use /_health.
           livenessProbe:
-            httpGet:
-              path: /_health
-              port: 3000
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
+            {{- toYaml .Values.outline.livenessProbe | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: /_health
-              port: 3000
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
-          # The startup probe gates liveness/readiness. Outline runs database
-          # migrations on startup: budget 10s * 30 = 300s.
+            {{- toYaml .Values.outline.readinessProbe | nindent 12 }}
           startupProbe:
-            httpGet:
-              path: /_health
-              port: 3000
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 30
+            {{- toYaml .Values.outline.startupProbe | nindent 12 }}
           resources:
             {{- include "outline.resources" .Values.outline.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.outline.securityContext.container | nindent 12 }}
           volumeMounts:
             - mountPath: "/outline-data/data"
               name: outline-data
               subPath: data
+            # Writable emptyDir so the root filesystem can stay read-only:
+            # Outline writes import/export scratch files to /tmp.
+            - mountPath: /tmp
+              name: tmp
       restartPolicy: Always
       volumes:
         - name: outline-data
           persistentVolumeClaim:
             claimName: {{ .Release.Name }}-{{ .Chart.Name }}-pvc
+        - name: tmp
+          emptyDir: {}

--- a/outline/values.yaml
+++ b/outline/values.yaml
@@ -19,6 +19,55 @@ outline:
   storage:
     size: 10Gi
     storageClass: null
+  # The upstream image (outlinewiki/outline) runs as its nodejs user
+  # (uid/gid 1001). Outline only writes to the upload storage (PVC) and to
+  # /tmp (import/export scratch files), which the chart mounts as an
+  # emptyDir, so the root filesystem stays read-only.
+  securityContext:
+    pod:
+      runAsNonRoot: true
+      runAsUser: 1001
+      runAsGroup: 1001
+      fsGroup: 1001
+      fsGroupChangePolicy: Always
+    container:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      capabilities:
+        drop:
+          - ALL
+  # Outline exposes a dedicated health endpoint at /_health (also used
+  # by the upstream Docker HEALTHCHECK). It checks Postgres and Redis;
+  # there is no dependency-free HTTP endpoint ("/" returns 500 too when
+  # the database is down), so all three probes use /_health.
+  livenessProbe:
+    httpGet:
+      path: /_health
+      port: 3000
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readinessProbe:
+    httpGet:
+      path: /_health
+      port: 3000
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+  # The startup probe gates liveness/readiness. Outline runs database
+  # migrations on startup: budget 10s * 30 = 300s.
+  startupProbe:
+    httpGet:
+      path: /_health
+      port: 3000
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 30
+  # Extra environment variables, appended to the ones the chart always sets.
+  # Values are rendered through tpl; value, secretKeyRef and configMapKeyRef
+  # forms are supported.
+  env: []
   resources:
     # Limits are optional: memory and ephemeral-storage limits default to
     # limitFactor x the request, an explicitly set limit always wins, and a
@@ -30,6 +79,11 @@ outline:
       ephemeralStorage: 10Mi
 
 ingress:
+  enabled: true
   maxUploadFileSize: 25m
   clusterIssuer: letsencrypt
   domain: null
+  className: nginx
+  # Extra annotations for the Ingress; merged with the cert-manager
+  # cluster-issuer and proxy-body-size annotations the chart always sets.
+  annotations: {}


### PR DESCRIPTION
Part of #32 — first Batch-3 major PR (outline). Bundles all audit findings for this chart in one major bump.

## Findings → Fixes

| Audit finding | Fix |
|---|---|
| Container without any securityContext; pod only `fsGroup: 1001` (undocumented) | `outline.securityContext.pod/container` values with hardened defaults: `runAsNonRoot` as uid/gid 1001 (the upstream image's `nodejs` user), `readOnlyRootFilesystem: true`, `allowPrivilegeEscalation: false`, all capabilities dropped. `/tmp` mounted as emptyDir (Outline's import/export scratch dir) so the root filesystem stays read-only — no documented deviation needed. |
| Probes hardcoded in the template | `outline.livenessProbe` / `readinessProbe` / `startupProbe` values; defaults are exactly the previous hardcoded settings (all `/_health`, startup budget 300s), incl. the explanatory comments now in values.yaml. |
| `ingressClassName: nginx` hardcoded | Repo-standard flexible ingress: `ingress.className` (default `nginx`), `ingress.annotations` merged with the always-set cert-manager + proxy-body-size annotations, `ingress.enabled` flag (default `true`). `ingress.domain`/`ingress.clusterIssuer` stay required; TLS secret name was already `tls-<release>-<chart>-ingress`. |
| No `env` value block | Additive `outline.env` rendered through `tpl` with the three forms (`value`/`secretKeyRef`/`configMapKeyRef`); chart-managed env entries stay in the template. |
| Naming | No findings for outline — nothing renamed. |

## Version bump

`3.1.1+up1.9.2` → `4.0.0+up1.9.2` — **major**: the hardening changes runtime behavior (non-root enforcement, read-only rootfs). App version unchanged.

## Verification

- `helm lint --strict outline` green (no findings).
- Render diff vs. `origin/main` (CI fixtures): only the intended additions (pod runAs*, container securityContext, /tmp emptyDir); probe and ingress output byte-identical apart from YAML key ordering.
- Override renders tested: all three `env` forms (incl. `tpl` expansion), probe overrides, `ingress.className`/`annotations` overrides, `ingress.enabled=false`.
- **k3d upgrade test**: throwaway cluster with `ci/outline/` fixtures (stub CRD, dummy secrets, postgres/redis/dex). Installed `origin/main` chart → Ready; upgraded to this branch → Ready with **0 restarts**, no permission errors in logs. In-pod check: `uid=1001(nodejs)`, `/tmp` writable, `/` read-only. Cluster deleted afterwards.
