### PR TITLE
Publish minecraft-server on the java17 line (0.4.0+upjava17)

### DIFF
--- a/ci/minecraft-server/test-values.yaml
+++ b/ci/minecraft-server/test-values.yaml
@@ -3,13 +3,13 @@
 #
 # 1. minecraft.version: the image tag comes from .Chart.AppVersion, so the JVM
 #    in the image is fixed per published chart version and the Minecraft
-#    version has to match that Java line - Java 8 runs Minecraft up to 1.16.5,
-#    modern versions need Java 17/21 and refuse to start otherwise. This chart
-#    version publishes appVersion "java8", hence 1.12.2 (a classic Java 8 era
-#    release). This value is bumped together with appVersion in the java17 and
-#    java21 follow-up PRs.
+#    version has to match that Java line - Java 8 runs Minecraft only up to
+#    1.16.5, 1.18-1.20.4 need Java 17, and 1.20.5+ need Java 21. No single
+#    Minecraft version boots on all three lines, so this value is bumped
+#    together with appVersion in every Java-line PR.
+#    This chart version publishes appVersion "java17", hence 1.20.1.
 #    The production default is "LATEST", which would pull a 1.21.x server that
-#    a Java 8 JVM cannot load at all.
+#    needs Java 21 and would not start on this line.
 # 2. minecraft.resources.storage: the production 32Gi world volume is backed by
 #    a static hostPath PV in CI (see fixtures.yaml); 2Gi is plenty for a server
 #    that only has to boot.
@@ -25,7 +25,7 @@ secrets:
   minecraftServerRef: vaults/CI/items/minecraft-server
 
 minecraft:
-  version: "1.12.2"
+  version: "1.20.1"
   management:
     # opPlayers deliberately stays at the default (null): the image resolves
     # every name in OPS against the external Playerdb API and aborts the whole

--- a/minecraft-server/Chart.yaml
+++ b/minecraft-server/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0+upjava8
+version: 0.4.0+upjava17
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "java8"
+appVersion: "java17"


### PR DESCRIPTION
Stage 1 of the Fleet migration for `minecraft-server`, **PR B of three**: publishes the same chart on the **java17** line.

Follows #71 (`0.4.0+upjava8`, already merged and published). PR C (`java21`) follows after this one is published. No `Fixes` trailer — #67 was already closed by PR A.

Why one PR per line: the image tag comes solely from `.Chart.AppVersion` (`itzg/minecraft-server:{{ .Chart.AppVersion }}`), there is no values switch, and every push to `main` publishes exactly the `Chart.yaml` state at that moment. So the three Java lines have to be published one after another.

## What changed

**`minecraft-server/Chart.yaml`** — nothing but the two version lines:

```diff
-version: 0.4.0+upjava8
+version: 0.4.0+upjava17
-appVersion: "java8"
+appVersion: "java17"
```

`helm package` produces `minecraft-server-0.4.0+upjava17.tgz`, matching the `<chart>-*.tgz` glob the publish workflow pushes.

**`ci/minecraft-server/test-values.yaml`** — `minecraft.version` moves from `1.12.2` to `1.20.1`, plus the comment explaining it.

### Why the CI values move with the appVersion

This is the deliberate coupling agreed for PRs B and C, and the reason this PR touches two files instead of one.

The image tag is the Java line, so the JVM inside the image is fixed per published chart version — and the Minecraft version has to match it: Java 8 runs Minecraft only up to 1.16.5, 1.18–1.20.4 need Java 17, and 1.20.5+ need Java 21. **There is no single Minecraft version that boots on all three lines.** Leaving the CI values at the java8-era `1.12.2` would mean this line's install-test runs a server the image's JVM cannot load.

That failure would not even be loud. The chart has no probes, so a pod counts as Ready the moment the container is *running* — `kubectl rollout status` returns before the Minecraft server has finished starting, and a server that dies right after would still leave a green check behind. This exact false pass was hit and documented in PR A. Pinning the version per line keeps the install-test a real test instead of a formality.

`ci/` lives outside the chart directory, so this change is not packaged into the chart tgz and does not trigger a publish workflow — it only affects what the PR pipeline installs.

## Verification

**The rendering changes in exactly one line, and it is the intended one.** Rendered output of the published java8 chart vs. this java17 chart, against all three real values files — the complete diff for each:

```diff
@@ -93,7 +93,7 @@
       automountServiceAccountToken: false
       containers:
         - name: mc-release-mc-server-container
-          image: "itzg/minecraft-server:java8"
+          image: "itzg/minecraft-server:java17"
           imagePullPolicy: IfNotPresent
```

Nothing else moves — no replicas, no ports, no volumes, no secret wiring.

**Byte-identity against the original cluster-config chart still holds.** The 3 values files × 3 Java lines matrix from PR A was re-run on this branch and returns the same nine sha256 hashes, unchanged:

```
IDENTICAL  java17  ftb-skies-2      ad14c3532b03837f82a54803f62cd3120953c0f27eef41545d822b1a80ccb972
IDENTICAL  java17  ftb-oceanblock   8df8f6b498a5318b98fe9531d741c5b55e0b6554f569939de22e1aff66904c2b
IDENTICAL  java17  sultan-saladin   bd492c3e5285f3286e5114ca120f61efd9d5f56a6aa1d58e29b2fed3057c0283
```

`scaleDown` behaviour is unchanged from PR A: the default still renders `replicas: 1`, `scaleDown: true` renders `replicas: 0`.

`helm lint --strict minecraft-server` passes (**exit 0**) with the same single INFO: `Chart.yaml: icon is recommended` — on the stage-2 list, not fixed here.

## Install-test

Run locally against a throwaway k3d cluster (same k3s image as CI, `v1.35.5-k3s1`, isolated kubeconfig), and checked past the readiness point rather than trusting the green rollout:

```
OK: chart 'minecraft-server' installed and all workloads are Ready.
$ kubectl rollout status sts/ci-server-deployment
partitioned roll out complete: 1 new pods have been updated...   # exit 0
$ helm status ci -o json | jq -r .info.status
deployed

[14:04:59] [Server thread/INFO]: Done (13.987s)! For help, type "help"
ready=true restarts=0
sts_replicas=1 image=itzg/minecraft-server:java17
svc_type=NodePort nodePort=30565
pvc=Bound sc=longhorn
opitem=ci-mc-secret
```

The 1.20.1 server boots on the java17 image and stays up — which is exactly what `1.12.2` would not have done here.

> **Until stage 2 adds probes, a green install-test for this chart only proves that the container runs, not that the server answers.**

## Unchanged

Everything else is untouched, including the full stage-2 deficiency list documented in #71 (no probes, no hardening, legacy naming scheme, hardcoded resources, the `containerPort: 35565` vs. Service `25565` mismatch, the initContainer guard testing the map instead of `.enabled`, and the misleading mc-router auto-discovery annotation). Nothing operationally relevant moves: NodePort from `server.outwardPort`, the OnePasswordItem secret and the PVC definition stay exactly as published.

## Follow-up

After merge and a verified publish of `0.4.0+upjava17`, PR C bumps the same two files to `java21` / `0.4.0+upjava21`. `main` then rests on java21 — the line of the only running server — while the registry holds all three tags.
