### PR TITLE
Fleet migration stage 1: import minecraft-server, publish java8 line

### DIFF
--- a/.github/workflows/change-app-version.yml
+++ b/.github/workflows/change-app-version.yml
@@ -33,6 +33,7 @@ on:
           - rallly
           - voucher-vault
           - minecraft-router
+          - minecraft-server
   workflow_call:
     inputs:
       app-version:

--- a/.github/workflows/publish-minecraft-server.yml
+++ b/.github/workflows/publish-minecraft-server.yml
@@ -1,0 +1,15 @@
+name: Publish Minecraft-Server Helm Chart
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - minecraft-server/**
+jobs:
+  publish-minecraft-server:
+    name: Publish Minecraft-Server Helm Chart
+    uses: ./.github/workflows/publish-helm-chart.yml
+    with:
+      chart-name: 'minecraft-server'
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Collection of some self-made helm-charts. Each top-level directory is a standalo
 | `homeassistant` | Home Assistant | StatefulSet, has `NOTES.txt` and Helm tests |
 | `matrix-synapse` | Matrix Synapse | StatefulSet plus an nginx delegation Deployment/Service |
 | `minecraft-router` | itzg/mc-router | Deployment + routing ConfigMap + NodePort Service (TCP only, no ingress); `mappings` is a required value |
+| `minecraft-server` | itzg/minecraft-server | StatefulSet + PVC + NodePort Service + init-script ConfigMap (no ingress); pre-existing chart, still on its legacy conventions. Published once per Java line (`appVersion: java8` / `java17` / `java21`) — the image tag comes from `.Chart.AppVersion`, so the Java line is chosen by picking the chart version |
 | `outline` | Outline | StatefulSet, separate DB/Redis secrets |
 | `paperless-ngx` | Paperless-ngx | Largest chart: consume CronJob, SMB-connector PV/PVC, pre/post-consumption scripts ConfigMap |
 | `patchmon` | PatchMon | Two Deployments (frontend + backend), OIDC secret |

--- a/ci/minecraft-server/fixtures.yaml
+++ b/ci/minecraft-server/fixtures.yaml
@@ -1,0 +1,70 @@
+# Fixtures for the minecraft-server install-test (release name: ci).
+#
+# The chart hardcodes storageClassName "longhorn" in its PVC, which does not
+# exist in k3d: a no-provisioner StorageClass named "longhorn" plus a pre-bound
+# hostPath PV stand in for it. A node-setup Job pre-creates the hostPath
+# directory world-writable, because the image's entrypoint chowns /data to
+# uid 1000 and hostPath volumes do not support fsGroup.
+#
+# The Secret is what the 1Password operator would otherwise materialize from
+# the OnePasswordItem CR the chart renders (stub CRD in ci/common/).
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: longhorn
+provisioner: kubernetes.io/no-provisioner
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: node-setup
+spec:
+  backoffLimit: 2
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: setup
+          image: public.ecr.aws/docker/library/busybox:1.36
+          command:
+            - sh
+            - -c
+            - >
+              mkdir -p /pv/minecraft-server/mc-data /pv/minecraft-server/mc-modpacks &&
+              chmod -R 0777 /pv/minecraft-server
+          volumeMounts:
+            - name: pv
+              mountPath: /pv
+      volumes:
+        - name: pv
+          hostPath:
+            path: /var/lib/ci-pv
+            type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: ci-minecraft-server-data
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: longhorn
+  claimRef:
+    namespace: default
+    name: ci-mc-volume-claim
+  hostPath:
+    path: /var/lib/ci-pv/minecraft-server
+    type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ci-mc-secret
+stringData:
+  rcon-password: ci-dummy-rcon-password
+  # Only consumed when curseforge.enabled is true; provided so the CI install
+  # keeps working if the test values ever enable a CurseForge modpack.
+  curseforge-api-key: ci-dummy-curseforge-key

--- a/ci/minecraft-server/settings.env
+++ b/ci/minecraft-server/settings.env
@@ -1,0 +1,3 @@
+# The itzg/minecraft-server image is large and the server downloads its vanilla
+# server jar on first start before the container settles.
+INSTALL_TIMEOUT=600

--- a/ci/minecraft-server/test-values.yaml
+++ b/ci/minecraft-server/test-values.yaml
@@ -1,0 +1,38 @@
+# Values for the minecraft-server install-test. Kept as close to the real
+# deployments as possible; only what a CI runner cannot provide is overridden.
+#
+# 1. minecraft.version: the image tag comes from .Chart.AppVersion, so the JVM
+#    in the image is fixed per published chart version and the Minecraft
+#    version has to match that Java line - Java 8 runs Minecraft up to 1.16.5,
+#    modern versions need Java 17/21 and refuse to start otherwise. This chart
+#    version publishes appVersion "java8", hence 1.12.2 (a classic Java 8 era
+#    release). This value is bumped together with appVersion in the java17 and
+#    java21 follow-up PRs.
+#    The production default is "LATEST", which would pull a 1.21.x server that
+#    a Java 8 JVM cannot load at all.
+# 2. minecraft.resources.storage: the production 32Gi world volume is backed by
+#    a static hostPath PV in CI (see fixtures.yaml); 2Gi is plenty for a server
+#    that only has to boot.
+# 3. minecraft.resources.memory: sets the JVM heap (-Xmx); 1G instead of 4G
+#    keeps the runner comfortable. The container resource *requests* are
+#    hardcoded in the template (cpu 2 / memory 4Gi) and cannot be overridden -
+#    they fit a 4-vCPU/16GB GitHub runner, and making them configurable is part
+#    of the stage-2 convention alignment.
+# 4. server.outwardPort stays at the chart default 30565: unlike minecraft-router
+#    that default is already inside the Kubernetes node-port range
+#    (30000-32767), so the k3d API server accepts it unchanged.
+secrets:
+  minecraftServerRef: vaults/CI/items/minecraft-server
+
+minecraft:
+  version: "1.12.2"
+  management:
+    # opPlayers deliberately stays at the default (null): the image resolves
+    # every name in OPS against the external Playerdb API and aborts the whole
+    # startup when a name does not resolve, so any placeholder name would break
+    # the install-test and a real name would make CI depend on a third-party
+    # lookup.
+    maxPlayers: 2
+  resources:
+    storage: 2Gi
+    memory: "1"

--- a/minecraft-server/.helmignore
+++ b/minecraft-server/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/minecraft-server/Chart.yaml
+++ b/minecraft-server/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: minecraft-server
+description: A Helm chart for deploying a itzg/minecraft-server
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.4.0+upjava8
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "java8"

--- a/minecraft-server/templates/_helpers.tpl
+++ b/minecraft-server/templates/_helpers.tpl
@@ -1,0 +1,35 @@
+{{/*
+Render the replica count for a Deployment/StatefulSet.
+
+Input: dict
+  "scaleDown"  the chart-global .Values.scaleDown flag (may be nil)
+  "replicas"   the workload's replicas value (may be nil)
+
+Rules (issue #25):
+  - scaleDown: true takes precedence and always yields 0.
+  - otherwise an explicitly set replicas value is used as given, including an
+    explicit 0 — Helm's "default" would swallow 0, hence the explicit
+    kindIs "invalid" nil check.
+  - a missing replicas value defaults to 1.
+
+Usage (the values path to the workload's replicas varies per chart):
+  replicas: {{ include "minecraft-server.replicas" (dict "scaleDown" .Values.scaleDown "replicas" .Values.server.replicas) }}
+
+NOTE: charts in this repo deliberately have no dependencies, so this helper is
+duplicated into every chart's templates/_helpers.tpl with the chart's name as
+define prefix. The reference implementation lives in template-chart.
+
+This chart is a stage-1 import (issue #67) and does not yet follow the repo
+conventions; only the replicas helper was taken over, because the scaleDown
+flag is needed before the Fleet migration. The resources helper follows in
+stage 2 together with the rest of the convention alignment.
+*/}}
+{{- define "minecraft-server.replicas" -}}
+{{- if .scaleDown -}}
+0
+{{- else if not (kindIs "invalid" .replicas) -}}
+{{- .replicas -}}
+{{- else -}}
+1
+{{- end -}}
+{{- end -}}

--- a/minecraft-server/templates/init-script-configmap.yaml
+++ b/minecraft-server/templates/init-script-configmap.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-init-config
+data:
+  init.sh: |
+    echo "downloading serverpack"
+    wget -O /modpacks/serverpack.zip {{ .Values.curseforgeServerpack.downloadUrl }}
+    SERVERPACK_DIR="{{ .Values.curseforgeServerpack.workingDirectory }}"
+    BACKUP_DIR="/data/serverpack-backup"
+
+    if [ -d "$SERVERPACK_DIR" ]; then
+      echo "found installed server. Migrating..."
+      if [ -d "$BACKUP_DIR" ]; then
+        echo "clearing old Backup"
+        rm -rf $BACKUP_DIR
+      fi
+
+      echo "backing up old server-files"
+      cp -r $SERVERPACK_DIR $BACKUP_DIR
+
+      rm -rf $SERVERPACK_DIR
+      mkdir $SERVERPACK_DIR
+
+      echo "extracting new server-files"
+      tar -xvf /modpacks/serverpack.zip -C $SERVERPACK_DIR
+
+      echo "copying old configuration-data"
+      cp -r $BACKUP_DIR/world $SERVERPACK_DIR/world
+      cp $BACKUP_DIR/banned-ips.json $SERVERPACK_DIR/banned-ips.json
+      cp $BACKUP_DIR/banned-players.json $SERVERPACK_DIR/banned-players.json
+      cp $BACKUP_DIR/ops.json $SERVERPACK_DIR/ops.json
+      cp $BACKUP_DIR/whitelist.json $SERVERPACK_DIR/whitelist.json
+
+      echo "change owner of files"
+      chown -R 1000:1000 $SERVERPACK_DIR
+
+      echo "successfully migrated server"
+
+      # echo "deleting serverpack.zip"
+      # rm /modpacks/serverpack.zip
+    fi

--- a/minecraft-server/templates/mc-pvc.yaml
+++ b/minecraft-server/templates/mc-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-mc-volume-claim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.minecraft.resources.storage }}
+  storageClassName: longhorn

--- a/minecraft-server/templates/mc-secret.yaml
+++ b/minecraft-server/templates/mc-secret.yaml
@@ -1,0 +1,6 @@
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: {{ .Release.Name }}-mc-secret
+spec:
+  itemPath: {{ .Values.secrets.minecraftServerRef }}

--- a/minecraft-server/templates/mc-server-service.yaml
+++ b/minecraft-server/templates/mc-server-service.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-service
+  {{- if .Values.mcRouterIntegration.enabled }}
+  annotations:
+    "mc-router.itzg.me/externalServerName": "{{ .Values.mcRouterIntegration.domain }}"
+  {{- end }}
+spec:
+  selector:
+    app: {{ .Release.Name }}-server-deployment
+  {{- if .Values.mcRouterIntegration.enabled }}
+  ports:
+    - name: mc-port
+      port: 25565
+      targetPort: 25565
+  type: ClusterIP
+  {{- else }}
+  ports:
+    - nodePort: {{ .Values.server.outwardPort }}
+      port: 25565
+      targetPort: 25565
+  type: NodePort
+  {{- end }}
+  

--- a/minecraft-server/templates/mc-server-sfs.yaml
+++ b/minecraft-server/templates/mc-server-sfs.yaml
@@ -1,0 +1,153 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Release.Name }}-server-deployment
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  replicas: {{ include "minecraft-server.replicas" (dict "scaleDown" .Values.scaleDown "replicas" .Values.server.replicas) }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-server-deployment
+  template:
+    metadata:
+      name: {{ .Release.Name }}-server-deployment
+      labels:
+        app: {{ .Release.Name }}-server-deployment
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: {{ .Release.Name }}-mc-server-container
+          image: "itzg/minecraft-server:{{ .Chart.AppVersion }}"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: mc-port
+              containerPort: 35565
+            - name: minecraft-rcon
+              containerPort: 25575
+            - name: metrics
+              containerPort: 19565
+          env:
+            - name: EULA
+              value: "true"
+            - name: DUMP_SERVER_PROPERTIES
+              value: "true"
+            - name: MOTD
+              value: "{{ .Values.server.motd }}"
+            - name: DIFFICULTY
+              value: {{ .Values.minecraft.difficulty }}
+            {{- if .Values.minecraft.whitelist.enabled }}
+            - name: EXISTING_WHITELIST_FILE
+              value: {{ .Values.minecraft.whitelist.overridePolicy }}
+            - name: WHITELIST
+              value: {{ .Values.minecraft.whitelist.players }}
+            {{- end }}
+            - name: OPS
+              value: {{ .Values.minecraft.management.opPlayers }}
+            - name: EXISTING_OPS_FILE
+              value: "SYNCHRONIZE"
+            - name: RCON_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: rcon-password
+                  name: {{ .Release.Name }}-mc-secret
+            - name: MAX_PLAYERS
+              value: "{{ .Values.minecraft.management.maxPlayers }}"
+            - name: FORCE_GAMEMODE
+              value: "{{ .Values.minecraft.management.forceGameMode }}"
+            - name: SNOOPER_ENABLED
+              value: "false"
+            - name: MODE
+              value: "{{ .Values.minecraft.management.gameMode }}"
+            - name: LEVEL
+              value: "{{ .Values.minecraft.management.worldSaveName }}"
+            - name: SERVER_NAME
+              value: "{{ .Values.minecraft.management.serverName }}"
+            - name: VERSION
+              value: "{{ .Values.minecraft.version }}"
+            - name: ENABLE_RCON
+              value: "false"
+            - name: ENABLE_AUTOPAUSE
+              value: "false"
+            - name: MEMORY
+              value: "{{ .Values.minecraft.resources.memory }}G"
+            {{- if .Values.curseforge.enabled }}
+            - name: TYPE
+              value: "AUTO_CURSEFORGE"
+            - name: CF_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: curseforge-api-key
+                  name: {{ .Release.Name }}-mc-secret
+            - name: CF_SLUG
+              value: "{{ .Values.curseforge.modpack.slug }}"
+            - name: CF_FILE_ID
+              value: "{{ .Values.curseforge.modpack.versionId }}"
+            - name: CF_EXCLUDE_MODS
+              value: "{{ .Values.curseforge.modpack.exclude }}"
+            - name: CF_OVERRIDES_EXCLUSIONS
+              value: "{{ .Values.curseforge.modpack.excludeOverride }}"
+            - name: CF_FORCE_INCLUDE_MODS
+              value: "{{ .Values.curseforge.modpack.include }}"
+            - name: CF_FORCE_SYNCHRONIZE
+              value: "{{ .Values.curseforge.forceReload }}"
+            {{- end }}
+            {{- if .Values.curseforgeServerpack.enabled }}
+            - name: TYPE
+              value: "CURSEFORGE"
+            - name: CF_SERVER_MOD
+              value: "/modpacks/serverpack.zip"
+            - name: CF_BASE_DIR
+              value: "{{ .Values.curseforgeServerpack.workingDirectory }}"
+            {{- end }}
+            {{- if .Values.ftb.enabled }}
+            - name: TYPE
+              value: FTBA
+            - name: FTB_MODPACK_ID
+              value: "{{ .Values.ftb.modpackId }}"
+            - name: FTB_MODPACK_VERSION_ID
+              value: "{{ .Values.ftb.versionId }}"
+            {{- end }}
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+              ephemeral-storage: "100Mi"
+            limits:
+              cpu: "4"
+              memory: "12Gi"
+              ephemeral-storage: "200Mi"
+          volumeMounts:
+            - name: "mc-volume"
+              mountPath: /data
+              subPath: mc-data/
+            - name: "mc-volume"
+              mountPath: /modpacks
+              subPath: mc-modpacks/
+      {{- if .Values.curseforgeServerpack }}
+      initContainers:
+        - name: download-serverpack
+          image: alpine
+          command: [ 'sh', '/init/init.sh' ]
+          volumeMounts:
+            - name: "mc-volume"
+              mountPath: /modpacks
+              subPath: mc-modpacks/
+            - name: "mc-volume"
+              mountPath: /data
+              subPath: mc-data/
+            - name: init-script
+              mountPath: /init/init.sh
+              subPath: init.sh
+      {{- end }}
+      restartPolicy: Always
+      volumes:
+        - name: "mc-volume"
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-mc-volume-claim
+        - name: init-script
+          configMap:
+            name: {{ .Release.Name }}-init-config
+  serviceName: {{ .Release.Name }}-service
+
+

--- a/minecraft-server/values.yaml
+++ b/minecraft-server/values.yaml
@@ -1,0 +1,55 @@
+# Scale the whole chart down without uninstalling it: scaleDown: true renders
+# every Deployment/StatefulSet with replicas: 0 (and suspends CronJobs) and
+# takes precedence over any per-workload replicas value. PVCs, Secrets and
+# Services stay in place; scaleDown: false brings the workloads back up.
+scaleDown: false
+
+secrets:
+  minecraftServerRef: null
+server:
+  # Replica count for this workload; 0 is allowed and scales it down.
+  # The chart-global scaleDown flag takes precedence.
+  replicas: 1
+  outwardPort: 30565
+  motd: 'Running \u00A72\u00A7o%MODPACK_NAME% \u00A70version \u00A7r%env:MODPACK_VERSION%'
+minecraft:
+  # Valid values are: peaceful, easy, normal, and hard
+  difficulty: "easy"
+  whitelist:
+    enabled: "true"
+    overridePolicy: "MERGE"
+    # Comma-separated List of Players
+    players: null
+  management:
+    # Comma-separated List of Players
+    opPlayers: null
+    maxPlayers: 10
+    forceGameMode: true
+    # Valid values are: creative, survival, adventure, spectator (only for Minecraft 1.8 or later)
+    gameMode: survival
+    worldSaveName: world
+    serverName: mc-server
+  resources:
+    storage: "32Gi"
+    memory: "4"
+  version: "LATEST"
+curseforge:
+  enabled: false
+  forceReload: false
+  modpack:
+    slug: null
+    versionId: null
+    exclude: null
+    excludeOverride: null
+    include: null
+ftb:
+  enabled: false
+  modpackId: null
+  versionId: null
+curseforgeServerpack:
+  enabled: false
+  downloadUrl: null
+  workingDirectory: '/data/serverpack'
+mcRouterIntegration:
+  enabled: false
+  domain: null


### PR DESCRIPTION
Fixes #67

Stage 1 of the Fleet migration for `minecraft-server`: the chart moves into this repo **functionally unchanged**, gets fully wired into CI and is published as the first of three Java lines, so the cluster-config session can switch the deployments to Fleet without any change to the rolled-out state. Convention alignment is stage 2, the app update is stage 3.

This is **PR A of three**. B (`java17`) and C (`java21`) follow one after the other, each after the previous publish, because every push to `main` publishes exactly the `Chart.yaml` state at that moment.

## What was imported

Verbatim copy of `/Users/justinklein/dev/cluster-config/minecraft/minecraft-server/minecraft-server/`: `.helmignore`, `values.yaml` and the five templates (`mc-server-sfs.yaml` StatefulSet, `mc-pvc.yaml`, `mc-secret.yaml` OnePasswordItem, `mc-server-service.yaml`, `init-script-configmap.yaml`). No ingress, pure TCP.

**Version:** `0.4.0+upjava8`, `appVersion: "java8"`. The chart semver stays at 0.4.0; the `+up` suffix is repo policy and does not affect rendering. `helm package` produces `minecraft-server-0.4.0+upjava8.tgz`, which matches the `<chart>-*.tgz` glob the publish workflow pushes.

A full `diff -ru` of source vs. imported chart contains exactly four changes: the two `Chart.yaml` lines above, the `replicas:` line, and the `values.yaml` block — plus the new `_helpers.tpl`. Nothing else was touched.

## The one approved deviation: `scaleDown`

`replicas: 1` was hardcoded in the StatefulSet. Two of the three servers stand at **0 replicas** in the cluster — a hand-scaled state the chart cannot express. Fleet reconciles continuously and would start both sleeping servers (32 GiB world PVC each, immediately reachable over the static router routes); scaling down by hand would not hold.

Implemented exactly along the `satisfactory` pattern, with its explanatory values comments taken over:

- chart-global, top level: **`.Values.scaleDown`** (default `false`)
- per workload: **`.Values.server.replicas`** (default `1`)
- helper `minecraft-server.replicas` in `templates/_helpers.tpl`, called as
  `include "minecraft-server.replicas" (dict "scaleDown" .Values.scaleDown "replicas" .Values.server.replicas)`

The helper keeps the explicit `kindIs "invalid"` nil check, so an explicit `replicas: 0` survives (Helm's `default` would swallow it).

### Rendered proof

The critical property — the default must still render `replicas: 1`:

```
$ helm template mc minecraft-server | grep -A6 '^kind: StatefulSet'
kind: StatefulSet
metadata:
  name: mc-server-deployment
  labels:
    app: mc
spec:
  replicas: 1

$ helm template mc minecraft-server --set scaleDown=true | grep -A6 '^kind: StatefulSet'
kind: StatefulSet
metadata:
  name: mc-server-deployment
  labels:
    app: mc
spec:
  replicas: 0
```

Precedence and per-workload control:

```
$ helm template mc minecraft-server --set server.replicas=3                        | grep '^  replicas:'
  replicas: 3
$ helm template mc minecraft-server --set server.replicas=0                        | grep '^  replicas:'
  replicas: 0
$ helm template mc minecraft-server --set server.replicas=3 --set scaleDown=true   | grep '^  replicas:'
  replicas: 0      # scaleDown wins over any replicas value
```

And against the three real release values files:

```
# ftb-skies-2 (the running server), default values:
  replicas: 1
# ftb-oceanblock  --set scaleDown=true:
  replicas: 0
# sultan-saladin  --set scaleDown=true:
  replicas: 0
```

## Verification: rendered output is byte-identical

`helm template` of the original chart vs. the imported chart, against the three real values files, for **all three Java lines** (the original was copied to a scratch directory and only its `appVersion` set per line; the source directory itself was never modified). The chart name is unchanged, so even the `# Source:` provenance comments match and **no normalization was needed** — the sha256 of the complete rendering is equal in all nine combinations:

```
IDENTICAL  java8   ftb-skies-2      ef5ef87069740178676c3028c8ca603a821c732f83600c1e16b08eceacb05994
IDENTICAL  java8   ftb-oceanblock   33bf753bfeacad6194807447bb11437f2f0de9e27ffc59245071db54c8d7df40
IDENTICAL  java8   sultan-saladin   f502bdef594b6fd68fd7f8bd61ec04dc7dac4d86f66c565f23222fbf283e659c
IDENTICAL  java17  ftb-skies-2      ad14c3532b03837f82a54803f62cd3120953c0f27eef41545d822b1a80ccb972
IDENTICAL  java17  ftb-oceanblock   8df8f6b498a5318b98fe9531d741c5b55e0b6554f569939de22e1aff66904c2b
IDENTICAL  java17  sultan-saladin   bd492c3e5285f3286e5114ca120f61efd9d5f56a6aa1d58e29b2fed3057c0283
IDENTICAL  java21  ftb-skies-2      0ad94c892d3e24804fdff65c62fb7984d69f3baed5decacf70a6df023daee44d
IDENTICAL  java21  ftb-oceanblock   d32ff3b2f70fce6c3a995edf3b7bd4c1179203a620e6b49934ad4c670a317b75
IDENTICAL  java21  sultan-saladin   689413da19016e7643a67072eb9f0e386e1400688418d158195a7fc36e6844c3
```

This also pre-verifies PR B and PR C: for those lines too the rendering only differs from today's state in the image tag they are meant to change.

`helm lint --strict minecraft-server` passes (**exit 0**) with a single INFO: `Chart.yaml: icon is recommended` — on the stage-2 list below, not fixed here.

## Install-test

**A real install-test runs; no exclusion entry was needed.** Fixtures under `ci/minecraft-server/`:

- `test-values.yaml` — overrides only what a runner cannot provide (see below)
- `fixtures.yaml` — no-provisioner StorageClass `longhorn` + pre-bound hostPath PV (the chart hardcodes `storageClassName: longhorn`, which does not exist in k3d), a node-setup Job that pre-creates the subPath dirs world-writable, and the dummy Secret the 1Password operator would otherwise materialize
- `settings.env` — `INSTALL_TIMEOUT=600` (large image, server jar download on first start)

`server.outwardPort` needed **no** CI override: unlike minecraft-router, its default 30565 is already inside the Kubernetes node-port range, so the k3d API server accepts the NodePort unchanged.

Run locally against a throwaway k3d cluster (same k3s image as CI, `v1.35.5-k3s1`, isolated kubeconfig):

```
OK: chart 'minecraft-server' installed and all workloads are Ready.
INSTALL_TEST_EXIT=0
```

Because a green rollout alone is weak for this chart (see below), the run was checked past the readiness point — the server really boots and stays up:

```
[13:35:17] [Server thread/INFO]: Done (3.853s)! For help, type "help" or "?"

ready=true restarts=0
sts_replicas=1 image=itzg/minecraft-server:java8
svc_type=NodePort nodePort=30565
pvc=Bound sc=longhorn
opitem=ci-mc-secret
```

### Two things the test surfaced, worth recording

**1. The first version of the test values was a false pass.** The chart has no probes at all, so a pod counts as Ready the moment the container is *running* — `kubectl rollout status` returns long before the Minecraft server has actually started. A placeholder op-player name in the CI values (`OPS=CiTestOperator`) made the image abort startup:

```
[mc-image-helper] ERROR : Invalid parameter provided for 'manage-users' command:
                          Could not resolve user from Playerdb: CiTestOperator
```

The install-test reported success anyway, and the pod was at `restarts=6` a few minutes later. The CI values now leave `opPlayers` at its default (`null`) — a real name would make CI depend on a third-party lookup — and the run was re-verified by watching the container past the readiness point (server boots, `restarts=0`).

> **Until stage 2 adds probes, a green install-test for this chart only proves that the container runs, not that the server answers.**

Worth carrying into every future PR on this chart: the green check has to be read together with a look at the container *after* the rollout returns. What the test does prove today is scheduling, volume mounting, image pull and "the container stays up".

**2. `minecraft.version` has to track the Java line.** The image tag comes solely from `.Chart.AppVersion`, so the JVM is fixed per published chart version, and the Minecraft version must match it: Java 8 runs up to 1.16.5, newer releases need Java 17/21 and refuse to start otherwise. There is no Minecraft version that boots on all three lines. The CI values therefore pin `1.12.2` for this `java8` chart, and **PRs B and C bump `ci/minecraft-server/test-values.yaml` alongside `appVersion`**. `ci/` lives outside the chart directory, so this does not affect the packaged chart or trigger a publish. The production default `LATEST` would pull a 1.21.x server that a Java 8 JVM cannot load at all.

## CI wiring

- `.github/workflows/publish-minecraft-server.yml` (triggers on `minecraft-server/**` pushes to `main`)
- `minecraft-server` added to the `chart-name` choice list in `change-app-version.yml`
- `ci/minecraft-server/` fixtures as above
- README chart table row, including the note that the Java line is selected by picking the chart version

## Deliberately NOT fixed — scheduled for stage 2

All of these are known and were left untouched on purpose, so this PR cannot change the rolled-out state.

### Real bugs, not style questions — highest priority for stage 2

- **`containerPort` mismatch**: the port named `mc-port` declares **35565**, while the Service targets **25565**, which is what the server actually listens on. This works today *only* because `targetPort` is the number and not the port name — the moment anyone switches the Service to the named port (the obvious "cleanup" while aligning conventions), the routing breaks. Fix the declared port and the name together.
- **initContainer guard tests the wrong thing**: `{{- if .Values.curseforgeServerpack }}` tests the *map*, which is always truthy, so the `download-serverpack` init container renders for **every** release, including the two FTB servers and the vanilla case. With `downloadUrl: null` it runs `wget -O … ` with an empty URL, fails, and the script continues (no `set -e`), so it silently no-ops — confirmed in the CI run, whose init-container log is a wget usage message. Should be `.Values.curseforgeServerpack.enabled`.

### Conventions and hardening

- **No probes at all** (liveness/readiness/startup) — see the install-test note above; this is the most consequential gap.
- **No hardening**: only `automountServiceAccountToken: false`. No `runAsNonRoot`, no `readOnlyRootFilesystem`, no dropped capabilities, no `allowPrivilegeEscalation: false`, no configurable `securityContext.pod` / `securityContext.container`. The container starts as root and the image's entrypoint drops to uid 1000 itself.
- **Naming scheme** deviates throughout: `{{ .Release.Name }}-server-deployment` (a *StatefulSet* named `-deployment`), `-service`, `-mc-secret`, `-init-config`, `-mc-volume-claim`, container `-mc-server-container` — instead of `{{ .Release.Name }}-{{ .Chart.Name }}-<kind>`. The StatefulSet's `metadata.labels.app` (`{{ .Release.Name }}`) also does not match its own selector (`{{ .Release.Name }}-server-deployment`). Template file names likewise do not follow `<app>.<kind>.yaml`.
- **PVC rename is blocked**: `{{ .Release.Name }}-mc-volume-claim` keeps its historical name (documented naming exception — a rename would provision a new, empty volume and orphan the 32 GiB worlds).
- **`icon:` missing** in `Chart.yaml` (the one `helm lint --strict` INFO).
- **Resources hardcoded** in the template (requests cpu 2 / memory 4Gi / ephemeral-storage 100Mi, limits cpu 4 / memory 12Gi / ephemeral-storage 200Mi) instead of values + the `limitFactor` helper. Inconsistent today: the JVM heap *is* a value (`minecraft.resources.memory` → `MEMORY`), the container memory request/limit is not — raising the heap does not raise the limit.
- **Init container image `alpine` is unpinned** (implicitly `:latest`) and comes from Docker Hub, against the "auxiliary images pinned via values" rule.
- **Misleading mc-router auto-discovery annotation**: the Service sets `mc-router.itzg.me/externalServerName` when `mcRouterIntegration.enabled`, implying auto-discovery, while routing is in fact static in the minecraft-router ConfigMap. All three real releases set it. Removal is explicitly stage 2 (static routing stays) — and note that this flag also flips the Service from NodePort to ClusterIP, so `server.outwardPort` is dead config in all three production releases.
- **Values-schema traps** (silently ignored settings, same class as the router's broken `mappings` default):
  - all three real values files set top-level `whitelist.enabled: false`, but the chart reads `minecraft.whitelist.enabled` (default `"true"`) — the setting has never had any effect.
  - `sultan-saladin.values.yaml` sets `curseforge.modpack.versionString`, while the chart reads `curseforge.modpack.versionId` → `CF_FILE_ID` renders empty.
- **No mutual exclusion** between `curseforge`, `ftb` and `curseforgeServerpack`: enabling two emits duplicate `TYPE` env entries (last one wins) instead of failing.
- **`storageClassName: longhorn` hardcoded** in the PVC (samba/teamspeak make it a value) — this is what forces the CI StorageClass fixture.
- **No additive `env` block**, no `tpl` rendering of env entries.
- **`minecraft.version` defaults to `"LATEST"`** — an unpinned app version that drifts on every restart.
- **`RCON_PASSWORD` is wired from the secret although `ENABLE_RCON: "false"`**, so the secret key is mandatory for a feature that is switched off.
- **No `NOTES.txt`**; `restartPolicy: Always` is spelled out redundantly on the pod template.

## Follow-up

After merge and a verified publish of `0.4.0+upjava8`, PR B (`java17`) follows, then PR C (`java21`), so `main` finally rests on the line of the only running server while the registry holds all three tags.
