### PR TITLE
Fleet migration stage 1: import minecraft-router unchanged

### DIFF
--- a/.github/workflows/change-app-version.yml
+++ b/.github/workflows/change-app-version.yml
@@ -32,6 +32,7 @@ on:
           - patchmon
           - rallly
           - voucher-vault
+          - minecraft-router
   workflow_call:
     inputs:
       app-version:

--- a/.github/workflows/publish-minecraft-router.yml
+++ b/.github/workflows/publish-minecraft-router.yml
@@ -1,0 +1,15 @@
+name: Publish Minecraft-Router Helm Chart
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - minecraft-router/**
+jobs:
+  publish-minecraft-router:
+    name: Publish Minecraft-Router Helm Chart
+    uses: ./.github/workflows/publish-helm-chart.yml
+    with:
+      chart-name: 'minecraft-router'
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Collection of some self-made helm-charts. Each top-level directory is a standalo
 | `gotenberg` | Gotenberg | Deployment + Service only (no ingress) |
 | `homeassistant` | Home Assistant | StatefulSet, has `NOTES.txt` and Helm tests |
 | `matrix-synapse` | Matrix Synapse | StatefulSet plus an nginx delegation Deployment/Service |
+| `minecraft-router` | itzg/mc-router | Deployment + routing ConfigMap + NodePort Service (TCP only, no ingress); pre-existing chart, still on its legacy conventions |
 | `outline` | Outline | StatefulSet, separate DB/Redis secrets |
 | `paperless-ngx` | Paperless-ngx | Largest chart: consume CronJob, SMB-connector PV/PVC, pre/post-consumption scripts ConfigMap |
 | `patchmon` | PatchMon | Two Deployments (frontend + backend), OIDC secret |

--- a/ci/minecraft-router/test-values.yaml
+++ b/ci/minecraft-router/test-values.yaml
@@ -1,0 +1,17 @@
+# minecraft-router needs no secrets, no ingress and no persistence for a CI
+# install - only two adjustments to the defaults:
+#
+# 1. server.outwardPort: the production default 25565 is outside the Kubernetes
+#    default node-port range (30000-32767). The real cluster runs an extended
+#    --service-node-port-range, the k3d CI cluster does not, so the API server
+#    would reject the Service. This is a CI-only override; the chart default
+#    stays 25565 (see minecraft-router/values.yaml).
+# 2. mappings: the chart default renders "<nil>": "<nil>:25565"; the install
+#    works either way, but the CI install uses a realistic routing table.
+server:
+  outwardPort: 30565
+mappings:
+  - domain: mc.example.com
+    internalUrl: survival-service.default.svc.cluster.local
+  - domain: creative.example.com
+    internalUrl: creative-service.default.svc.cluster.local

--- a/minecraft-router/.helmignore
+++ b/minecraft-router/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/minecraft-router/Chart.yaml
+++ b/minecraft-router/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: minecraft-router
+description: A Helm chart for deploying a itzg/mc-router
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.1+up1.25.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.25.1"

--- a/minecraft-router/templates/mc-router-config.yaml
+++ b/minecraft-router/templates/mc-router-config.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-config
+data:
+  custom-routing-config.json: |
+    {
+      "mappings": {
+    {{- $length := len .Values.mappings }}
+    {{- $indexLength := sub $length 1 }}
+    {{- range $index, $value := .Values.mappings }}
+        "{{ $value.domain }}": "{{ $value.internalUrl }}:25565"{{ if lt $index $indexLength }},{{ end }}
+    {{- end }}
+      }
+    }

--- a/minecraft-router/templates/mc-router-deployment.yaml
+++ b/minecraft-router/templates/mc-router-deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-deployment
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-deployment
+  template:
+    metadata:
+      name: {{ .Release.Name }}-deployment
+      labels:
+        app: {{ .Release.Name }}-deployment
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - image: "itzg/mc-router:{{ .Chart.AppVersion }}"
+          name: mc-router
+          args: ["--api-binding", ":8080"]
+          ports:
+            - name: proxy-port
+              containerPort: 25565
+            - name: api-port
+              containerPort: 8080
+          env:
+            - name: ROUTES_CONFIG
+              value: /data/custom-routing-config.json
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: "100m"
+              ephemeral-storage: "50Mi"
+            limits:
+              memory: 100Mi
+              cpu: "250m"
+              ephemeral-storage: "500Mi"
+          volumeMounts:
+            - name: config-mount
+              mountPath: /data/custom-routing-config.json
+              subPath: custom-routing-config.json
+
+      volumes:
+        - name: config-mount
+          configMap:
+            name: {{ .Release.Name }}-config

--- a/minecraft-router/templates/mc-router-service.yaml
+++ b/minecraft-router/templates/mc-router-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-service
+spec:
+  selector:
+    app: {{ .Release.Name }}-deployment
+  ports:
+    - nodePort: {{ .Values.server.outwardPort }}
+      port: 25565
+      targetPort: 25565
+      name: proxy-port
+  type: NodePort
+  

--- a/minecraft-router/values.yaml
+++ b/minecraft-router/values.yaml
@@ -1,0 +1,9 @@
+server:
+  # nodePort of the router Service. 25565 is the Minecraft default port and is
+  # deliberately outside the Kubernetes default node-port range (30000-32767) -
+  # the cluster runs an extended --service-node-port-range. Do NOT "fix" this
+  # into the default range: the Minecraft clients connect to this exact port.
+  outwardPort: 25565
+mappings:
+  - domain: null
+    internalUrl: null


### PR DESCRIPTION
Fixes #62

Stage 1 of the Fleet migration for the pilot chart `minecraft-router`: the chart moves into this repo **functionally unchanged** and gets published in exactly this version, so the cluster-config session can switch the deployment to Fleet without any change to the rolled-out state. Convention alignment is stage 2, the app update is stage 3.

## What was imported

Verbatim copy of `/Users/justinklein/dev/cluster-config/minecraft/minecraft-router/minecraft-router/`: `.helmignore`, `values.yaml` and the three templates (`mc-router-config.yaml` ConfigMap, `mc-router-deployment.yaml`, `mc-router-service.yaml` NodePort Service). No ingress, pure TCP.

**Version:** `0.1.1+up1.25.1`, `appVersion: "1.25.1"`. The chart semver stays at 0.1.1; the `+up` suffix is repo policy and does not affect rendering.

## The one approved deviation

`Chart.yaml` carried `name: minecraft-server` (copy-paste from the sister chart). Corrected to `minecraft-router`.

This is required for stage 1 to be publishable at all: `publish-helm-chart.yml` runs `helm package <directory>` and pushes via the glob `<directory>-*.tgz`, while `helm package` names the archive after the **Chart.yaml name**. Without the correction the archive would be `minecraft-server-0.1.1+up1.25.1.tgz`, the glob would find nothing and the publish job would fail. Verified after the fix:

```
$ helm package minecraft-router
Successfully packaged chart and saved it to: minecraft-router-0.1.1+up1.25.1.tgz
```

Besides that, only a **comment** was added to `values.yaml` documenting why the node port is 25565 (outside the Kubernetes default range 30000-32767; the cluster runs an extended `--service-node-port-range`), so nobody later "optimizes" it into the default range and breaks the Minecraft clients. Comments in `values.yaml` do not affect rendering.

## Verification: rendered output is identical

`helm template` with a realistic two-entry routing table, old chart vs. new chart. The **only** difference is the three `# Source:` provenance comments helm derives from the chart name - a direct consequence of the name correction, and not part of any manifest field that reaches the cluster:

```diff
-# Source: minecraft-server/templates/mc-router-config.yaml
+# Source: minecraft-router/templates/mc-router-config.yaml
-# Source: minecraft-server/templates/mc-router-service.yaml
+# Source: minecraft-router/templates/mc-router-service.yaml
-# Source: minecraft-server/templates/mc-router-deployment.yaml
+# Source: minecraft-router/templates/mc-router-deployment.yaml
```

After normalizing those three lines the two renderings are byte-identical:

```
$ diff -u old-normalized.yaml new.yaml && echo IDENTICAL
IDENTICAL
$ shasum -a 256 old-normalized.yaml new.yaml
4c836097133e599a87e9f99489c5aff40fbfd3f3bdf328115d33ba539c9c7e2b  old-normalized.yaml
4c836097133e599a87e9f99489c5aff40fbfd3f3bdf328115d33ba539c9c7e2b  new.yaml
```

`helm lint --strict minecraft-router` passes (exit 0) with a single INFO: `Chart.yaml: icon is recommended` - see the stage-2 list below.

## Install-test

Fixtures under `ci/minecraft-router/test-values.yaml`; no `fixtures.yaml` needed (no secrets, no infrastructure, no persistence - same as `ci/apache-tika/`). **No exclusion entry was needed.**

The fixed node port was the open question, and it was checked rather than assumed. The k3d API server does reject it:

```
The Service "np-range-check" is invalid: spec.ports[0].nodePort: Invalid value: 25565:
provided port is not in the valid range. The range of valid ports is 30000-32767
```

Since `server.outwardPort` is already a value, the CI install simply overrides it with `30565` - a CI-only override, the chart default stays 25565. The test values also set a realistic routing table instead of the broken default.

Run locally against a throwaway k3d cluster (same k3s image as CI, `v1.35.5-k3s1`, isolated kubeconfig):

```
OK: chart 'minecraft-router' installed and all workloads are Ready.
```

## Deliberately NOT fixed - scheduled for stage 2

All of these are known and were left untouched on purpose, so this PR cannot change the rolled-out state:

- **Broken `mappings` default** (`domain: null` / `internalUrl: null`, renders `"<nil>": "<nil>:25565"`) - to be replaced by `required()`.
- **No hardening**: only `automountServiceAccountToken: false` is set; no `runAsNonRoot`, no `readOnlyRootFilesystem`, no dropped capabilities, no `allowPrivilegeEscalation: false`, no configurable `securityContext.pod` / `securityContext.container`.
- **No probes** (liveness/readiness/startup) - the container exposes an API port on 8080 that a probe could use.
- **Naming scheme** deviates: resources are `{{ .Release.Name }}-deployment` / `-service` / `-config` instead of `{{ .Release.Name }}-{{ .Chart.Name }}-<kind>`. Note the deployment's `metadata.labels.app` (`{{ .Release.Name }}`) does not match its selector label (`{{ .Release.Name }}-deployment`).
- **`icon:` missing** in `Chart.yaml` (the one `helm lint --strict` INFO).
- **Resource limits hardcoded** in the template instead of values + the `_helpers.tpl` limit-factor helper; requests are not overridable via values either.
- **No `replicas` value and no `scaleDown` flag**; `replicas: 1` is hardcoded.
- **No additive `env` block**, no `tpl` rendering of env entries.
- **Port 25565 hardcoded** in the ConfigMap template and the Service `port`/`targetPort`/`containerPort`; only the node port is a value.
- **No `NOTES.txt`**, no `_helpers.tpl`.
- The issue also lists "remove the misleading mc-router auto-discovery annotations" for stage 2. For the record: this chart contains no annotations at all - the auto-discovery annotation sits on the **sister chart's** Service (`minecraft-server/templates/mc-server-service.yaml`), so that cleanup belongs to the minecraft-server migration, not to this chart. Either way, the static routing configuration stays.

## Follow-up

The peer session's Fleet PR (cluster-config #13) is open as a draft with `0.1.1+up1.25.1` and may only be merged once that tag is actually in the registry. It will be notified after the publish.
