### PR TITLE
Urlaubsverwaltung chart: naming scheme, configurable probes (conventions batch 3)

### DIFF
--- a/ci/urlaubsverwaltung/fixtures.yaml
+++ b/ci/urlaubsverwaltung/fixtures.yaml
@@ -1,11 +1,11 @@
 # Fixtures for the urlaubsverwaltung install-test: throwaway postgres, a dex
 # OIDC provider (Spring performs OIDC discovery against the issuer at boot)
 # and the secrets the 1Password operator would otherwise materialize.
-# Note: this chart names secrets <chart>-<release>-..., release name is ci.
+# Note: secrets are named <release>-<chart>-..., release name is ci.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: urlaubsverwaltung-ci-uv-db-secret
+  name: ci-urlaubsverwaltung-db-secret
 stringData:
   jdbc-url: jdbc:postgresql://postgres:5432/urlaubsverwaltung
   username: ci
@@ -14,7 +14,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: urlaubsverwaltung-ci-uv-oidc-secret
+  name: ci-urlaubsverwaltung-oidc-secret
 stringData:
   client-id: ci-client
   client-secret: ci-client-secret

--- a/urlaubsverwaltung/Chart.yaml
+++ b/urlaubsverwaltung/Chart.yaml
@@ -4,5 +4,5 @@ description: A Helm chart to deploy urlaubsverwaltung on Kubernetes
 icon: https://raw.githubusercontent.com/urlaubsverwaltung/urlaubsverwaltung/main/src/main/resources/static/favicons/apple-touch-icon.png
 type: application
 
-version: 4.1.2+up6.7.0
+version: 5.0.0+up6.7.0
 appVersion: 6.7.0

--- a/urlaubsverwaltung/templates/urlaubsverwaltung-db.secret.yaml
+++ b/urlaubsverwaltung/templates/urlaubsverwaltung-db.secret.yaml
@@ -1,6 +1,6 @@
 apiVersion: onepassword.com/v1
 kind: OnePasswordItem
 metadata:
-  name: {{ .Chart.Name }}-{{ .Release.Name }}-uv-db-secret
+  name: {{ .Release.Name }}-{{ .Chart.Name }}-db-secret
 spec:
   itemPath: {{ .Values.secrets.databaseSecretRef }}

--- a/urlaubsverwaltung/templates/urlaubsverwaltung-oidc.secret.yaml
+++ b/urlaubsverwaltung/templates/urlaubsverwaltung-oidc.secret.yaml
@@ -1,6 +1,6 @@
 apiVersion: onepassword.com/v1
 kind: OnePasswordItem
 metadata:
-  name: {{ .Chart.Name }}-{{ .Release.Name }}-uv-oidc-secret
+  name: {{ .Release.Name }}-{{ .Chart.Name }}-oidc-secret
 spec:
   itemPath: {{ .Values.secrets.oidcSecretRef }}

--- a/urlaubsverwaltung/templates/urlaubsverwaltung.deployment.yaml
+++ b/urlaubsverwaltung/templates/urlaubsverwaltung.deployment.yaml
@@ -1,25 +1,25 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Chart.Name }}-{{ .Release.Name }}-uv-deployment
+  name: {{ .Release.Name }}-{{ .Chart.Name }}-deployment
   labels:
-    app: {{ .Chart.Name }}-{{ .Release.Name }}
+    app: {{ .Release.Name }}-{{ .Chart.Name }}-deployment
 spec:
   replicas: {{ include "urlaubsverwaltung.replicas" (dict "scaleDown" .Values.scaleDown "replicas" .Values.urlaubsverwaltung.replicas) }}
   selector:
     matchLabels:
-      app: {{ .Chart.Name }}-{{ .Release.Name }}-uv-deployment
+      app: {{ .Release.Name }}-{{ .Chart.Name }}-deployment
   template:
     metadata:
-      name: {{ .Chart.Name }}-{{ .Release.Name }}-uv-deployment
+      name: {{ .Release.Name }}-{{ .Chart.Name }}-deployment
       labels:
-        app: {{ .Chart.Name }}-{{ .Release.Name }}-uv-deployment
+        app: {{ .Release.Name }}-{{ .Chart.Name }}-deployment
     spec:
       automountServiceAccountToken: false
       securityContext:
         {{- toYaml .Values.urlaubsverwaltung.securityContext.pod | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}-{{ .Release.Name }}-uv-container
+        - name: {{ .Release.Name }}-{{ .Chart.Name }}-deployment
           image: "urlaubsverwaltung/urlaubsverwaltung:{{ .Chart.AppVersion }}"
           imagePullPolicy: IfNotPresent
           securityContext:
@@ -38,17 +38,17 @@ spec:
             - name: SPRING_DATASOURCE_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Chart.Name }}-{{ .Release.Name }}-uv-db-secret
+                  name: {{ .Release.Name }}-{{ .Chart.Name }}-db-secret
                   key: jdbc-url
             - name: SPRING_DATASOURCE_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Chart.Name }}-{{ .Release.Name }}-uv-db-secret
+                  name: {{ .Release.Name }}-{{ .Chart.Name }}-db-secret
                   key: username
             - name: SPRING_DATASOURCE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Chart.Name }}-{{ .Release.Name }}-uv-db-secret
+                  name: {{ .Release.Name }}-{{ .Chart.Name }}-db-secret
                   key: password
             # Mail
             - name: UV_MAIL_FROM
@@ -72,17 +72,17 @@ spec:
             - name: SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_DEFAULT_CLIENT-ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Chart.Name }}-{{ .Release.Name }}-uv-oidc-secret
+                  name: {{ .Release.Name }}-{{ .Chart.Name }}-oidc-secret
                   key: client-id
             - name: SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_DEFAULT_CLIENT-SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Chart.Name }}-{{ .Release.Name }}-uv-oidc-secret
+                  name: {{ .Release.Name }}-{{ .Chart.Name }}-oidc-secret
                   key: client-secret
             - name: SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_DEFAULT_CLIENT-NAME
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Chart.Name }}-{{ .Release.Name }}-uv-oidc-secret
+                  name: {{ .Release.Name }}-{{ .Chart.Name }}-oidc-secret
                   key: issuer-name
             - name: SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_DEFAULT_PROVIDER
               value: default
@@ -93,49 +93,50 @@ spec:
             - name: SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_DEFAULT_REDIRECT-URI
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Chart.Name }}-{{ .Release.Name }}-uv-oidc-secret
+                  name: {{ .Release.Name }}-{{ .Chart.Name }}-oidc-secret
                   key: redirect-uri
             - name: SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_DEFAULT_ISSUER-URI
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Chart.Name }}-{{ .Release.Name }}-uv-oidc-secret
+                  name: {{ .Release.Name }}-{{ .Chart.Name }}-oidc-secret
                   key: issuer-uri
             - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER-URI
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Chart.Name }}-{{ .Release.Name }}-uv-oidc-secret
+                  name: {{ .Release.Name }}-{{ .Chart.Name }}-oidc-secret
                   key: jwt-issuer-uri
             - name: UV_SECURITY_OIDC_CLAIM-MAPPERS_GROUP-CLAIM_ENABLED
               value: "true"
             - name: UV_SECURITY_OIDC_CLAIM-MAPPERS_GROUP-CLAIM_CLAIM-NAME
               value: "groups"
+            {{- range $value := .Values.urlaubsverwaltung.env }}
+            {{- if $value.value }}
+            - name: {{ $value.name | quote }}
+              value: {{ tpl $value.value $ | quote }}
+            {{- else if $value.valueFrom }}
+            {{- if $value.valueFrom.secretKeyRef }}
+            - name: {{ $value.name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ tpl $value.valueFrom.secretKeyRef.name $ | quote }}
+                  key: {{ tpl $value.valueFrom.secretKeyRef.key $ | quote }}
+            {{- else if $value.valueFrom.configMapKeyRef }}
+            - name: {{ $value.name }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ tpl $value.valueFrom.configMapKeyRef.name $ | quote }}
+                  key: {{ tpl $value.valueFrom.configMapKeyRef.key $ | quote }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
           resources:
             {{- include "urlaubsverwaltung.resources" .Values.urlaubsverwaltung.resources | nindent 12 }}
-          readinessProbe:
-            httpGet:
-              port: 8080
-              path: /actuator/health/readiness
-            periodSeconds: 5
-            failureThreshold: 3
-            successThreshold: 1
-            timeoutSeconds: 5
           livenessProbe:
-            httpGet:
-              port: 8080
-              path: /actuator/health/liveness
-            periodSeconds: 10
-            failureThreshold: 3
-            successThreshold: 1
-            timeoutSeconds: 5
-          # The startup probe gates liveness/readiness. Spring Boot startup
-          # (JVM + Liquibase migrations) gets a budget of 10s * 30 = 300s.
+            {{- toYaml .Values.urlaubsverwaltung.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.urlaubsverwaltung.readinessProbe | nindent 12 }}
           startupProbe:
-            httpGet:
-              port: 8080
-              path: /actuator/health/liveness
-            periodSeconds: 10
-            failureThreshold: 30
-            timeoutSeconds: 5
+            {{- toYaml .Values.urlaubsverwaltung.startupProbe | nindent 12 }}
       volumes:
         - name: tmp
           emptyDir: {}

--- a/urlaubsverwaltung/templates/urlaubsverwaltung.ingress.yaml
+++ b/urlaubsverwaltung/templates/urlaubsverwaltung.ingress.yaml
@@ -1,18 +1,22 @@
+{{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ .Chart.Name }}-{{ .Release.Name }}-uv-ingress
+  name: {{ .Release.Name }}-{{ .Chart.Name }}-ingress
   annotations:
-    cert-manager.io/cluster-issuer: {{ required "A Cluster-Issuer must be provided" .Values.ingress.clusterIssuer}}
+    cert-manager.io/cluster-issuer: {{ required "A Cluster-Issuer must be provided" .Values.ingress.clusterIssuer }}
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
-  ingressClassName: nginx
+  ingressClassName: {{ .Values.ingress.className }}
   rules:
     - host: {{ required "A Domain/Host must be provided" .Values.ingress.domain }}
       http:
         paths:
           - backend:
               service:
-                name: {{ .Chart.Name }}-{{ .Release.Name }}-uv-service
+                name: {{ .Release.Name }}-{{ .Chart.Name }}-service
                 port:
                   name: http
             path: /
@@ -20,4 +24,5 @@ spec:
   tls:
     - hosts:
         - {{ required "A Domain/Host must be provided" .Values.ingress.domain }}
-      secretName: tls-{{ .Chart.Name }}-{{ .Release.Name }}-ingress
+      secretName: tls-{{ .Release.Name }}-{{ .Chart.Name }}-ingress
+{{- end }}

--- a/urlaubsverwaltung/templates/urlaubsverwaltung.service.yaml
+++ b/urlaubsverwaltung/templates/urlaubsverwaltung.service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Chart.Name }}-{{ .Release.Name }}-uv-service
+  name: {{ .Release.Name }}-{{ .Chart.Name }}-service
 spec:
   selector:
-    app: {{ .Chart.Name }}-{{ .Release.Name }}-uv-deployment
+    app: {{ .Release.Name }}-{{ .Chart.Name }}-deployment
   ports:
     - protocol: TCP
       port: 80

--- a/urlaubsverwaltung/values.yaml
+++ b/urlaubsverwaltung/values.yaml
@@ -9,8 +9,13 @@ secrets:
   oidcSecretRef: null
 
 ingress:
+  enabled: true
   clusterIssuer: "letsencrypt-issuer"
   domain: null
+  className: nginx
+  # Extra annotations for the Ingress; merged with the cert-manager
+  # cluster-issuer annotation the chart always sets.
+  annotations: {}
 
 urlaubsverwaltung:
   # Replica count for this workload; 0 is allowed and scales it down.
@@ -31,6 +36,35 @@ urlaubsverwaltung:
       capabilities:
         drop:
           - ALL
+  livenessProbe:
+    httpGet:
+      port: 8080
+      path: /actuator/health/liveness
+    periodSeconds: 10
+    failureThreshold: 3
+    successThreshold: 1
+    timeoutSeconds: 5
+  readinessProbe:
+    httpGet:
+      port: 8080
+      path: /actuator/health/readiness
+    periodSeconds: 5
+    failureThreshold: 3
+    successThreshold: 1
+    timeoutSeconds: 5
+  # The startup probe gates liveness/readiness. Spring Boot startup
+  # (JVM + Liquibase migrations) gets a budget of 10s * 30 = 300s.
+  startupProbe:
+    httpGet:
+      port: 8080
+      path: /actuator/health/liveness
+    periodSeconds: 10
+    failureThreshold: 30
+    timeoutSeconds: 5
+  # Extra environment variables, appended to the ones the chart always sets.
+  # Values are rendered through tpl; value, secretKeyRef and configMapKeyRef
+  # forms are supported.
+  env: []
   resources:
     # Limits are optional: memory and ephemeral-storage limits default to
     # limitFactor x the request, an explicitly set limit always wins, and a


### PR DESCRIPTION
Part of #32 — Batch-3 major PR for urlaubsverwaltung. Bundles all audit findings for this chart in one major bump.

## Findings → Fixes

| Audit finding | Fix |
|---|---|
| All resources named `<chart>-<release>-uv-<kind>` — order swapped + `uv` infix | Renamed to the repo standard `{{ .Release.Name }}-{{ .Chart.Name }}-<kind>`: deployment, service, ingress and both OnePasswordItem secrets (now `…-db-secret` / `…-oidc-secret`); container name and `app` labels aligned. The chart has **no PVCs** and uses a Deployment, so no storage migration is needed. |
| TLS secret `tls-<chart>-<release>-ingress` (order swapped) | Standard name `tls-{{ .Release.Name }}-{{ .Chart.Name }}-ingress`. cert-manager issues a fresh certificate into the new secret on upgrade; the old `tls-<chart>-<release>-ingress` secret can be deleted afterwards. |
| Probes hardcoded in the template | `urlaubsverwaltung.livenessProbe` / `readinessProbe` / `startupProbe` values; defaults are **exactly** the previously hardcoded settings calibrated in #9 (readiness `/actuator/health/readiness` 5s period, liveness `/actuator/health/liveness` 10s period, startup budget 10s × 30 = 300s), incl. the explanatory comment now in values.yaml. |
| `ingressClassName: nginx` hardcoded | Repo-standard flexible ingress: `ingress.className` (default `nginx`), `ingress.annotations` merged with the always-set cert-manager annotation, `ingress.enabled` flag (default `true`). `ingress.domain`/`ingress.clusterIssuer` stay required (existing `letsencrypt-issuer` default kept). |
| No `env` value block | Additive `urlaubsverwaltung.env` rendered through `tpl` with the three forms (`value`/`secretKeyRef`/`configMapKeyRef`); chart-managed env entries stay in the template. |
| Hardening (audit point 5) | Already conform (values-configurable, complete) — verified, untouched. |

CI fixtures (`ci/urlaubsverwaltung/fixtures.yaml`) updated to the new secret names.

## Upgrade note (brief downtime)

The Deployment is renamed, so Helm deletes the old Deployment and creates the new one (the selector is immutable anyway — a rename is the clean replace). Expect a short downtime of one pod cycle; no data is involved (stateless workload, no PVCs). The 1Password operator materializes the secrets under their new names automatically.

## Version bump

`4.1.2+up6.7.0` → `5.0.0+up6.7.0` — **major**: resource renames (deployment/service/ingress/secrets, TLS secret name). App version unchanged.

## Verification

- `helm lint --strict urlaubsverwaltung` green (no findings).
- Render diff vs. `origin/main` (CI fixtures): only the intended renames; probe and ingress output identical apart from YAML key ordering.
- Override renders tested: all three `env` forms (incl. `tpl` expansion), probe overrides, `ingress.className`/`annotations` overrides, `ingress.enabled=false`, and both `required` errors (domain, clusterIssuer).
- **k3d upgrade test** (throwaway cluster `b3-uv`, `ci/urlaubsverwaltung/` fixtures: stub CRD, dummy secrets, postgres, dex): installed `origin/main` chart (4.1.2) → Ready; upgraded to this branch → renamed Deployment Ready with **0 restarts**, old deployment/service/ingress/secrets removed by Helm, TLS secret name and OnePasswordItems verified, no permission errors in logs. Cluster deleted afterwards.
