### PR TITLE
TeamSpeak chart: naming scheme, hardening, configurable node ports (conventions batch 3)

### DIFF
--- a/teamspeak-server/Chart.yaml
+++ b/teamspeak-server/Chart.yaml
@@ -5,5 +5,5 @@ icon: https://avatars.githubusercontent.com/u/136759148
 
 type: application
 
-version: 3.1.2+up6.0.0.beta12.1
+version: 4.0.0+up6.0.0.beta12.1
 appVersion: "6.0.0-beta12.1"

--- a/teamspeak-server/templates/teamspeak-server.service.yaml
+++ b/teamspeak-server/templates/teamspeak-server.service.yaml
@@ -1,19 +1,21 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-service
+  name: {{ .Release.Name }}-{{ .Chart.Name }}-service
+  labels:
+    app: {{ .Release.Name }}-{{ .Chart.Name }}-service
 spec:
   selector:
-    app: {{ .Release.Name }}-server-sfs
+    app: {{ .Release.Name }}-{{ .Chart.Name }}-sfs
   ports:
-    - port: 30987
+    - port: {{ .Values.server.voicePort }}
       name: voice-port
       targetPort: voice-port
       protocol: UDP
-      nodePort: 30987
-    - port: 30033
+      nodePort: {{ .Values.server.voicePort }}
+    - port: {{ .Values.server.fileTransferPort }}
       name: file-transfer
       targetPort: file-transfer
       protocol: TCP
-      nodePort: 30033
+      nodePort: {{ .Values.server.fileTransferPort }}
   type: NodePort

--- a/teamspeak-server/templates/teamspeak-server.sfs.yaml
+++ b/teamspeak-server/templates/teamspeak-server.sfs.yaml
@@ -1,31 +1,33 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ .Release.Name }}-server-sfs
+  name: {{ .Release.Name }}-{{ .Chart.Name }}-sfs
   labels:
-    app: {{ .Release.Name }}
+    app: {{ .Release.Name }}-{{ .Chart.Name }}-sfs
 spec:
   replicas: {{ include "teamspeak-server.replicas" (dict "scaleDown" .Values.scaleDown "replicas" .Values.replicas) }}
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-server-sfs
+      app: {{ .Release.Name }}-{{ .Chart.Name }}-sfs
   template:
     metadata:
-      name: {{ .Release.Name }}-server-sfs
+      name: {{ .Release.Name }}-{{ .Chart.Name }}-sfs
       labels:
-        app: {{ .Release.Name }}-server-sfs
+        app: {{ .Release.Name }}-{{ .Chart.Name }}-sfs
     spec:
       automountServiceAccountToken: false
+      securityContext:
+        {{- toYaml .Values.securityContext.pod | nindent 8 }}
       containers:
-        - name: {{ .Release.Name }}-ts-server-container
+        - name: {{ .Release.Name }}-{{ .Chart.Name }}-sfs
           image: "teamspeaksystems/teamspeak6-server:{{ .Chart.AppVersion }}"
           imagePullPolicy: IfNotPresent
           ports:
             - name: voice-port
-              containerPort: 30987
+              containerPort: {{ .Values.server.voicePort }}
               protocol: UDP
             - name: file-transfer
-              containerPort: 30033
+              containerPort: {{ .Values.server.fileTransferPort }}
               protocol: TCP
             - name: web-query
               containerPort: 10080
@@ -34,40 +36,47 @@ spec:
             - name: TSSERVER_LICENSE_ACCEPTED
               value: "accept"
             - name: TSSERVER_DEFAULT_PORT
-              value: "30987"
-          # The voice service is UDP and cannot be probed; probe the TCP
-          # file-transfer port instead.
+              value: {{ .Values.server.voicePort | quote }}
+            - name: TSSERVER_FILE_TRANSFER_PORT
+              value: {{ .Values.server.fileTransferPort | quote }}
+            {{- range $value := .Values.env }}
+            {{- if $value.value }}
+            - name: {{ $value.name }}
+              value: {{ tpl $value.value $ }}
+            {{- else if $value.valueFrom }}
+            {{- if $value.valueFrom.secretKeyRef }}
+            - name: {{ $value.name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ tpl $value.valueFrom.secretKeyRef.name $ }}
+                  key: {{ tpl $value.valueFrom.secretKeyRef.key $ }}
+            {{- else if $value.valueFrom.configMapKeyRef }}
+            - name: {{ $value.name }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ tpl $value.valueFrom.configMapKeyRef.name $ }}
+                  key: {{ tpl $value.valueFrom.configMapKeyRef.key $ }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
           livenessProbe:
-            tcpSocket:
-              port: file-transfer
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
-            tcpSocket:
-              port: file-transfer
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
-          # The startup probe gates liveness/readiness. Startup budget = 5s * 30 = 150s.
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
           startupProbe:
-            tcpSocket:
-              port: file-transfer
-            periodSeconds: 5
-            timeoutSeconds: 5
-            failureThreshold: 30
+            {{- toYaml .Values.startupProbe | nindent 12 }}
           resources:
             {{- include "teamspeak-server.resources" .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext.container | nindent 12 }}
           volumeMounts:
             - name: "teamspeak-volume"
               mountPath: /var/tsserver/
       restartPolicy: Always
-      securityContext:
-        fsGroup: 9987
       volumes:
         - name: "teamspeak-volume"
           persistentVolumeClaim:
+            # Deliberate exception from the naming scheme: renaming the PVC
+            # would detach existing data (see README, naming exceptions).
             claimName: {{ .Release.Name }}-teamspeak-volume-claim
-  serviceName: {{ .Release.Name }}-service
-
-
+  serviceName: {{ .Release.Name }}-{{ .Chart.Name }}-service

--- a/teamspeak-server/values.yaml
+++ b/teamspeak-server/values.yaml
@@ -8,6 +8,15 @@ scaleDown: false
 # The chart-global scaleDown flag takes precedence.
 replicas: 1
 
+server:
+  # UDP voice port and TCP file transfer port. Each value is used as the
+  # container port, the service port and the NodePort, and is passed to the
+  # server via TSSERVER_DEFAULT_PORT / TSSERVER_FILE_TRANSFER_PORT so the
+  # server always listens on the exposed port (file transfer requires the
+  # in-container port to match the externally reachable port).
+  voicePort: 30987
+  fileTransferPort: 30033
+
 resources:
   # Limits are optional: memory and ephemeral-storage limits default to
   # limitFactor x the request, an explicitly set limit always wins, and a
@@ -17,6 +26,65 @@ resources:
     cpu: 0.2
     memory: 100Mi
     ephemeral-storage: 100Mi
+
+# Extra environment variables for the server container, appended to the ones
+# the chart always sets (TSSERVER_LICENSE_ACCEPTED, TSSERVER_DEFAULT_PORT,
+# TSSERVER_FILE_TRANSFER_PORT). Values are rendered through tpl and support
+# the value, secretKeyRef and configMapKeyRef forms:
+#   - name: SOME_ENV
+#     value: "{{ .Release.Name }}"
+#   - name: FROM_SECRET
+#     valueFrom:
+#       secretKeyRef:
+#         name: "some-secret"
+#         key: "someKey"
+#   - name: FROM_CONFIGMAP
+#     valueFrom:
+#       configMapKeyRef:
+#         name: "some-configmap"
+#         key: "someKey"
+env: []
+
+livenessProbe:
+  # The voice service is UDP and cannot be probed; probe the TCP
+  # file-transfer port instead.
+  tcpSocket:
+    port: file-transfer
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+readinessProbe:
+  tcpSocket:
+    port: file-transfer
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+# The startup probe gates liveness/readiness, so those need no
+# initialDelaySeconds. Startup budget = periodSeconds * failureThreshold = 150s.
+startupProbe:
+  tcpSocket:
+    port: file-transfer
+  periodSeconds: 5
+  timeoutSeconds: 5
+  failureThreshold: 30
+
+securityContext:
+  pod:
+    runAsNonRoot: true
+    # The teamspeak6-server image runs as the non-root user "teamspeak"
+    # (uid/gid 9987); fsGroup 9987 keeps the data volume writable.
+    runAsUser: 9987
+    runAsGroup: 9987
+    fsGroup: 9987
+    fsGroupChangePolicy: Always
+  container:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    capabilities:
+      drop:
+        - ALL
+      add: []
 
 storage:
   size: 25Gi


### PR DESCRIPTION
Part of #32 (batch 3 — per-chart major PRs). All audit findings for the `teamspeak-server` chart in one PR. Chart `3.1.2+up6.0.0.beta12.1` → **`4.0.0+up6.0.0.beta12.1`** (major: resource renames + values-affecting hardening; appVersion unchanged).

## Findings → fixes

| Audit finding | Fix |
|---|---|
| Service named `{{ .Release.Name }}-service` (chart name missing, collision-prone) | Renamed to `{{ .Release.Name }}-{{ .Chart.Name }}-service` ⚠️ in-cluster DNS name changes |
| StatefulSet named `{{ .Release.Name }}-server-sfs` | Renamed to `{{ .Release.Name }}-{{ .Chart.Name }}-sfs` (labels/selector aligned, `spec.serviceName` points to the new service) ⚠️ one-time migration, see below |
| PVC `{{ .Release.Name }}-teamspeak-volume-claim` off-scheme | **Deliberately untouched** — documented naming exception for existing PVCs (README); renaming would orphan the data. The StatefulSet still references exactly this claim (comment added in the template) |
| NodePorts `30987`/`30033` hardcoded | New values `server.voicePort` / `server.fileTransferPort` (defaults = previous ports, satisfactory pattern). Used as containerPort, service port and nodePort, and passed to the server via `TSSERVER_DEFAULT_PORT` / `TSSERVER_FILE_TRANSFER_PORT` so the in-container port always matches the exposed port (required for file transfer) |
| No container securityContext (pod only `fsGroup: 9987`) | Values-configurable `securityContext.pod` / `securityContext.container` with hardened defaults: `runAsNonRoot`, uid/gid 9987 (image user `teamspeak`), `readOnlyRootFilesystem: true`, `allowPrivilegeEscalation: false`, all capabilities dropped. No deviations needed — the server writes only under `/var/tsserver` (the PVC), no extra emptyDirs required |
| Probes hardcoded | `livenessProbe` / `readinessProbe` / `startupProbe` now values, defaults exactly the previous values (TCP probe on the named `file-transfer` port, so probes keep working under port overrides) |
| No `env` convention | Additive `env` value rendered through `tpl`, supporting the `value` / `secretKeyRef` / `configMapKeyRef` forms (template-chart pattern); appended after the chart-managed `TSSERVER_*` variables |

No ingress exists in this chart — ingress standard not applicable.

## ⚠️ One-time migration for existing installations

The StatefulSet and Service renames make a plain `helm upgrade` fail: the API server rejects mutations of the immutable StatefulSet fields, and the new Service cannot allocate the fixed NodePorts while the old Service still holds them. Data is safe — the chart uses a standalone PVC (no `volumeClaimTemplates`), and the PVC name is unchanged. Migration (analogous to the cwa migration in #28, plus pod and service deletion because name **and** selector change here):

```bash
# 1. Remove the old StatefulSet object, keep the pod running for now
kubectl -n <ns> delete statefulset <release>-server-sfs --cascade=orphan

# 2. Delete the orphaned pod (frees the RWO volume; the new pod will not
#    adopt it because the selector changed) — downtime starts here
kubectl -n <ns> delete pod <release>-server-sfs-0

# 3. Delete the old service (frees the fixed NodePorts 30987/30033)
kubectl -n <ns> delete service <release>-service

# 4. Upgrade
helm upgrade <release> ... --version 4.0.0+up6.0.0.beta12.1
```

**In-cluster DNS change**: the service is now resolvable as `<release>-teamspeak-server-service` instead of `<release>-service`; any consumer referencing the old DNS name must be updated. External clients are unaffected (same NodePorts).

## Validation

- `helm lint --strict` green; `helm package` OK.
- `helm template` with defaults: rendered output differs from `origin/main` only in the intended changes (renames, security contexts, `TSSERVER_FILE_TRANSFER_PORT` — value identical to the image default — and `toYaml` key reordering of the probes).
- Override renders verified: `server.voicePort/fileTransferPort` (nodePort + containerPort + env follow), probe overrides, `securityContext.container.readOnlyRootFilesystem=false`, `env` in all three forms incl. `tpl` (`{{ .Release.Name }}` resolved).

## k3d migration test (performed)

Throwaway cluster, `ci/teamspeak-server/test-values.yaml`:

1. Installed the chart from `origin/main` → Ready; wrote a marker file into `/var/tsserver`.
2. Ran the migration above, upgraded to this branch.
3. Result: new pod `Ready 1/1`, **0 restarts** over several probe cycles; PVC `<release>-teamspeak-volume-claim` re-bound; marker file present (same data); logs clean — license accepted (`No License` beta license, valid), SQLite integrity check passed, **no new privilege key generated** (existing database reused), server listening on 30987/30033.
4. Runtime confirmed uid/gid `9987(teamspeak)`; hardened security contexts active (`readOnlyRootFilesystem`, caps dropped) with no write errors.
5. The test also surfaced that step 3 (service deletion) is mandatory: without it the upgrade fails with `provided port is already allocated`.
