### PR TITLE
Zipline chart: ingress standard, secret ref structure (conventions batch 3)

### DIFF
--- a/ci/zipline/fixtures.yaml
+++ b/ci/zipline/fixtures.yaml
@@ -10,7 +10,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: ci-zipline-core-secret
+  name: ci-zipline-secret
 stringData:
   server-secret: zipline-ci-core-secret-0123456789abcdef0123456789abcdef0123456789
 ---

--- a/ci/zipline/test-values.yaml
+++ b/ci/zipline/test-values.yaml
@@ -1,9 +1,11 @@
 config:
   storage: 1Gi
   storageClass: local-path
+ingress:
   domain: zipline.ci.local
-  # The OnePasswordItem CRs only need non-null item paths; the actual
-  # Kubernetes Secrets come from ci/zipline/fixtures.yaml.
-  secretRef:
-    db: op://ci/zipline-db
-    zipline: op://ci/zipline-core
+  clusterIssuer: ci-issuer
+# The OnePasswordItem CRs only need non-null item paths; the actual
+# Kubernetes Secrets come from ci/zipline/fixtures.yaml.
+secrets:
+  databaseSecretRef: op://ci/zipline-db
+  ziplineSecretRef: op://ci/zipline-core

--- a/zipline/Chart.yaml
+++ b/zipline/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.1.2+up4.7.0
+version: 5.0.0+up4.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/zipline/templates/db-connection.secret.yaml
+++ b/zipline/templates/db-connection.secret.yaml
@@ -3,4 +3,4 @@ kind: OnePasswordItem
 metadata:
   name: {{ .Release.Name }}-{{ .Chart.Name }}-db-secret
 spec:
-  itemPath: {{ required "A secret-reference for the DB-Secret must be provided" .Values.config.secretRef.db }}
+  itemPath: {{ required "You must provide a databaseSecret Reference" .Values.secrets.databaseSecretRef }}

--- a/zipline/templates/zipline.ingress.yaml
+++ b/zipline/templates/zipline.ingress.yaml
@@ -3,13 +3,16 @@ kind: Ingress
 metadata:
   name: {{ .Release.Name }}-{{ .Chart.Name }}-ingress
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-issuer
+    cert-manager.io/cluster-issuer: {{ required "A Cluster-Issuer must be provided" .Values.ingress.clusterIssuer }}
     nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.config.maxUploadFileSize }}
     nginx.org/client-max-body-size: {{ .Values.config.maxUploadFileSize }}
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
-  ingressClassName: nginx
+  ingressClassName: {{ .Values.ingress.className }}
   rules:
-    - host: {{ required "A Domain/Host must be provided" .Values.config.domain }}
+    - host: {{ required "A Domain/Host must be provided" .Values.ingress.domain }}
       http:
         paths:
           - backend:
@@ -21,5 +24,5 @@ spec:
             pathType: Prefix
   tls:
     - hosts:
-        - {{ required "A Domain/Host must be provided" .Values.config.domain }}
-      secretName: tls-{{ .Release.Name }}-{{ .Chart.Name }}-{{ .Values.config.domain }}-ingress
+        - {{ required "A Domain/Host must be provided" .Values.ingress.domain }}
+      secretName: tls-{{ .Release.Name }}-{{ .Chart.Name }}-ingress

--- a/zipline/templates/zipline.pvc.yaml
+++ b/zipline/templates/zipline.pvc.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  # Documented exception from the "-<kind>" naming scheme (issue #32): renaming
+  # a PVC would provision a new, empty volume, so the historic "-vc" name stays.
   name: {{ .Release.Name }}-{{ .Chart.Name }}-vc
 spec:
   accessModes:

--- a/zipline/templates/zipline.secret.yaml
+++ b/zipline/templates/zipline.secret.yaml
@@ -1,6 +1,6 @@
 apiVersion: onepassword.com/v1
 kind: OnePasswordItem
 metadata:
-  name: {{ .Release.Name }}-{{ .Chart.Name }}-core-secret
+  name: {{ .Release.Name }}-{{ .Chart.Name }}-secret
 spec:
-  itemPath: {{ required "A secret-reference for the DB-Secret must be provided" .Values.config.secretRef.zipline }}
+  itemPath: {{ required "You must provide a ziplineSecret Reference" .Values.secrets.ziplineSecretRef }}

--- a/zipline/templates/zipline.sfs.yaml
+++ b/zipline/templates/zipline.sfs.yaml
@@ -27,14 +27,34 @@ spec:
                   name: {{ .Release.Name }}-{{ .Chart.Name }}-db-secret
                   key: connection-url
             - name: CORE_DEFAULT_DOMAIN
-              value: "{{ .Values.config.domain }}"
+              value: "{{ .Values.ingress.domain }}"
             - name: CORE_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-{{ .Chart.Name }}-core-secret
+                  name: {{ .Release.Name }}-{{ .Chart.Name }}-secret
                   key: server-secret
             - name: UPLOADER_ADMIN_LIMIT
               value: 500mb
+            {{- range $value := .Values.zipline.env }}
+            {{- if $value.value }}
+            - name: {{ $value.name | quote }}
+              value: {{ tpl $value.value $ | quote }}
+            {{- else if $value.valueFrom }}
+            {{- if $value.valueFrom.secretKeyRef }}
+            - name: {{ $value.name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ tpl $value.valueFrom.secretKeyRef.name $ | quote }}
+                  key: {{ tpl $value.valueFrom.secretKeyRef.key $ | quote }}
+            {{- else if $value.valueFrom.configMapKeyRef }}
+            - name: {{ $value.name }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ tpl $value.valueFrom.configMapKeyRef.name $ | quote }}
+                  key: {{ tpl $value.valueFrom.configMapKeyRef.key $ | quote }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
           resources:
             {{- include "zipline.resources" .Values.zipline.resources | nindent 12 }}
           ports:

--- a/zipline/values.yaml
+++ b/zipline/values.yaml
@@ -4,14 +4,15 @@
 # Services stay in place; scaleDown: false brings the workloads back up.
 scaleDown: false
 
+secrets:
+  databaseSecretRef: null
+  ziplineSecretRef: null
+
 config:
   storage: 50Gi
   storageClass: longhorn
-  secretRef:
-    db: null
-    zipline: null
-  domain: null
   maxUploadFileSize: 30m
+
 zipline:
   # Replica count for this workload; 0 is allowed and scales it down.
   # The chart-global scaleDown flag takes precedence.
@@ -68,3 +69,15 @@ zipline:
       cpu: 0.1
       memory: 265Mi
       ephemeralStorage: 100Mi
+  # Extra environment variables, appended to the ones the chart always sets.
+  # Rendered through tpl; value, secretKeyRef and configMapKeyRef forms are
+  # supported (see template-chart).
+  env: []
+
+ingress:
+  clusterIssuer: null
+  domain: null
+  className: nginx
+  # Extra annotations for the Ingress; merged with the cert-manager
+  # cluster-issuer and upload-size annotations the chart always sets.
+  annotations: {}


### PR DESCRIPTION
Part of #32 — Batch-3 major PR for zipline. Bundles all audit findings for this chart in one major bump; zipline carries the largest ingress/values rework of the batch.

## Findings → Fixes

| Audit finding | Fix |
|---|---|
| `cert-manager.io/cluster-issuer: letsencrypt-issuer` **hardcoded** in the ingress | `required .Values.ingress.clusterIssuer`, per the repo standard |
| Domain lives under `config.domain` instead of `ingress.domain` | Moved to `ingress.domain` (required). The `CORE_DEFAULT_DOMAIN` env in the StatefulSet now references `.Values.ingress.domain` — rendered value unchanged for the same domain |
| TLS secret `tls-<release>-<chart>-<domain>-ingress` (domain in the name) | Standard `tls-<release>-<chart>-ingress`. cert-manager issues a fresh certificate into the new secret on upgrade → **short certificate changeover**; the old `tls-…-<domain>-ingress` secret can be deleted afterwards |
| `ingressClassName: nginx` hardcoded | `ingress.className` value (default `nginx`) plus `ingress.annotations` merged with the always-set cert-manager and upload-size annotations |
| Secret refs `config.secretRef.db` / `config.secretRef.zipline` — neither `secrets:` block nor `<name>SecretRef` naming | Standard `secrets.databaseSecretRef` / `secrets.ziplineSecretRef`; `required` messages fixed along the way (the zipline secret wrongly said "DB-Secret") |
| Naming: OnePasswordItem `…-core-secret` | Renamed to the standard `{{ .Release.Name }}-{{ .Chart.Name }}-secret` (main app secret, matching voucher-vault/template-chart; `…-db-secret` already matches the secondary-secret pattern). Safe rename: the CR is re-created and the operator materializes the Secret under the new name; the StatefulSet's `CORE_SECRET` ref follows in the same upgrade |
| Naming: PVC `…-vc` | **Untouched** — documented exception from the naming scheme (maintainer decision in #32: renaming a PVC would provision a new empty volume); comment added in the template |
| Naming: other resources / workload kind | Verified only: sfs/service/ingress names already conform; the workload is a StatefulSet whose name already matches, so **no SFS rename/migration needed** |
| Hardening (audit point 5) | Verified only: zipline is conformant (values-configurable pod/container securityContext, non-root, read-only rootfs, caps dropped) — untouched |
| Probes (audit point 6) | Verified only: already values-configurable — untouched |
| Env convention | Additive `zipline.env: []` block, rendered through `tpl`, supporting `value` / `secretKeyRef` / `configMapKeyRef` (template-chart pattern) |
| CI fixtures | `ci/zipline/test-values.yaml` moved to the new value paths; fixture secret renamed `ci-zipline-core-secret` → `ci-zipline-secret` |

## Breaking values changes (migration mapping old → new)

| Old | New |
|---|---|
| `config.domain` | `ingress.domain` (required) |
| — (hardcoded `letsencrypt-issuer`) | `ingress.clusterIssuer` (required — set it to `letsencrypt-issuer` to keep the current issuer) |
| `config.secretRef.db` | `secrets.databaseSecretRef` |
| `config.secretRef.zipline` | `secrets.ziplineSecretRef` |
| — | `ingress.className` (new, default `nginx`) |
| — | `ingress.annotations` (new, default `{}`) |
| — | `zipline.env` (new, default `[]`) |

`config.storage`, `config.storageClass` and `config.maxUploadFileSize` are unchanged.

Breaking on the cluster side:

- **TLS secret name changes** → brief certificate re-issue on upgrade (see above).
- **Materialized app secret renamed** `<release>-zipline-core-secret` → `<release>-zipline-secret` (OnePasswordItem CR re-created; no action needed with the 1Password operator running).
- No data migration: the PVC keeps its name, the StatefulSet keeps its name — a plain `helm upgrade` with the mapped values suffices.

## Version bump

`4.1.2+up4.7.0` → `5.0.0+up4.7.0` — **major**: breaking values-schema changes (ingress/secrets restructuring) and renamed TLS/app secrets. App version unchanged (4.7.0).

## Verification

- `helm lint --strict zipline` green (no findings).
- Render diff vs. `origin/main` (CI fixtures): only the intended changes (cluster-issuer annotation from value, standard TLS secret name, secret rename, PVC comment); `ingressClassName` and `CORE_DEFAULT_DOMAIN` byte-identical with defaults.
- Override renders tested: `ingress.className`/`ingress.annotations` merge, `zipline.env` with all three forms (tpl expansion verified), `required` errors for missing `ingress.clusterIssuer`, `ingress.domain`, `secrets.databaseSecretRef`, `secrets.ziplineSecretRef`.
- **k3d upgrade test** (throwaway cluster `b3-zipline`, `ci/zipline/` fixtures: stub CRD, dummy secrets, throwaway postgres): installed the `origin/main` chart with the old values → Ready; wrote a marker file into the uploads PVC; upgraded to this branch with the new values → Ready with **0 restarts**, same PVC still Bound, marker file intact, `CORE_DEFAULT_DOMAIN`/`CORE_SECRET` correct from the new paths/secret name, `/api/healthcheck` returns `{"pass":true}`, no permission/read-only errors in the logs. Old OnePasswordItem CR removed by the upgrade, new `ci-zipline-secret` in place. Cluster deleted afterwards.
