### PR TITLE
VoucherVault chart: complete security hardening, flexible ingress (conventions batch 3)

### DIFF
--- a/voucher-vault/Chart.yaml
+++ b/voucher-vault/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://raw.githubusercontent.com/l4rm4nd/VoucherVault/main/myapp/static/a
 
 type: application
 
-version: 3.1.2+up1.30.1
+version: 4.0.0+up1.30.1
 appVersion: "1.30.1"
 
 maintainers:

--- a/voucher-vault/templates/voucher-vault.ingress.yaml
+++ b/voucher-vault/templates/voucher-vault.ingress.yaml
@@ -4,9 +4,12 @@ kind: Ingress
 metadata:
   name: {{ .Release.Name }}-{{ .Chart.Name }}-ingress
   annotations:
-    cert-manager.io/cluster-issuer: {{ required "A Cluster-Issuer must be provided" .Values.ingress.clusterIssuer}}
+    cert-manager.io/cluster-issuer: {{ required "A Cluster-Issuer must be provided" .Values.ingress.clusterIssuer }}
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
-  ingressClassName: nginx
+  ingressClassName: {{ .Values.ingress.className }}
   rules:
     - host: {{ required "A Domain/Host must be provided" .Values.ingress.domain }}
       http:

--- a/voucher-vault/templates/voucher-vault.sfs.yaml
+++ b/voucher-vault/templates/voucher-vault.sfs.yaml
@@ -19,6 +19,33 @@ spec:
       automountServiceAccountToken: false
       securityContext:
         {{- toYaml .Values.voucherVault.securityContext.pod | nindent 8 }}
+      initContainers:
+        # STATIC_ROOT (/opt/app/myapp/static) doubles as the app's own static
+        # source directory, so it cannot simply be shadowed by an empty
+        # volume: this init container seeds the static-files emptyDir with
+        # the assets shipped in the image (cp -a preserves timestamps, so the
+        # entrypoint's collectstatic only adds what is missing, e.g. the
+        # Django admin static files). See securityContext in values.yaml.
+        - name: init-static
+          image: "l4rm4nd/vouchervault:{{ .Chart.AppVersion }}"
+          imagePullPolicy: IfNotPresent
+          # Copies the children (not ".") so cp never tries to set metadata
+          # on the mountpoint itself, which the non-root uid may not own.
+          command: ["sh", "-c", "cp -a /opt/app/myapp/static/* /static-seed/"]
+          securityContext:
+            {{- toYaml .Values.voucherVault.securityContext.container | nindent 12 }}
+          volumeMounts:
+            - name: static-files
+              mountPath: /static-seed
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+              ephemeral-storage: 1Mi
+            limits:
+              cpu: 200m
+              memory: 64Mi
+              ephemeral-storage: 10Mi
       containers:
         - name: {{ .Release.Name }}-{{ .Chart.Name }}-sfs
           image: "l4rm4nd/vouchervault:{{ .Chart.AppVersion }}"
@@ -63,7 +90,15 @@ spec:
           securityContext:
             {{- toYaml .Values.voucherVault.securityContext.container | nindent 12 }}
           volumeMounts:
-            {{- if .Values.voucherVault.storage.volumeMounts }}
+            # Writable emptyDirs over the paths the image writes at runtime,
+            # so the root filesystem can stay read-only (see securityContext
+            # in values.yaml).
+            - name: tmp
+              mountPath: /tmp
+            - name: logs
+              mountPath: /opt/app/logs
+            - name: static-files
+              mountPath: /opt/app/myapp/static
             {{- range $value := .Values.voucherVault.storage.volumeMounts }}
             - name: {{ tpl $value.name $ | quote }}
               mountPath: {{ tpl $value.mountPath $ | quote }}
@@ -77,12 +112,16 @@ spec:
               readOnly: {{ tpl $value.readOnly $ | quote }}
               {{- end }}
             {{- end }}
-            {{- else }}
-            []
-            {{- end }}
       restartPolicy: Always
       volumes:
-        {{- if .Values.voucherVault.storage.volumes }}
+        # Writable emptyDirs backing the read-only root filesystem (see
+        # securityContext in values.yaml).
+        - name: tmp
+          emptyDir: {}
+        - name: logs
+          emptyDir: {}
+        - name: static-files
+          emptyDir: {}
         {{- range $value := .Values.voucherVault.storage.volumes }}
         - name: {{ tpl $value.name $ | quote }}
           {{- if $value.persistentVolumeClaim }}
@@ -127,7 +166,4 @@ spec:
             sizeLimit: {{ tpl $value.emptyDir.sizeLimit $ | quote }}
             {{- end }}
           {{- end }}
-        {{- end }}
-        {{- else }}
-        []
         {{- end }}

--- a/voucher-vault/values.yaml
+++ b/voucher-vault/values.yaml
@@ -21,7 +21,10 @@ voucherVault:
     requests:
       cpu: 0.1
       memory: 256Mi
-      ephemeral-storage: 10Mi
+      # The static-files emptyDir (~90Mi of static assets, see the
+      # securityContext comment) counts toward the pod's ephemeral-storage
+      # usage, so the request must cover it.
+      ephemeral-storage: 128Mi
   # "/" answers with a redirect for anonymous users, which httpGet treats as
   # success. The Host header must be set to 127.0.0.1 because Django's
   # ALLOWED_HOSTS only accepts 127.0.0.1 and the configured DOMAIN — probing
@@ -57,6 +60,13 @@ voucherVault:
     periodSeconds: 5
     timeoutSeconds: 5
     failureThreshold: 30
+  # The upstream image (l4rm4nd/vouchervault) runs as www-data (uid/gid 33).
+  # With readOnlyRootFilesystem the chart mounts emptyDirs over the paths the
+  # image writes at runtime: /tmp (upload/PDF scratch files), /opt/app/logs
+  # and STATIC_ROOT /opt/app/myapp/static (the entrypoint runs collectstatic
+  # at every start; an init container seeds the volume with the static files
+  # shipped in the image, because the directory doubles as the app's static
+  # source). Uploads and the database live on the PVC at /opt/app/database.
   securityContext:
     pod:
       runAsNonRoot: true
@@ -66,7 +76,11 @@ voucherVault:
       fsGroupChangePolicy: Always
     container:
       allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
       runAsNonRoot: true
+      capabilities:
+        drop:
+          - ALL
   ports:
     - containerPort: 8000
       protocol: TCP
@@ -185,3 +199,7 @@ ingress:
   enabled: true
   clusterIssuer: null
   domain: null
+  className: nginx
+  # Extra annotations for the Ingress; merged with the cert-manager
+  # cluster-issuer annotation the chart always sets.
+  annotations: {}


### PR DESCRIPTION
Part of #32 — Batch-3 major PR for voucher-vault. Bundles all audit findings for this chart in one major bump.

## Findings → Fixes

| Audit finding | Fix |
|---|---|
| Container securityContext values-configurable but without `readOnlyRootFilesystem` and without `capabilities.drop` (not documented as deviation) | Hardened defaults completed: `readOnlyRootFilesystem: true` and `capabilities.drop: [ALL]`. The image (runs as www-data, uid/gid 33) writes to `/tmp` (upload/PDF scratch), `/opt/app/logs` and `STATIC_ROOT` `/opt/app/myapp/static` (the entrypoint runs `collectstatic` at every start) — all three are now chart-managed emptyDirs, so the root filesystem stays read-only with **no documented deviation needed**. Uploads and the database were already on the PVC at `/opt/app/database`. |
| `STATIC_ROOT` doubles as the app's static *source* dir, so it cannot simply be shadowed by an empty volume | Small `init-static` init container (same image, hardened securityContext, explicit small resources) seeds the emptyDir with the ~90Mi of static assets shipped in the image; `cp -a` preserves timestamps so `collectstatic` only adds what is missing (e.g. Django admin static). It copies the directory's children instead of `.` so cp never touches the mountpoint's own metadata (root-owned via fsGroup). |
| — (consequence) | `ephemeral-storage` request raised 10Mi → 128Mi: the static emptyDir counts toward the pod's ephemeral-storage usage; with the old 30Mi computed limit the pod would be evicted. |
| `ingressClassName: nginx` hardcoded | Repo-standard flexible ingress: `ingress.className` (default `nginx`) and `ingress.annotations` merged with the always-set cert-manager annotation. `ingress.domain` / `ingress.clusterIssuer` stay **required**; TLS secret name was already the standard `tls-<release>-<chart>-ingress`. |
| Env convention | Verified only: voucher-vault already renders `env` through `tpl` with all three forms (`value` / `secretKeyRef` / `configMapKeyRef`) — unchanged. |
| Naming | No findings for voucher-vault — nothing renamed. |

## Version bump

`3.1.2+up1.30.1` → `4.0.0+up1.30.1` — **major**: the hardening defaults change runtime behavior (read-only rootfs, dropped capabilities). App version unchanged.

## Verification

- `helm lint --strict voucher-vault` green (no findings).
- Render diff vs. `origin/main` (CI fixtures): only the intended additions (init container, container `readOnlyRootFilesystem`/`capabilities`, three emptyDirs, ephemeral-storage values); ingress output byte-identical with defaults.
- Override renders tested: `ingress.className`/`ingress.annotations` overrides, `ingress.enabled=false`, missing-domain `required` error, `securityContext.container.readOnlyRootFilesystem=false` override.
- **k3d upgrade test** (throwaway cluster `b3-vv`, `ci/voucher-vault/` fixtures: stub CRD, dummy secrets, postgres/redis/dex): installed the `origin/main` chart → Ready; upgraded to this branch → Ready with **0 restarts**, no permission/read-only errors in logs (migrations, collectstatic, celery worker+beat, uwsgi all clean). In-pod checks: `uid=33(www-data)`, `/` read-only, `/tmp` + `/opt/app/logs` writable, static volume seeded (89M, `admin/` collected), app answers `200` on `/` and serves `/static/admin/css/base.css`. Cluster deleted afterwards.
