### PR TITLE
Minecraft-router: update to mc-router 1.46.4 (Fleet migration stage 3)

### DIFF
--- a/minecraft-router/Chart.yaml
+++ b/minecraft-router/Chart.yaml
@@ -5,8 +5,8 @@ icon: https://avatars.githubusercontent.com/u/988985
 
 type: application
 
-version: 1.0.0+up1.25.1
-appVersion: "1.25.1"
+version: 1.0.1+up1.46.4
+appVersion: "1.46.4"
 
 maintainers:
   - name: jklein

--- a/minecraft-router/values.yaml
+++ b/minecraft-router/values.yaml
@@ -44,11 +44,18 @@ server:
       cpu: 100m
       memory: 50Mi
       ephemeral-storage: 50Mi
-  # The probes query the mc-router API. GET /routes answers with the live
-  # routing table, but only with the "Accept: application/json" header - the
-  # API router matches on it and answers 404 without it. The API server is
-  # started after the routes config has been read and the Minecraft listener is
-  # up, so a 200 here means the router is actually serving clients.
+  # The probes query the mc-router API. Even in 1.46.4 there is still no
+  # /health or /healthz endpoint - the API server serves GET/POST /routes,
+  # POST /defaultRoute, DELETE /routes/{addr}, /vars and /metrics and nothing
+  # else - so GET /routes stays the health signal. It answers with the live
+  # routing table, and the API server is only started after the routes config
+  # has been read and the Minecraft listener is up, so a 200 here means the
+  # router is actually serving clients.
+  # The "Accept: application/json" header was mandatory in 1.25.1 (the API
+  # router matched on it and answered 404 without it); mc-router 1.32.2 dropped
+  # that matcher, so from there on the header is optional. It is kept because
+  # it is the correct request for a JSON endpoint and the response is identical
+  # with and without it - removing it would be churn without any gain.
   livenessProbe:
     httpGet:
       path: /routes
@@ -85,9 +92,12 @@ server:
   securityContext:
     pod:
       runAsNonRoot: true
-      # The itzg/mc-router image is built FROM scratch and declares no user, so
-      # it would run as root by default. The statically linked binary needs no
-      # particular uid/gid, so the chart pins an unprivileged one.
+      # Up to 1.45.x the itzg/mc-router image was built FROM scratch and
+      # declared no user, so it would have run as root. Since 1.46.0 it is
+      # based on cgr.dev/chainguard/static and declares USER 65532. The chart
+      # keeps pinning its own unprivileged uid/gid regardless, so the runtime
+      # identity does not silently change with the base image; the statically
+      # linked binary needs no particular uid/gid.
       runAsUser: 10000
       runAsGroup: 10000
       # Keeps the mounted routing-config ConfigMap readable for that gid.
@@ -95,8 +105,9 @@ server:
       fsGroupChangePolicy: Always
     container:
       allowPrivilegeEscalation: false
-      # No deviation needed: the scratch image writes nothing, and the only
-      # mount is the read-only routing config.
+      # No deviation needed: the image ships nothing but the static binary and
+      # a CA bundle, mc-router writes nothing, and the only mount is the
+      # read-only routing config.
       readOnlyRootFilesystem: true
       runAsNonRoot: true
       capabilities:
@@ -104,8 +115,14 @@ server:
           - ALL
         add: []
   # Extra environment variables for the router container, appended to the ones
-  # the chart always sets (ROUTES_CONFIG). Values are rendered through tpl and
-  # support the value, secretKeyRef and configMapKeyRef forms:
+  # the chart always sets (ROUTES_CONFIG). This is also how every mc-router
+  # option that the chart does not model explicitly is set: mc-router parses
+  # its flags with go-flagsfiller, so every "--some-flag" is equally settable
+  # as "SOME_FLAG" (that is exactly how ROUTES_CONFIG maps to --routes-config).
+  # Useful examples in 1.46.4: LOG_LEVEL (debug/info/warn/error),
+  # BACKEND_DIAL_TIMEOUT, CONNECTION_RATE_LIMIT.
+  # Values are rendered through tpl and support the value, secretKeyRef and
+  # configMapKeyRef forms:
   #   - name: SOME_ENV
   #     value: "{{ .Release.Name }}"
   #   - name: FROM_SECRET


### PR DESCRIPTION
Fixes #69. Stage 3 (final) of the Fleet migration for `minecraft-router`: the app update. Chart `1.0.0+up1.25.1` → **`1.0.1+up1.46.4`**, `appVersion` `1.25.1` → `1.46.4`.

Only `Chart.yaml` and comments in `values.yaml` change. **No value, no default and no template is touched** — the diff is 2 files, +31/−14.

## Versioning: why patch

Per the README's semver rules a *plain app-version update* is a patch, and the checks below found nothing that forces a value or a template change: the flags the chart passes are unchanged, the routing config schema is unchanged, and no new value was warranted (see "New values" below). So `1.0.1+up1.46.4`.

The one genuine runtime change is upstream shutdown behaviour (see below). It is not a chart change — it ships with the image at any chart version — and it makes restarts *shorter*, not more disruptive, so it does not turn this into a major.

### The image tag

Upstream switched its **git tags** to a `v` prefix in 1.35.0 (`v1.46.4`), but the **Docker tags** stayed unprefixed. `itzg/mc-router:1.46.4` exists and is what `{{ .Chart.AppVersion }}` renders; verified against the Docker Hub tag list and pulled in k3d.

## Changelog review

21 minor releases were reviewed from the GitHub release notes, and every point below was then **confirmed against the upstream source at tag `v1.46.4`** rather than inferred from release titles — the titles are mostly dependency bumps and hide the two findings that actually matter.

### 1. CLI flags — no change, chart starts as before

`server/configs.go` at `v1.46.4` still declares `ApiBinding` and `Port`, which go-flagsfiller renders as `--api-binding` and `--port`. The chart's `--port <n> --api-binding :<n>` is unchanged and correct. Confirmed in-cluster: `args` are `["--port","25565","--api-binding",":8080"]` and the router logs `Listening for Minecraft client connections listenAddress=":25565"` and `Serving API requests binding="[::]:8080"`.

The flag *did* get restructured internally — 1.25.1 had a flat `RoutesConfig string`, 1.46.4 has a nested `Routes.Config` — but flagsfiller derives the same names from both, so `--routes-config` / `ROUTES_CONFIG` survive the refactor unchanged. This was the one rename that could have silently broken the chart, so it was checked explicitly.

### 2. ROUTES_CONFIG format — identical, the dangerous case did not happen

This was the risk worth the most attention: a changed schema would leave a *healthy* pod routing nothing. It did not change.

| | 1.25.1 (`server/routes_config.go`) | 1.46.4 (`server/routes_config_loader.go`) |
|---|---|---|
| struct | `routesConfigStructure` | `RoutesConfigSchema` |
| fields | `DefaultServer` → `json:"default-server"`, `Mappings map[string]string` → `json:"mappings"` | **identical** |

The chart's `{"mappings": {"<domain>": "<target>:<port>"}}` is exactly what both versions parse. Confirmed in-cluster on 1.46.4 — both mappings load, including the per-mapping port override:

```
Created route mapping backend="creative-service.mcr.svc.cluster.local:25566" serverAddress=creative.example.com
Created route mapping backend="survival-service.mcr.svc.cluster.local:25565" serverAddress=mc.example.com
```

**It actually got safer.** In 1.25.1 a config file that failed to parse was only logged (`logrus.Error`) and the router came up **route-less but healthy** — precisely the silent failure this issue worried about. In 1.46.4 the same error aborts startup (`NewServer` returns the error, `main` calls `logrus.Fatal`), so a broken config is now a crash-looping pod instead of a silently useless one. (A *missing* file is still ignored in both, but the chart always mounts it.)

### 3. Probe endpoint — still no health endpoint, `/routes` stays

**There is still no `/health` or `/healthz` in 1.46.4.** `registerApiRoutes` in `server/api_server.go` registers exactly `GET /routes`, `POST /routes`, `POST /defaultRoute`, `DELETE /routes/{serverAddress}`, plus `/vars` and `/metrics`. Verified in-cluster: `GET /health` → **404**. So the stage-2 choice of `GET /routes` stands; there is no cleaner option to switch to.

What *did* change: the `Headers("Accept", "application/json")` matcher that made the header mandatory in 1.25.1 was dropped in **1.32.2** (PR #424, "Code cleanup of routes config loader and API server"). Verified in-cluster on 1.46.4 — both requests return **200** with an identical body:

```
GET /routes  -H 'Accept: application/json'  -> 200
GET /routes  (no header)                    -> 200
```

The probes keep sending the header: it is the correct request for a JSON endpoint, the response is identical either way, and removing it would be churn on three probe blocks for no behavioural gain. The `values.yaml` comment, which claimed the header is required, is corrected to say what is actually true now.

Also noted, harmless for us: the `/routes` **response body** changed in 1.42.0 from `{addr: "backend"}` to `{addr: {"backend": ..., "scalingTarget": ...}}`. The probes only check the status code, so they are unaffected — but anything parsing that endpoint would break.

One argument for taking **1.46.4 specifically** rather than 1.46.0: 1.46.0 introduced nil-pointer panics in exactly the `GET /routes` list handler the probes hit, fixed across 1.46.1 (`Ensure api server can list routes with nil scaling target`), 1.46.2 and 1.46.4. On 1.46.0 the probe endpoint could have panicked the router.

### 4. Existing connections and restarts — the one real behaviour change

**mc-router no longer handles `SIGTERM`.** 1.36.1 (PR #466, "Use signal.NotifyContext and WaitGroup.Go") replaced `signal.Notify(signals, SIGINT, SIGTERM, SIGHUP)` with `signal.NotifyContext(ctx, os.Interrupt)` + `signal.Notify(signals, SIGHUP)`. `os.Interrupt` is SIGINT only, so SIGTERM — which is exactly what kubelet sends — is no longer caught, and the graceful drain in `Server.Run` (`WaitForConnections()`) never runs.

Measured, not assumed. Two otherwise identical pods, same args, same config mount, terminated by kubelet:

| | 1.25.1 | 1.46.4 |
|---|---|---|
| exit code | **0** (`Completed`) | **2** (`Error`) |
| shutdown logs | `Stopping. Waiting for connections to complete...` → `Stopped` | **none** — process is gone |

And with a **real proxied connection held open** (a genuine Minecraft handshake through the router to a stand-in backend, not just an idle TCP connect — 1.25.1 drops those after a 5 s handshake timeout), deleting the 1.25.1 pod took **31 s**: it waited out the entire 30 s grace period and was then SIGKILLed. The 1.46.4 pod terminates in about a second.

**Net effect for this chart: an improvement, with one cosmetic wart.**

- Players are disconnected either way — 1.25.1's "drain" waited for a connection that a connected player never ends, so it just burned the full grace period before SIGKILL. A restart now takes ~1 s instead of ~30 s.
- **Every normal restart now records the container as exiting with code 2 / reason `Error`.** Nothing is wrong, but monitoring that alerts on container exit reasons will see `Error` on every rollout and every node drain. Worth knowing before it is rolled out.
- No chart change follows from this. `terminationGracePeriodSeconds` is left at the default; it is simply no longer reached.

This looks like an upstream regression rather than an intentional change (the drain code is still there, only unreachable via SIGTERM). Not fixable from the chart.

### 5. Security context / base image — comment corrected

1.46.0 rebased the image from `scratch` onto `cgr.dev/chainguard/static` and it now declares **`USER 65532`** (verified in the registry image config: 1.25.1 `User: None`, 1.46.4 `User: '65532'`). The upstream release notes flag this as potentially disruptive, but only for Docker-socket access in auto-discovery/auto-scaling setups — which this chart does not use.

The chart pins `runAsUser/runAsGroup: 10000` and therefore overrides the image's user, so **the runtime identity does not change across this upgrade**. Confirmed in-cluster: the pod runs Ready with `runAsUser: 10000`, `readOnlyRootFilesystem: true` and all capabilities dropped on the new base image. The `values.yaml` comments claiming a `scratch` image with no user are corrected.

### 6. New values — none, deliberately

The new options between 1.26 and 1.46 are `--log-level`, `--backend-dial-timeout`, `--routes-config-watch`, `--kube-namespace`, the webhook notifier/scaler, Docker/Swarm auto-scaling and the asleep/loading MOTDs. **None is added as a chart value**, for two reasons:

1. **They are already reachable.** mc-router parses flags with go-flagsfiller and `WithEnv("")`, so every `--some-flag` is settable as `SOME_FLAG` — which is exactly how the chart's own `ROUTES_CONFIG` maps to `--routes-config`. The additive `server.env` block from stage 2 therefore already exposes all of them without a values-schema change. The `values.yaml` comment now records this, with `LOG_LEVEL` / `BACKEND_DIAL_TIMEOUT` / `CONNECTION_RATE_LIMIT` as examples.
2. **The rest do not apply.** The Kubernetes auto-scaling and discovery features need a ServiceAccount token and RBAC; this chart runs with `automountServiceAccountToken: false` and a static routing table on purpose. Docker/Swarm are irrelevant.

**`--routes-config-watch` was considered and rejected**, and it is worth writing down why so it is not "fixed" later: it looks attractive (mapping changes without a pod restart), but the chart mounts the config with **`subPath`**, and kubelet never updates a `subPath` mount when the ConfigMap changes. The fsnotify watch would never fire, so the value would be a promise the chart cannot keep. Enabling it would mean dropping `subPath` and remounting the whole ConfigMap as a directory — a template and behaviour change with no request behind it, and out of scope for an app update.

## Verification

- `helm lint --strict minecraft-router`: **no findings** (only the same `[INFO] Missing required value` lines for `mappings` that the other charts produce). With the CI values: completely clean.
- `helm template` variants: CI values; **without** `mappings` → aborts with the required message; `mappings: []` → same; a mapping missing `internalUrl` → `mappings[0].internalUrl is required`; two mappings with a per-mapping `port` override; `server.port`/`apiPort`/`outwardPort`/`backendPort` overrides (args, containerPorts, Service and routing config all follow); `env` in all three forms with `tpl` resolved; `replicas: 0`; `scaleDown: true`; `limitFactor: 2` with an explicit CPU limit.
- **k3d, real upgrade path** (throwaway cluster `mcr-s3`, every call with an explicit `--context k3d-mcr-s3`, cluster deleted afterwards): installed the published **`1.0.0+up1.25.1`** (built from the exact commit that published it), then `helm upgrade` to this branch → revision 2, `minecraft-router-1.0.1+up1.46.4`, app version 1.46.4, **8.5 s**, no NodePort collision (no rename in this stage, as expected). New pod `1/1 Running`, image `itzg/mc-router:1.46.4`, **0 restarts and no `Unhealthy` events over ~3.5 min of probe cycles**. Routing config loaded with both mappings; `GET /routes` 200 with and without the header; `/health` 404; TCP connect to NodePort 30565 on the node succeeds. `server.port` was overridden to keep the node port inside k3d's 30000–32767 range.
- **CI harness locally**: `ci/run-install-test.sh minecraft-router` against the same cluster → `OK: chart 'minecraft-router' installed and all workloads are Ready.` The CI fixtures are unchanged and need no update.

## Rollout

No rename, no values change, so the upgrade is a plain image roll: one pod restart, interruption ≈ pod start time (a few seconds), connected players reconnect. As agreed, this version is **published but not rolled out** — the corresponding Fleet PR stays open.
