### PR TITLE
Paperless-ngx chart: naming scheme, secret refs, pinned init images (conventions batch 3)

### DIFF
--- a/ci/paperless-ngx/test-values.yaml
+++ b/ci/paperless-ngx/test-values.yaml
@@ -1,7 +1,7 @@
 secrets:
-  redisRef: op://ci/paperless-redis
-  databaseRef: op://ci/paperless-db
-  paperlessRef: op://ci/paperless
+  redisSecretRef: op://ci/paperless-redis
+  databaseSecretRef: op://ci/paperless-db
+  paperlessSecretRef: op://ci/paperless
 
 ingress:
   domain: paperless.ci.local

--- a/paperless-ngx/Chart.yaml
+++ b/paperless-ngx/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://raw.githubusercontent.com/paperless-ngx/paperless-ngx/dev/src-ui/s
 
 type: application
 
-version: 8.0.1+up3.0.5
+version: 9.0.0+up3.0.5
 
 appVersion: 3.0.5
 

--- a/paperless-ngx/templates/db-connection.secret.yaml
+++ b/paperless-ngx/templates/db-connection.secret.yaml
@@ -3,4 +3,4 @@ kind: OnePasswordItem
 metadata:
   name: {{ .Release.Name }}-{{ .Chart.Name }}-db-secret
 spec:
-  itemPath: {{ required "A secret-reference for the DB-Secret must be provided" .Values.secrets.databaseRef }}
+  itemPath: {{ required "A secret-reference for the DB-Secret must be provided" .Values.secrets.databaseSecretRef }}

--- a/paperless-ngx/templates/paperless-consume.cronjob.yaml
+++ b/paperless-ngx/templates/paperless-consume.cronjob.yaml
@@ -17,7 +17,7 @@ spec:
             {{- toYaml .Values.smbConnection.cron.securityContext.pod | nindent 12 }}
           containers:
             - name: paperless-consume-cronjob
-              image: busybox:1.28
+              image: "{{ .Values.paperless.busybox.image.repository }}:{{ .Values.paperless.busybox.image.tag }}"
               imagePullPolicy: IfNotPresent
               securityContext:
                 {{- toYaml .Values.smbConnection.cron.securityContext.container | nindent 16 }}

--- a/paperless-ngx/templates/paperless-consume.pvc.yaml
+++ b/paperless-ngx/templates/paperless-consume.pvc.yaml
@@ -1,6 +1,9 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  # Documented exception from the "-<kind>" naming scheme (issue #32):
+  # renaming a PVC would provision a new, empty volume, so the historic
+  # "-consume-volume-claim" name stays.
   name: {{ .Release.Name }}-{{ .Chart.Name }}-consume-volume-claim
 spec:
   accessModes:

--- a/paperless-ngx/templates/paperless-server.secret.yaml
+++ b/paperless-ngx/templates/paperless-server.secret.yaml
@@ -3,4 +3,4 @@ kind: OnePasswordItem
 metadata:
   name: {{ .Release.Name }}-{{ .Chart.Name }}-secret
 spec:
-  itemPath: {{ required "A secret-reference for the Paperless-Secret must be provided" .Values.secrets.paperlessRef }}
+  itemPath: {{ required "A secret-reference for the Paperless-Secret must be provided" .Values.secrets.paperlessSecretRef }}

--- a/paperless-ngx/templates/paperless-server.sfs.yaml
+++ b/paperless-ngx/templates/paperless-server.sfs.yaml
@@ -26,7 +26,7 @@ spec:
         # paperless.securityContext in values.yaml) so the main container can
         # run fully hardened (non-root, no privilege escalation).
         - name: init-run-ownership
-          image: busybox:1.28
+          image: "{{ .Values.paperless.busybox.image.repository }}:{{ .Values.paperless.busybox.image.tag }}"
           imagePullPolicy: IfNotPresent
           command:
             - sh
@@ -185,6 +185,26 @@ spec:
             - name: PAPERLESS_DISABLE_REGULAR_LOGIN
               value: "{{ .Values.oidc.disableRegularLogin }}"
             {{- end }}
+            {{- range $value := .Values.paperless.env }}
+            {{- if $value.value }}
+            - name: {{ $value.name }}
+              value: {{ tpl $value.value $ }}
+            {{- else if $value.valueFrom }}
+            {{- if $value.valueFrom.secretKeyRef }}
+            - name: {{ $value.name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ tpl $value.valueFrom.secretKeyRef.name $ }}
+                  key: {{ tpl $value.valueFrom.secretKeyRef.key $ }}
+            {{- else if $value.valueFrom.configMapKeyRef }}
+            - name: {{ $value.name }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ tpl $value.valueFrom.configMapKeyRef.name $ }}
+                  key: {{ tpl $value.valueFrom.configMapKeyRef.key $ }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
           volumeMounts:
             - mountPath: "/usr/src/paperless/data"
               name: "paperless-volume"
@@ -206,32 +226,11 @@ spec:
           resources:
             {{- include "paperless-ngx.resources" .Values.paperless.resources | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: /
-              port: 8000
-            periodSeconds: 10
-            failureThreshold: 3
-            successThreshold: 1
-            timeoutSeconds: 5
+            {{- toYaml .Values.paperless.readinessProbe | nindent 12 }}
           livenessProbe:
-            httpGet:
-              path: /
-              port: 8000
-            periodSeconds: 30
-            failureThreshold: 3
-            successThreshold: 1
-            timeoutSeconds: 5
-          # The startup probe gates liveness/readiness. Paperless runs database
-          # migrations on startup, and since 3.0 the first start after an
-          # upgrade also rebuilds the search index from scratch (Whoosh ->
-          # Tantivy): budget 10s * 60 = 600s.
+            {{- toYaml .Values.paperless.livenessProbe | nindent 12 }}
           startupProbe:
-            httpGet:
-              path: /
-              port: 8000
-            periodSeconds: 10
-            failureThreshold: 60
-            timeoutSeconds: 5
+            {{- toYaml .Values.paperless.startupProbe | nindent 12 }}
       restartPolicy: Always
       volumes:
         - name: tmp

--- a/paperless-ngx/templates/paperless-smb-connector.pvc.yaml
+++ b/paperless-ngx/templates/paperless-smb-connector.pvc.yaml
@@ -2,6 +2,9 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  # Documented exception from the "-<kind>" naming scheme (issue #32):
+  # renaming a PVC would provision a new, empty volume, so the historic
+  # "-smb-volume-claim" name stays.
   name: {{ .Release.Name }}-{{ .Chart.Name }}-smb-volume-claim
 spec:
   accessModes:

--- a/paperless-ngx/templates/paperless.ingress.yaml
+++ b/paperless-ngx/templates/paperless.ingress.yaml
@@ -3,11 +3,14 @@ kind: Ingress
 metadata:
   name: {{ .Release.Name }}-{{ .Chart.Name }}-ingress
   annotations:
-    cert-manager.io/cluster-issuer: {{ required "A Cluster-Issuer must be provided" .Values.ingress.clusterIssuer}}
+    cert-manager.io/cluster-issuer: {{ required "A Cluster-Issuer must be provided" .Values.ingress.clusterIssuer }}
     nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.paperless.files.maxUploadFileSize }}
     nginx.org/client-max-body-size: {{ .Values.paperless.files.maxUploadFileSize }}
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
-  ingressClassName: nginx
+  ingressClassName: {{ .Values.ingress.className }}
   rules:
     - host: {{ required "A Domain/Host must be provided" .Values.ingress.domain }}
       http:
@@ -22,4 +25,4 @@ spec:
   tls:
     - hosts:
         - {{ required "A Domain/Host must be provided" .Values.ingress.domain }}
-      secretName: tls-{{ .Release.Name }}-{{ .Chart.Name }}-{{ .Values.ingress.domain }}-ingress
+      secretName: tls-{{ .Release.Name }}-{{ .Chart.Name }}-ingress

--- a/paperless-ngx/templates/paperless.pvc.yaml
+++ b/paperless-ngx/templates/paperless.pvc.yaml
@@ -1,6 +1,9 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  # Documented exception from the "-<kind>" naming scheme (issue #32):
+  # renaming a PVC would provision a new, empty volume, so the historic
+  # "-volume-claim" name stays.
   name: {{ .Release.Name }}-{{ .Chart.Name }}-volume-claim
 spec:
   accessModes:

--- a/paperless-ngx/templates/pre-post-consumption-scripts.configmap.yaml
+++ b/paperless-ngx/templates/pre-post-consumption-scripts.configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-{{ .Chart.Name }}-pre-post-consumption-scripts
+  name: {{ .Release.Name }}-{{ .Chart.Name }}-pre-post-consumption-scripts-configmap
 data:
   pre-consume-script: |-
     #!/bin/sh

--- a/paperless-ngx/templates/redis-connection.secret.yaml
+++ b/paperless-ngx/templates/redis-connection.secret.yaml
@@ -3,4 +3,4 @@ kind: OnePasswordItem
 metadata:
   name: {{ .Release.Name }}-{{ .Chart.Name }}-redis-secret
 spec:
-  itemPath: {{ required "A secret-reference for the Redis-Secret must be provided" .Values.secrets.redisRef }}
+  itemPath: {{ required "A secret-reference for the Redis-Secret must be provided" .Values.secrets.redisSecretRef }}

--- a/paperless-ngx/values.yaml
+++ b/paperless-ngx/values.yaml
@@ -5,20 +5,31 @@
 scaleDown: false
 
 secrets:
-  redisRef: null
-  databaseRef: null
-  paperlessRef: null
+  redisSecretRef: null
+  databaseSecretRef: null
+  paperlessSecretRef: null
   smbConnectionSecretRef: null
   oidcSecretRef: null
 
 ingress:
   clusterIssuer: "letsencrypt-issuer"
   domain: null
+  className: nginx
+  # Extra annotations for the Ingress; merged with the cert-manager
+  # cluster-issuer and upload-size annotations the chart always sets.
+  annotations: {}
 
 paperless:
   # Replica count for this workload; 0 is allowed and scales it down.
   # The chart-global scaleDown flag takes precedence.
   replicas: 1
+  # Auxiliary busybox image, used by the /run-ownership init container and the
+  # SMB consume-mover CronJob. Pinned independently of appVersion (which
+  # tracks paperless-ngx); reviewed alongside every app-version update round.
+  busybox:
+    image:
+      repository: busybox
+      tag: "1.38.0"
   ocr:
     languages: "eng"
     # Paperless-ngx 3.x modes: auto (default, skips OCR when embedded text
@@ -53,6 +64,37 @@ paperless:
   scripts:
     postConsumptionScripts: []
     preConsumptionScripts: []
+  livenessProbe:
+    httpGet:
+      path: /
+      port: 8000
+    periodSeconds: 30
+    failureThreshold: 3
+    successThreshold: 1
+    timeoutSeconds: 5
+  readinessProbe:
+    httpGet:
+      path: /
+      port: 8000
+    periodSeconds: 10
+    failureThreshold: 3
+    successThreshold: 1
+    timeoutSeconds: 5
+  # The startup probe gates liveness/readiness. Paperless runs database
+  # migrations on startup, and since 3.0 the first start after an upgrade
+  # also rebuilds the search index from scratch (Whoosh -> Tantivy):
+  # budget 10s * 60 = 600s.
+  startupProbe:
+    httpGet:
+      path: /
+      port: 8000
+    periodSeconds: 10
+    failureThreshold: 60
+    timeoutSeconds: 5
+  # Extra environment variables, appended to the ones the chart always sets.
+  # Values are rendered through tpl; value, secretKeyRef and configMapKeyRef
+  # forms are supported.
+  env: []
   resources:
     # Limits are optional: memory and ephemeral-storage limits default to
     # limitFactor x the request, an explicitly set limit always wins, and a


### PR DESCRIPTION
Part of #32 — Batch-3-Major-PR für das paperless-ngx-Chart: alle Audit-Findings dieses Charts in einem PR.

## Findings → Fixes

| # | Audit-Finding | Fix |
|---|---|---|
| 1 | PVC-Namen `…-volume-claim` / `…-consume-volume-claim` / `…-smb-volume-claim` weichen vom `-<kind>`-Schema ab | **Unangetastet** (Bestandsschutz-Ausnahme laut Maintainer-Entscheidung; Rename würde neue leere Volumes provisionieren). Ausnahme jetzt per Kommentar in allen drei PVC-Templates dokumentiert |
| 2 | ConfigMap `…-pre-post-consumption-scripts` ohne Kind-Suffix | → `…-pre-post-consumption-scripts-configmap` (Template ist `{{ if false }}`-deaktiviert, trotzdem konsistent gemacht) |
| 3 | Übrige Ressourcen (SFS `-sfs`, Service `-service`, Secrets `-secret`/`-db-secret`/`-redis-secret`/`-smb-secret`, Ingress `-ingress`, CronJob `-consume-cronjob`, PV `-smb-pv`) | Geprüft — bereits schema-konform, **kein SFS-Rename nötig**, daher keine Migration |
| 4 | TLS-Secret `tls-<release>-<chart>-<domain>-ingress` (Domain im Namen) | → Standard `tls-<release>-<chart>-ingress` |
| 5 | `secrets.redisRef` / `databaseRef` / `paperlessRef` inkonsistent zu `smbConnectionSecretRef`/`oidcSecretRef` | → `redisSecretRef` / `databaseSecretRef` / `paperlessSecretRef` (OnePasswordItem-Templates + CI-Fixtures nachgezogen) |
| 6 | `busybox:1.28` hartkodiert (Init-Container + Consume-CronJob) | → `paperless.busybox.image.repository`/`.tag`, Default `busybox:1.38.0` (aktuelles Docker-Hub-Release, Tag verifiziert); Kommentar zur Pflege bei App-Version-Updates |
| 7 | Probes hartkodiert im SFS-Template | → `paperless.livenessProbe`/`readinessProbe`/`startupProbe`-Values; Defaults = bisherige Ist-Werte aus #9 (unverändert, inkl. 600s-Startup-Budget). Consume-CronJob hat weiterhin bewusst keine Probes |
| 8 | Ingress-Standard (#32) | `ingress.className` (Default `nginx`), `ingress.annotations` (gemerged mit cert-manager- und Upload-Size-Annotations); `domain`/`clusterIssuer` weiterhin `required` (clusterIssuer behält den bisherigen Default `letsencrypt-issuer`) |
| 9 | env-Konvention fehlte | Additiver `paperless.env`-Block, per `tpl` gerendert, `value`/`secretKeyRef`/`configMapKeyRef`-Formen (Default `[]`, Render unverändert) |
| 10 | Härtung (Audit-Punkt 5: konform inkl. dokumentiertem Root-Init-Container) | Verifiziert, unverändert |

## Breaking Changes (Values, alt → neu)

| alt | neu |
|---|---|
| `secrets.redisRef` | `secrets.redisSecretRef` |
| `secrets.databaseRef` | `secrets.databaseSecretRef` |
| `secrets.paperlessRef` | `secrets.paperlessSecretRef` |

Alle drei sind `required` — ein Upgrade mit den alten Keys schlägt beim Rendern mit klarer Fehlermeldung fehl (kein stiller Bruch).

**Zertifikatswechsel-Hinweis:** Das TLS-Secret heißt jetzt `tls-<release>-paperless-ngx-ingress` (vorher stand die Domain im Namen). cert-manager stellt beim Upgrade automatisch ein neues Zertifikat unter dem neuen Secret-Namen aus (kurzer Ausstellungs-Moment, Rate-Limits von Let's Encrypt beachten); das alte Secret `tls-<release>-paperless-ngx-<domain>-ingress` bleibt zurück und kann manuell gelöscht werden.

**Keine Workload-/PVC-Migration nötig:** StatefulSet-, Service- und Secret-Namen waren bereits konform; die PVC-Namen bleiben per dokumentierter Ausnahme erhalten — Daten und Volumes werden vom Upgrade nicht angefasst.

## Version-Bump

`8.0.1+up3.0.5` → `9.0.0+up3.0.5` (**Major**: Breaking Values-Schema-Änderung der Secret-Refs + TLS-Secret-Rename; appVersion unverändert `3.0.5`).

## k3d-Verifikation (Wegwerf-Cluster `b3-paperless`, expliziter Kubeconfig)

1. `origin/main`-Chart mit CI-Fixtures (Postgres/Redis, Longhorn-Stub-PVs) installiert → StatefulSet Ready.
2. Marker-Datei auf der Daten-PVC abgelegt.
3. Upgrade auf diesen Branch mit neuen Values → Ready, **0 Restarts**, Init-Container läuft mit `busybox:1.38.0`, Daten-PVC identisch (gleiche UID) + Marker erhalten, alle PVCs Bound, Probes-Values im Pod-Spec, Ingress mit `ingressClassName: nginx` und `tls-ci-paperless-ngx-ingress`.
4. Zweites Upgrade mit `smbConnection.enabled=true` → CronJob `ci-paperless-ngx-consume-cronjob` mit `busybox:1.38.0` gerendert, StatefulSet weiterhin Ready.
5. Cluster gelöscht.

Zusätzlich lokal: `helm lint --strict` grün; Render-Diff gegen `origin/main` für Default-, smb-, oidc- und smb+oidc-Variante enthält ausschließlich die beabsichtigten Änderungen (Image-Pin, TLS-Secret-Name, Kommentare, Key-Sortierung der Probes durch `toYaml`); Override-Tests für `ingress.className`/`annotations`, Probe-Overrides und alle drei `env`-Formen.
