### PR TITLE
Calibre-Web-Automated chart: naming scheme, security hardening (conventions batch 3)

### DIFF
--- a/calibre-web-automated/Chart.yaml
+++ b/calibre-web-automated/Chart.yaml
@@ -5,7 +5,7 @@ name: calibre-web-automated
 description: A Helm chart to deploy calibere-web-automated
 icon: https://raw.githubusercontent.com/crocodilestick/Calibre-Web-Automated/main/README_images/cwa-logo-round-dark.png
 
-version: 3.1.1+upv4.0.6
+version: 4.0.0+upv4.0.6
 appVersion: v4.0.6
 
 maintainers:

--- a/calibre-web-automated/templates/calibre-web-automated-consume.pvc.yaml
+++ b/calibre-web-automated/templates/calibre-web-automated-consume.pvc.yaml
@@ -1,6 +1,9 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  # Deliberate naming exception (see README): this PVC keeps its historical
+  # <chart>-<release>-cwa-consume-pvc name — renaming a PVC would provision
+  # a new, empty volume and orphan the existing data.
   name: {{ .Chart.Name }}-{{ .Release.Name }}-cwa-consume-pvc
 spec:
   accessModes:

--- a/calibre-web-automated/templates/calibre-web-automated.ingress.yaml
+++ b/calibre-web-automated/templates/calibre-web-automated.ingress.yaml
@@ -1,20 +1,23 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ .Chart.Name }}-{{ .Release.Name }}-cwa-ingress
+  name: {{ .Release.Name }}-{{ .Chart.Name }}-ingress
   annotations:
-    cert-manager.io/cluster-issuer: {{ required "A Cluster-Issuer must be provided" .Values.ingress.clusterIssuer}}
+    cert-manager.io/cluster-issuer: {{ required "A Cluster-Issuer must be provided" .Values.ingress.clusterIssuer }}
     nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.cwa.maxUploadFileSize }}
     nginx.org/client-max-body-size: {{ .Values.cwa.maxUploadFileSize }}
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
-  ingressClassName: nginx
+  ingressClassName: {{ .Values.ingress.className }}
   rules:
     - host: {{ required "A Domain/Host must be provided" .Values.ingress.domain }}
       http:
         paths:
           - backend:
               service:
-                name: {{ .Chart.Name }}-{{ .Release.Name }}-cwa-service
+                name: {{ .Release.Name }}-{{ .Chart.Name }}-service
                 port:
                   name: http
             path: /
@@ -22,4 +25,4 @@ spec:
   tls:
     - hosts:
         - {{ required "A Domain/Host must be provided" .Values.ingress.domain }}
-      secretName: tls-{{ .Chart.Name }}-{{ .Release.Name }}-ingress
+      secretName: tls-{{ .Release.Name }}-{{ .Chart.Name }}-ingress

--- a/calibre-web-automated/templates/calibre-web-automated.pvc.yaml
+++ b/calibre-web-automated/templates/calibre-web-automated.pvc.yaml
@@ -1,6 +1,9 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  # Deliberate naming exception (see README): this PVC keeps its historical
+  # <chart>-<release>-cwa-pvc name — renaming a PVC would provision a new,
+  # empty volume and orphan the existing data.
   name: {{ .Chart.Name }}-{{ .Release.Name }}-cwa-pvc
 spec:
   accessModes:

--- a/calibre-web-automated/templates/calibre-web-automated.secret.yaml
+++ b/calibre-web-automated/templates/calibre-web-automated.secret.yaml
@@ -1,6 +1,6 @@
 apiVersion: onepassword.com/v1
 kind: OnePasswordItem
 metadata:
-  name: {{ .Chart.Name }}-{{ .Release.Name }}-cwa-secret
+  name: {{ .Release.Name }}-{{ .Chart.Name }}-secret
 spec:
   itemPath: {{ .Values.secrets.cwaSecretRef }}

--- a/calibre-web-automated/templates/calibre-web-automated.service.yaml
+++ b/calibre-web-automated/templates/calibre-web-automated.service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Chart.Name }}-{{ .Release.Name }}-cwa-service
+  name: {{ .Release.Name }}-{{ .Chart.Name }}-service
 spec:
   selector:
-    app: {{ .Chart.Name }}-{{ .Release.Name }}-cwa-sfs
+    app: {{ .Release.Name }}-{{ .Chart.Name }}-sfs
   ports:
     - protocol: TCP
       port: 80

--- a/calibre-web-automated/templates/calibre-web-automated.sfs.yaml
+++ b/calibre-web-automated/templates/calibre-web-automated.sfs.yaml
@@ -1,23 +1,26 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ .Chart.Name }}-{{ .Release.Name }}-cwa-sfs
+  name: {{ .Release.Name }}-{{ .Chart.Name }}-sfs
   labels:
-    app: {{ .Chart.Name }}-{{ .Release.Name }}
+    app: {{ .Release.Name }}-{{ .Chart.Name }}-sfs
 spec:
-  serviceName: {{ .Chart.Name }}-{{ .Release.Name }}-cwa-service
+  serviceName: {{ .Release.Name }}-{{ .Chart.Name }}-service
   replicas: {{ include "calibre-web-automated.replicas" (dict "scaleDown" .Values.scaleDown "replicas" .Values.cwa.replicas) }}
   selector:
     matchLabels:
-      app: {{ .Chart.Name }}-{{ .Release.Name }}-cwa-sfs
+      app: {{ .Release.Name }}-{{ .Chart.Name }}-sfs
   template:
     metadata:
-      name: {{ .Chart.Name }}-{{ .Release.Name }}-cwa-sfs
+      name: {{ .Release.Name }}-{{ .Chart.Name }}-sfs
       labels:
-        app: {{ .Chart.Name }}-{{ .Release.Name }}-cwa-sfs
+        app: {{ .Release.Name }}-{{ .Chart.Name }}-sfs
     spec:
+      automountServiceAccountToken: false
+      securityContext:
+        {{- toYaml .Values.cwa.securityContext.pod | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}-{{ .Release.Name }}-cwa-container
+        - name: {{ .Release.Name }}-{{ .Chart.Name }}-container
           image: "ghcr.io/crocodilestick/calibre-web-automated:{{ .Chart.AppVersion }}"
           imagePullPolicy: IfNotPresent
           ports:
@@ -34,12 +37,32 @@ spec:
             - name: HARDCOVER_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Chart.Name }}-{{ .Release.Name }}-cwa-secret
+                  name: {{ .Release.Name }}-{{ .Chart.Name }}-secret
                   key: hardcover-api-token
             - name: CALIBRE_CONFIG_DIR
               value: "/config/.config/calibre"
             - name: NETWORK_SHARE_MODE
               value: "false"
+            {{- range $value := .Values.cwa.env }}
+            {{- if $value.value }}
+            - name: {{ $value.name | quote }}
+              value: {{ tpl $value.value $ | quote }}
+            {{- else if $value.valueFrom }}
+            {{- if $value.valueFrom.secretKeyRef }}
+            - name: {{ $value.name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ tpl $value.valueFrom.secretKeyRef.name $ | quote }}
+                  key: {{ tpl $value.valueFrom.secretKeyRef.key $ | quote }}
+            {{- else if $value.valueFrom.configMapKeyRef }}
+            - name: {{ $value.name }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ tpl $value.valueFrom.configMapKeyRef.name $ | quote }}
+                  key: {{ tpl $value.valueFrom.configMapKeyRef.key $ | quote }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
           volumeMounts:
             - mountPath: "/config"
               name: cwa
@@ -63,12 +86,13 @@ spec:
             {{- toYaml .Values.cwa.startupProbe | nindent 12 }}
           resources:
             {{- include "calibre-web-automated.resources" .Values.cwa.resources | nindent 12 }}
-      automountServiceAccountToken: false
-      securityContext:
-        fsGroup: 1000
-        fsGroupChangePolicy: Always
+          securityContext:
+            {{- toYaml .Values.cwa.securityContext.container | nindent 12 }}
       restartPolicy: Always
       volumes:
+        # Deliberate naming exception (see README): both PVCs keep their
+        # historical <chart>-<release>-cwa-* names — renaming a PVC would
+        # provision a new, empty volume and orphan the existing data.
         - name: cwa
           persistentVolumeClaim:
             claimName: {{ .Chart.Name }}-{{ .Release.Name }}-cwa-pvc
@@ -77,7 +101,7 @@ spec:
             claimName: {{ .Chart.Name }}-{{ .Release.Name }}-cwa-consume-pvc
         - name: cwa-plugins-config
           secret:
-            secretName: {{ .Chart.Name }}-{{ .Release.Name }}-cwa-secret
+            secretName: {{ .Release.Name }}-{{ .Chart.Name }}-secret
             items:
               - key: calibre-plugins
                 path: customize.py.json

--- a/calibre-web-automated/values.yaml
+++ b/calibre-web-automated/values.yaml
@@ -46,7 +46,47 @@ cwa:
       cpu: 0.1
       memory: 512Mi
       ephemeralStorage: 100Mi
+  # Documented deviation from the repo-wide hardening standard: the CWA image
+  # (linuxserver.io-style) must start as root — it boots via the s6-overlay
+  # init system, whose stage-1/2 setup runs as uid 0 and then drops the app
+  # to the PUID/PGID user (1000), so runAsNonRoot/runAsUser are deliberately
+  # not set (s6 supervisors stay root, the application runs as uid 1000).
+  # readOnlyRootFilesystem is deliberately false: in read-only mode the image
+  # disables the PUID/PGID remapping (the runtime uid would silently change
+  # from 1000 to the built-in 911 and break existing volume data) and its
+  # init fails to write the ImageMagick policy under /etc. Everything else
+  # is hardened: no privilege escalation and all capabilities dropped except
+  # the minimal set the s6 init/supervision needs (verified against v4.0.6):
+  # CHOWN/DAC_OVERRIDE/FOWNER/SETGID/SETUID for the ownership fix-up of
+  # /config etc. and the root->PUID drop, KILL so the root supervisor can
+  # signal the uid-1000 services (without it the pod cannot shut down
+  # cleanly and gets SIGKILLed).
+  securityContext:
+    pod:
+      fsGroup: 1000
+      fsGroupChangePolicy: Always
+    container:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: false
+      capabilities:
+        drop:
+          - ALL
+        add:
+          - CHOWN
+          - DAC_OVERRIDE
+          - FOWNER
+          - KILL
+          - SETGID
+          - SETUID
+  # Extra environment variables, appended to the ones the chart always sets.
+  # Rendered through tpl; value, secretKeyRef and configMapKeyRef forms are
+  # supported (see template-chart).
+  env: []
 
 ingress:
-  clusterIssuer: "letsencrypt-issuer"
+  clusterIssuer: null
   domain: null
+  className: nginx
+  # Extra annotations for the Ingress; merged with the cert-manager
+  # cluster-issuer and proxy-body-size annotations the chart always sets.
+  annotations: {}

--- a/ci/calibre-web-automated/fixtures.yaml
+++ b/ci/calibre-web-automated/fixtures.yaml
@@ -1,7 +1,9 @@
 # Fixtures for the calibre-web-automated install-test: the cwa secret the
 # 1Password operator would otherwise materialize and static hostPath PVs
 # (the consume PVC is ReadWriteMany, which local-path cannot provision).
-# This chart names resources <chart>-<release>-..., release name is ci.
+# Release name is ci; resources are named <release>-<chart>-..., except the
+# PVCs, which keep their historical <chart>-<release>-cwa-* names
+# (documented naming exception, see README).
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -74,7 +76,7 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: calibre-web-automated-ci-cwa-secret
+  name: ci-calibre-web-automated-secret
 stringData:
   hardcover-api-token: ci-dummy-token
   # Mounted as /config/.config/calibre/customize.py.json (calibre plugin

--- a/ci/calibre-web-automated/test-values.yaml
+++ b/ci/calibre-web-automated/test-values.yaml
@@ -9,4 +9,5 @@ cwa:
   storage: 2Gi
 
 ingress:
+  clusterIssuer: ci
   domain: cwa.ci.local


### PR DESCRIPTION
Part of #32 (batch 3 — per-chart major PRs). All audit findings for the `calibre-web-automated` chart in one PR. Chart `3.1.1+upv4.0.6` → **`4.0.0+upv4.0.6`** (major: resource renames + values-schema changes; appVersion unchanged).

## Findings → fixes

| Audit finding | Fix |
|---|---|
| **All** resources named `{{ .Chart.Name }}-{{ .Release.Name }}-cwa-<kind>` (order inverted + `cwa` infix) | StatefulSet, Service, OnePasswordItem secret and Ingress renamed to `{{ .Release.Name }}-{{ .Chart.Name }}-<kind>`; labels/selector aligned, `spec.serviceName` and all secret/service references follow ⚠️ one-time migration, see below |
| The two PVCs also carry the inverted name | **Deliberately untouched** — documented naming exception for existing PVCs (README); renaming would provision new, empty volumes and orphan the data. The StatefulSet still references exactly these claims (comments added in the templates) |
| TLS secret `tls-<chart>-<release>-ingress` (inverted) | Renamed to the standard `tls-<release>-<chart>-ingress` (cert-manager issues a fresh certificate into the new secret) |
| Ingress off the repo standard (`ingressClassName: nginx` hardcoded, no annotations merge, `clusterIssuer` silently defaulted to `"letsencrypt-issuer"`) | Standard ingress: `ingress.className` (default `nginx`), `ingress.annotations` merged with the chart-managed cert-manager + proxy-body-size annotations, `ingress.clusterIssuer` now **required** (like `ingress.domain`) |
| No container securityContext (pod only `fsGroup: 1000`), not values-configurable, no documented deviation | Values-configurable `securityContext.pod` / `securityContext.container`. Hardened as far as the image allows: `allowPrivilegeEscalation: false`, all capabilities dropped except the minimal set the s6-overlay init/supervision needs — `CHOWN`/`DAC_OVERRIDE`/`FOWNER`/`SETGID`/`SETUID` (ownership fix-up + root→PUID drop) and `KILL` (root supervisor must signal the uid-1000 services; without it the pod cannot shut down cleanly and is SIGKILLed — verified empirically). Documented deviations in `values.yaml`, see below |
| Probes (audit point 6) | Already values-configurable on `origin/main` — verified, untouched |
| No `env` convention | Additive `cwa.env` value rendered through `tpl`, supporting the `value` / `secretKeyRef` / `configMapKeyRef` forms (template-chart pattern); appended after the chart-managed variables |

## Documented hardening deviations (values.yaml comment)

The image (`crocodilestick/calibre-web-automated`, linuxserver.io-style) boots via **s6-overlay as root** and drops the app to the PUID/PGID user (1000), so `runAsNonRoot`/`runAsUser` are not set — same situation as homeassistant. `readOnlyRootFilesystem` stays `false` deliberately: in read-only mode the image **disables PUID/PGID remapping upstream** (the runtime uid would silently change from 1000 to the built-in 911 and break existing volume data) and its init fails writing the ImageMagick policy under `/etc` (both verified against `v4.0.6`).

## ⚠️ One-time migration for existing installations

The StatefulSet rename makes a plain `helm upgrade` fail (immutable fields). Data is safe — the chart uses standalone PVCs (no `volumeClaimTemplates`) and the PVC names are unchanged. Migration (same procedure as in #48; deleting the old pod is required because the RWO volume must be released and the new StatefulSet's selector no longer matches it):

```bash
# 1. Remove the old StatefulSet object, keep the pod running for now
kubectl -n <ns> delete statefulset calibre-web-automated-<release>-cwa-sfs --cascade=orphan

# 2. Delete the orphaned pod (frees the RWO volume) — downtime starts here
kubectl -n <ns> delete pod calibre-web-automated-<release>-cwa-sfs-0

# 3. Delete the old service
kubectl -n <ns> delete service calibre-web-automated-<release>-cwa-service

# 4. Upgrade
helm upgrade <release> ... --version 4.0.0+upv4.0.6
```

**Note for the maintainer:** if you already performed the `--cascade=orphan` migration for the `serviceName` fix in #28, this is a **second, separate migration** — the StatefulSet name itself changes this time, so the full procedure above (including pod and service deletion) is needed again.

**In-cluster DNS change:** the service is now `<release>-calibre-web-automated-service` instead of `calibre-web-automated-<release>-cwa-service`; any consumer referencing the old DNS name must be updated.

**Values change:** installations relying on the previous implicit `ingress.clusterIssuer: "letsencrypt-issuer"` default must now set the value explicitly (it is `required`, matching the repo standard).

## Bump justification

Major: resource renames (StatefulSet/Service/Secret/Ingress, TLS secret name), `ingress.clusterIssuer` default removed (now required), and runtime behavior change through the new security contexts.

## Validation

- `helm lint --strict` green (0 failures, only the expected `required`-value INFO lines); `helm package` OK.
- `helm template` with defaults: rendered output differs from `origin/main` only in the intended changes (renames, security contexts, comments).
- Override renders verified: `ingress.className`/`ingress.annotations` (merge with chart-managed annotations), missing `clusterIssuer` → required error, `cwa.env` in all three forms incl. `tpl` (`{{ .Release.Name }}` resolved), `securityContext.container` override.

## k3d migration test (performed)

Throwaway cluster `b3-cwa`, `ci/calibre-web-automated/` fixtures:

1. Installed the chart from `origin/main` → `Ready 1/1`; wrote a marker file into `/config` (data PVC).
2. Ran the migration above, upgraded to this branch.
3. Result: new pod `Ready 1/1`, **0 restarts** over several probe cycles; both PVCs re-bound (`calibre-web-automated-ci-cwa-pvc` / `...-consume-pvc`, same volumes); marker file present; app reachable through the new service DNS (login page served).
4. Hardening verified at runtime: `CapEff 0xeb` (exactly the six granted capabilities), `NoNewPrivs: 1`, web app running as uid 1000 (`abc`), s6 supervisors as root; no permission errors (the only `chown` complaint is the pre-existing one on the read-only secret projection of `customize.py.json`, unrelated to the hardening).
5. Capability set determined empirically against `v4.0.6`: startup fails without the five file/uid caps; without `KILL`, shutdown hangs the full grace period and ends in SIGKILL (exit 137) — with `KILL`, clean stop in ~1s.
