### PR TITLE
minecraft-server: publish the java17 line (1.0.0+upjava17)

### DIFF
--- a/minecraft-server/Chart.yaml
+++ b/minecraft-server/Chart.yaml
@@ -8,8 +8,8 @@ type: application
 # The Java line of this chart version is chosen through appVersion, which is
 # the image tag: the chart is published once per line (java8 / java17 / java21)
 # and minecraft.version in values.yaml must match the line published here.
-version: 1.0.0+upjava8
-appVersion: "java8"
+version: 1.0.0+upjava17
+appVersion: "java17"
 
 maintainers:
   - name: jklein

--- a/minecraft-server/values.yaml
+++ b/minecraft-server/values.yaml
@@ -184,8 +184,8 @@ minecraft:
   # This value must match the Java line of the chart version: the image tag
   # comes from .Chart.AppVersion, so the JVM is fixed per published chart
   # version. Java 8 runs Minecraft up to 1.16.5, 1.18-1.20.4 need Java 17 and
-  # 1.20.5+ need Java 21. This chart publishes appVersion "java8".
-  version: "1.12.2"
+  # 1.20.5+ need Java 21. This chart publishes appVersion "java17".
+  version: "1.20.1"
 
 # curseforge, ftb and curseforgeServerpack are mutually exclusive - enabling
 # more than one is rejected by the chart (before 1.0.0 it silently rendered a


### PR DESCRIPTION
**PR B of three**, following the stage-2 conventions PR (#75, `1.0.0+upjava8`). No chart logic changes — this republishes the *same* chart for the second Java line so all three tags exist at stage-2 level.

`0.4.0+upjava17` → **`1.0.0+upjava17`**, `appVersion: "java17"`.

## What changes

Four lines, in two files:

| File | Change |
|---|---|
| `Chart.yaml` | `version: 1.0.0+upjava17`, `appVersion: "java17"` |
| `values.yaml` | `minecraft.version: "1.12.2"` → `"1.20.1"` (and the comment naming the published line) |

The image tag comes from `.Chart.AppVersion`, so the JVM is fixed per published chart version and the Minecraft version has to match it: Java 8 runs Minecraft only up to 1.16.5, 1.18–1.20.4 need Java 17, and 1.20.5+ need Java 21. There is no Minecraft version that boots on all three lines.

## Why nothing changes under `ci/`

Since #75 the CI values deliberately **no longer override `minecraft.version`** — the chart ships a pinned default per Java line and the install-test exercises that default. So the version bump above is what CI actually boots, and a Java line published with a mismatched default fails the install-test instead of passing on a CI-only override. That is the intended behaviour of that change, and this PR is its first exercise.

## Verification

- `helm lint --strict minecraft-server`: no findings.
- `helm template` renders `image: "itzg/minecraft-server:java17"` and `VERSION=1.20.1`.
- Install-test in CI boots 1.20.1 on the java17 image, with the probes from #75 active — so a green check means the server answered a server-list ping, not merely that the container started.
- Rebased on `origin/main`; commit SSH-signed.

PR C (`java21`, Minecraft 1.21.1) follows after this one is merged and published, so `main` finally rests on the line of the only running server.
