### PR TITLE
Publish minecraft-server on the java21 line (0.4.0+upjava21)

### DIFF
--- a/ci/minecraft-server/test-values.yaml
+++ b/ci/minecraft-server/test-values.yaml
@@ -7,9 +7,11 @@
 #    1.16.5, 1.18-1.20.4 need Java 17, and 1.20.5+ need Java 21. No single
 #    Minecraft version boots on all three lines, so this value is bumped
 #    together with appVersion in every Java-line PR.
-#    This chart version publishes appVersion "java17", hence 1.20.1.
-#    The production default is "LATEST", which would pull a 1.21.x server that
-#    needs Java 21 and would not start on this line.
+#    This chart version publishes appVersion "java21", hence 1.21.1 - which is
+#    also what ftb-skies-2, the one server actually running on this line, sets
+#    in its real values file, so CI exercises the production version rather
+#    than an arbitrary Java-21-capable one.
+#    The production default is "LATEST", which would drift on every restart.
 # 2. minecraft.resources.storage: the production 32Gi world volume is backed by
 #    a static hostPath PV in CI (see fixtures.yaml); 2Gi is plenty for a server
 #    that only has to boot.
@@ -25,7 +27,7 @@ secrets:
   minecraftServerRef: vaults/CI/items/minecraft-server
 
 minecraft:
-  version: "1.20.1"
+  version: "1.21.1"
   management:
     # opPlayers deliberately stays at the default (null): the image resolves
     # every name in OPS against the external Playerdb API and aborts the whole

--- a/minecraft-server/Chart.yaml
+++ b/minecraft-server/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0+upjava17
+version: 0.4.0+upjava21
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "java17"
+appVersion: "java21"


### PR DESCRIPTION
Stage 1 of the Fleet migration for `minecraft-server`, **PR C of three — the last one**: publishes the chart on the **java21** line and completes the stage.

Follows #71 (`0.4.0+upjava8`) and #72 (`0.4.0+upjava17`), both merged and published. No `Fixes` trailer — #67 was already closed by PR A.

After this merge `main` rests on **java21**, the line of the only server actually running, and the registry holds all three tags.

## What changed

**`minecraft-server/Chart.yaml`** — nothing but the two version lines:

```diff
-version: 0.4.0+upjava17
+version: 0.4.0+upjava21
-appVersion: "java17"
+appVersion: "java21"
```

`helm package` produces `minecraft-server-0.4.0+upjava21.tgz`, matching the `<chart>-*.tgz` glob the publish workflow pushes.

**`ci/minecraft-server/test-values.yaml`** — `minecraft.version` moves from `1.20.1` to `1.21.1`, plus the comment explaining it.

### Why the CI values move with the appVersion

Same deliberate coupling as PR B, and the reason this PR touches two files instead of one.

The image tag is the Java line, so the JVM inside the image is fixed per published chart version, and the Minecraft version has to match it: Java 8 runs only up to 1.16.5, 1.18–1.20.4 need Java 17, 1.20.5+ need Java 21. **No single Minecraft version boots on all three lines.**

What makes this more than bookkeeping: the chart has **no probes**, so a pod counts as Ready the moment the container is *running* — `kubectl rollout status` returns before the Minecraft server has finished starting. A mismatched version that the image's JVM cannot load would crash *after* the rollout returned, and **the install-test would still have been green**. That is not hypothetical: PR A hit exactly this false pass, and the java17 line demonstrated it again — the previous `1.12.2` would not have booted on the java17 image, and CI would have reported success anyway. Pinning the version per line is what keeps this a real test.

For this line the version is not just any Java-21-capable release: **`1.21.1` is what `ftb-skies-2` — the one server actually running on java21 — sets in its real values file**, so CI exercises the production version rather than an arbitrary substitute.

`ci/` lives outside the chart directory, so this change is neither packaged into the chart tgz nor does it trigger a publish workflow.

## Verification

**The rendering changes in exactly one line, and it is the intended one.** Rendered output of the published java17 chart vs. this java21 chart, against all three real values files — the complete diff for each:

```diff
       automountServiceAccountToken: false
       containers:
         - name: mc-release-mc-server-container
-          image: "itzg/minecraft-server:java17"
+          image: "itzg/minecraft-server:java21"
           imagePullPolicy: IfNotPresent
```

Nothing else moves — no replicas, no ports, no volumes, no secret wiring.

**The closing check for the whole series.** Because the source chart in cluster-config is itself on `appVersion: "java21"`, this final state can be compared directly against it. Rendered for `mc-ftb-skies-2` with its real values file, the new chart and the original chart are **byte-identical**:

```
$ diff -u <(helm template mc-ftb-skies-2 <original-chart> -f ftb-skies-2.values.yaml) \
          <(helm template mc-ftb-skies-2 minecraft-server -f ftb-skies-2.values.yaml) \
  && echo IDENTICAL
IDENTICAL
```

So the state `main` comes to rest on renders exactly like the chart cluster-config runs today — no normalization, not even the `# Source:` provenance comments differ. The 3 values files × 3 Java lines matrix was re-run on this branch and returns the same nine sha256 hashes as in PR A and B; the java21 row is that identity:

```
IDENTICAL  java21  ftb-skies-2      0ad94c892d3e24804fdff65c62fb7984d69f3baed5decacf70a6df023daee44d
IDENTICAL  java21  ftb-oceanblock   d32ff3b2f70fce6c3a995edf3b7bd4c1179203a620e6b49934ad4c670a317b75
IDENTICAL  java21  sultan-saladin   689413da19016e7643a67072eb9f0e386e1400688418d158195a7fc36e6844c3
```

`scaleDown` behaviour is unchanged: the default still renders `replicas: 1` (so the running ftb-skies server is unaffected), `scaleDown: true` renders `replicas: 0` for the two sleeping ones.

`helm lint --strict minecraft-server` passes (**exit 0**) with the same single INFO: `Chart.yaml: icon is recommended` — on the stage-2 list, not fixed here.

## Install-test

Run locally against a throwaway k3d cluster (same k3s image as CI, `v1.35.5-k3s1`, isolated kubeconfig), and checked past the readiness point rather than trusting the green rollout:

```
OK: chart 'minecraft-server' installed and all workloads are Ready.
$ kubectl rollout status sts/ci-server-deployment
partitioned roll out complete: 1 new pods have been updated...   # exit 0
$ helm status ci -o json | jq -r .info.status
deployed
$ helm get metadata ci -o json | jq -r '"\(.version) \(.appVersion)"'
0.4.0+upjava21 java21

[14:11:30] [Server thread/INFO]: Done (4.227s)! For help, type "help"
ready=true restarts=0
sts_replicas=1 image=itzg/minecraft-server:java21
svc_type=NodePort nodePort=30565
pvc=Bound sc=longhorn
opitem=ci-mc-secret
```

> **Until stage 2 adds probes, a green install-test for this chart only proves that the container runs, not that the server answers.**

## Unchanged

Everything else is untouched, including the full stage-2 deficiency list documented in #71 (no probes, no hardening, legacy naming scheme, hardcoded resources, the `containerPort: 35565` vs. Service `25565` mismatch, the initContainer guard testing the map instead of `.enabled`, and the misleading mc-router auto-discovery annotation). Nothing operationally relevant moves: NodePort from `server.outwardPort`, the OnePasswordItem secret and the PVC definition stay exactly as published.

## End state

With this merged, stage 1 is complete:

| Release | Java line | Published chart version |
|---|---|---|
| mc-sultan-saladin-server | java8 | `0.4.0+upjava8` |
| mc-oceanblock-2-server | java17 | `0.4.0+upjava17` |
| mc-ftb-skies-2-server | java21 | `0.4.0+upjava21` |

`main` rests on java21. Stage 2 (repo conventions, including removal of the misleading auto-discovery annotations) and stage 3 (app update) follow as their own issues.
