### PR TITLE
minecraft-server: publish the java21 line (1.0.0+upjava21)

### DIFF
--- a/minecraft-server/Chart.yaml
+++ b/minecraft-server/Chart.yaml
@@ -8,8 +8,8 @@ type: application
 # The Java line of this chart version is chosen through appVersion, which is
 # the image tag: the chart is published once per line (java8 / java17 / java21)
 # and minecraft.version in values.yaml must match the line published here.
-version: 1.0.0+upjava17
-appVersion: "java17"
+version: 1.0.0+upjava21
+appVersion: "java21"
 
 maintainers:
   - name: jklein

--- a/minecraft-server/values.yaml
+++ b/minecraft-server/values.yaml
@@ -184,8 +184,8 @@ minecraft:
   # This value must match the Java line of the chart version: the image tag
   # comes from .Chart.AppVersion, so the JVM is fixed per published chart
   # version. Java 8 runs Minecraft up to 1.16.5, 1.18-1.20.4 need Java 17 and
-  # 1.20.5+ need Java 21. This chart publishes appVersion "java17".
-  version: "1.20.1"
+  # 1.20.5+ need Java 21. This chart publishes appVersion "java21".
+  version: "1.21.1"
 
 # curseforge, ftb and curseforgeServerpack are mutually exclusive - enabling
 # more than one is rejected by the chart (before 1.0.0 it silently rendered a


### PR DESCRIPTION
**PR C of three, and the last of stage 2.** Following #75 (`1.0.0+upjava8`, the conventions/schema PR) and #76 (`1.0.0+upjava17`). No chart logic changes — this republishes the *same* chart for the third Java line, after which all three tags exist at stage-2 level and `main` rests on the line of the only server that is actually running (ftb-skies-2).

`0.4.0+upjava21` → **`1.0.0+upjava21`**, `appVersion: "java21"`.

## What changes

Four lines, in two files — `ci/` is deliberately untouched:

| File | Change |
|---|---|
| `Chart.yaml` | `version: 1.0.0+upjava21`, `appVersion: "java21"` |
| `values.yaml` | `minecraft.version: "1.20.1"` → `"1.21.1"` (and the comment naming the published line) |

The image tag comes from `.Chart.AppVersion`, so the JVM is fixed per published chart version and the Minecraft version has to match it: Java 8 runs Minecraft only up to 1.16.5, 1.18–1.20.4 need Java 17, and 1.20.5+ need Java 21.

**This default is the production value.** `1.21.1` is exactly what ftb-skies-2 sets in its own values file, so the install-test now boots the version the real server runs rather than an arbitrary Java-21-capable one — and once the bundle values are cleaned up (see #75), that release could drop its explicit `minecraft.version` entirely and simply inherit the chart default.

## Why nothing changes under `ci/`

Since #75 the CI values deliberately **do not override `minecraft.version`**: the chart ships a pinned default per Java line and the install-test exercises that default. An override that replaces the value under test would only be testing itself. So the bump above is what CI actually boots, and a Java line published with a mismatched default fails the install-test instead of being masked.

## Verification

- `helm lint --strict minecraft-server`: no findings.
- `helm template` renders `image: "itzg/minecraft-server:java21"` and `VERSION=1.21.1`.
- Install-test in CI boots 1.21.1 on the java21 image with the probes from #75 active, so a green check means the server answered a server-list ping rather than merely that the container started.
- Rebased on `origin/main`; commit SSH-signed.

After this publish, stage 2 is complete: all three Java lines carry the conventions, the hardening, the probes and the strict `values.schema.json`. The bundle-values cleanup listed in #75 (including the `mcRouterIntegration` removal and the router-mapping DNS change) remains with the cluster-config session and must happen **before** any release is pulled onto these versions.
