### PR TITLE
Rallly chart: deployment naming, values-driven security contexts (conventions batch 3)

### DIFF
--- a/rallly/Chart.yaml
+++ b/rallly/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://raw.githubusercontent.com/lukevella/rallly/main/apps/landing/publi
 
 type: application
 
-version: 3.1.2+up4.12.3
+version: 4.0.0+up4.12.3
 appVersion: "4.12.3"
 
 maintainers:

--- a/rallly/templates/rallly.deployment.yaml
+++ b/rallly/templates/rallly.deployment.yaml
@@ -1,29 +1,25 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-{{ .Chart.Name }}
+  name: {{ .Release.Name }}-{{ .Chart.Name }}-deployment
   labels:
-    app: {{ .Release.Name }}-{{ .Chart.Name }}
+    app: {{ .Release.Name }}-{{ .Chart.Name }}-deployment
 spec:
   replicas: {{ include "rallly.replicas" (dict "scaleDown" .Values.scaleDown "replicas" .Values.rallly.replicas) }}
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-{{ .Chart.Name }}
+      app: {{ .Release.Name }}-{{ .Chart.Name }}-deployment
   template:
     metadata:
-      name: {{ .Release.Name }}-{{ .Chart.Name }}
+      name: {{ .Release.Name }}-{{ .Chart.Name }}-deployment
       labels:
-        app: {{ .Release.Name }}-{{ .Chart.Name }}
+        app: {{ .Release.Name }}-{{ .Chart.Name }}-deployment
     spec:
       automountServiceAccountToken: false
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 20000
-        runAsGroup: 1000
-        fsGroup: 1000
-        fsGroupChangePolicy: Always
+        {{- toYaml .Values.rallly.securityContext.pod | nindent 8 }}
       containers:
-        - name: {{ .Release.Name }}-{{ .Chart.Name }}
+        - name: {{ .Release.Name }}-{{ .Chart.Name }}-deployment
           image: "lukevella/rallly:{{ .Chart.AppVersion }}"
           imagePullPolicy: IfNotPresent
           env:
@@ -120,6 +116,26 @@ spec:
                   name: {{ .Release.Name }}-{{ .Chart.Name }}-database-secret
                   key: database-url
             # TODO: Add Storage Configuration
+            {{- range $value := .Values.rallly.env }}
+            {{- if $value.value }}
+            - name: {{ $value.name }}
+              value: {{ tpl $value.value $ }}
+            {{- else if $value.valueFrom }}
+            {{- if $value.valueFrom.secretKeyRef }}
+            - name: {{ $value.name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ tpl $value.valueFrom.secretKeyRef.name $ }}
+                  key: {{ tpl $value.valueFrom.secretKeyRef.key $ }}
+            {{- else if $value.valueFrom.configMapKeyRef }}
+            - name: {{ $value.name }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ tpl $value.valueFrom.configMapKeyRef.name $ }}
+                  key: {{ tpl $value.valueFrom.configMapKeyRef.key $ }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
           ports:
             - containerPort: 3000
               protocol: TCP
@@ -133,12 +149,5 @@ spec:
           resources:
             {{- include "rallly.resources" .Values.rallly.resources | nindent 12 }}
           securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            capabilities:
-              drop:
-                - ALL
-              add:
-                -
+            {{- toYaml .Values.rallly.securityContext.container | nindent 12 }}
       restartPolicy: Always

--- a/rallly/templates/rallly.ingress.yaml
+++ b/rallly/templates/rallly.ingress.yaml
@@ -3,9 +3,12 @@ kind: Ingress
 metadata:
   name: {{ .Release.Name }}-{{ .Chart.Name }}-ingress
   annotations:
-    cert-manager.io/cluster-issuer: {{ required "A Cluster-Issuer must be provided" .Values.ingress.clusterIssuer}}
+    cert-manager.io/cluster-issuer: {{ required "A Cluster-Issuer must be provided" .Values.ingress.clusterIssuer }}
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
-  ingressClassName: nginx
+  ingressClassName: {{ .Values.ingress.className }}
   rules:
     - host: {{ required "A Domain/Host must be provided" .Values.ingress.domain }}
       http:

--- a/rallly/templates/rallly.service.yaml
+++ b/rallly/templates/rallly.service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Release.Name }}-{{ .Chart.Name }}-service
 spec:
   selector:
-    app: {{ .Release.Name }}-{{ .Chart.Name }}
+    app: {{ .Release.Name }}-{{ .Chart.Name }}-deployment
   ports:
     - protocol: TCP
       port: 80

--- a/rallly/values.yaml
+++ b/rallly/values.yaml
@@ -23,6 +23,25 @@ rallly:
     pictureClaimPath: 'picture'
     emailClaimPath: 'email'
     nameClaimPath: 'name'
+  securityContext:
+    pod:
+      runAsNonRoot: true
+      runAsUser: 20000
+      runAsGroup: 1000
+      fsGroup: 1000
+      fsGroupChangePolicy: Always
+    container:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      capabilities:
+        drop:
+          - ALL
+        add: []
+  # Extra environment variables, appended to the ones the chart always sets.
+  # Values are rendered through tpl; value, secretKeyRef and configMapKeyRef
+  # forms are supported.
+  env: []
   resources:
     # Limits are optional: memory and ephemeral-storage limits default to
     # limitFactor x the request, an explicitly set limit always wins, and a
@@ -59,3 +78,7 @@ rallly:
 ingress:
   clusterIssuer: null
   domain: null
+  className: nginx
+  # Extra annotations for the Ingress; merged with the cert-manager
+  # cluster-issuer annotation the chart always sets.
+  annotations: {}


### PR DESCRIPTION
Part of #32 — Batch-3 major PR for the **rallly** chart: all audit findings for this chart in one PR.

## Findings → Fixes

| # | Audit finding | Fix |
|---|---|---|
| 1 | Deployment named `{{ .Release.Name }}-{{ .Chart.Name }}` without `-deployment` suffix | Renamed to `…-deployment` (metadata, labels, selector, pod template, container name); Service selector updated to match |
| 2 | Hardening complete but hardcoded in the template | Moved to `rallly.securityContext.pod` / `rallly.securityContext.container` values; defaults are exactly the previous hardcoded settings |
| 3 | Ingress: `ingressClassName: nginx` hardcoded, no extra-annotations hook | New standard: `ingress.className` (default `nginx`), `ingress.annotations` merged with the cert-manager annotation; `ingress.domain`/`ingress.clusterIssuer` remain required; TLS secret name was already `tls-<release>-<chart>-ingress` |
| 4 | Probes | Verified: already values-configurable (`rallly.livenessProbe`/`readinessProbe`/`startupProbe`) — no change needed |
| 5 | No `env` value | Added `rallly.env` (template-chart pattern): rendered through `tpl`, supports `value`, `secretKeyRef`, `configMapKeyRef`; appended to the built-in env |
| 6 | `required`-message typos | Already fixed in batch 1 — untouched |

## Render diff vs. `origin/main`

Only the intended changes: the `-deployment` name/label/selector suffix, `toYaml` key reordering of the (semantically identical) security contexts, and one deliberate cleanup — the container `capabilities.add` list previously rendered a bogus null entry (`add: [~]`) and now renders `add: []`. Everything else is byte-identical, including with `smtp.enabled=true` and with env/className/annotations overrides.

## Upgrade note (major bump: 3.1.2+up4.12.3 → 4.0.0+up4.12.3)

The Deployment selector is immutable, so Helm **replaces** the Deployment on upgrade (delete + create). Expect a short downtime while the new pod starts; no PVC/StatefulSet is involved, so no data migration is needed and no manual step is required.

## k3d verification (cluster `b3-rallly`, deleted afterwards)

1. Installed `origin/main` chart with `ci/rallly` fixtures (stub `OnePasswordItem` CRD, dummy secrets, throwaway postgres + dex) → `ci-rallly` Available.
2. Upgraded to this branch → old Deployment replaced, `ci-rallly-deployment` Ready with **0 restarts**, pod/container security contexts applied as before, no permission errors, `ci-rallly-service` answers HTTP 200. (The pre-existing `.next/cache` ENOENT log line from the read-only root filesystem is unchanged from main and harmless.)
