### PR TITLE
Update minecraft-server to the java17 line (2.0.0+up2026.8.2.java17)

### DIFF
--- a/minecraft-server/Chart.yaml
+++ b/minecraft-server/Chart.yaml
@@ -13,8 +13,8 @@ type: application
 # continuously, so a pod restart could pull a different image than the last one
 # without anything being recorded anywhere. The dated tags are immutable, so the
 # image is now pinned by the chart version like every other chart in this repo.
-version: 2.0.0+up2026.8.2.java8
-appVersion: "2026.8.2-java8"
+version: 2.0.0+up2026.8.2.java17
+appVersion: "2026.8.2-java17"
 
 maintainers:
   - name: jklein

--- a/minecraft-server/values.yaml
+++ b/minecraft-server/values.yaml
@@ -206,8 +206,8 @@ minecraft:
   # This value must match the Java line of the chart version: the image tag
   # comes from .Chart.AppVersion, so the JVM is fixed per published chart
   # version. Java 8 runs Minecraft up to 1.16.5, 1.18-1.20.4 need Java 17 and
-  # 1.20.5+ need Java 21. This chart publishes appVersion "2026.8.2-java8".
-  version: "1.12.2"
+  # 1.20.5+ need Java 21. This chart publishes appVersion "2026.8.2-java17".
+  version: "1.20.1"
 
 # curseforge, ftb and curseforgeServerpack are mutually exclusive - enabling
 # more than one is rejected by the chart (before 1.0.0 it silently rendered a


### PR DESCRIPTION
**PR B of three** for stage 3 of the Fleet migration (#78, merged as PR A #79 → `2.0.0+up2026.8.2.java8`, published). No `Fixes` trailer — the issue is already closed by PR A.

The chart content is **identical** to the published java8 version. Only the published Java line changes:

| | PR A (published) | this PR |
|---|---|---|
| `appVersion` | `2026.8.2-java8` | `2026.8.2-java17` |
| `version` | `2.0.0+up2026.8.2.java8` | `2.0.0+up2026.8.2.java17` |
| `minecraft.version` default | `1.12.2` | `1.20.1` |

The diff is exactly four lines in two files (`Chart.yaml`, `values.yaml`) — no template, schema or `ci/` changes. `minecraft.version` stays coupled to the Java line through the **chart default**, not through `ci/`, so the install-test exercises the default a user actually gets: Java 8 runs Minecraft up to 1.16.5, 1.18–1.20.4 need Java 17, 1.20.5+ need Java 21.

For what the major bump 1.0.0 → 2.0.0 contains — immutable dated image tags and the corrected whitelist semantics, including the k3d proof that `enabled: false` overwrites a persisted `white-list=true` — see **#79**. That behaviour is line-independent and is not re-litigated here.

## Verification

The relevant risk for a line PR is that the pinned Minecraft version does not match the JVM in the image, so this was booted rather than assumed. Throwaway cluster `mcs-s3b` (created with `--kubeconfig-switch-context=false`, isolated kubeconfig, deleted afterwards; the global context was never touched):

```
$ ci/run-install-test.sh minecraft-server
OK: chart 'minecraft-server' installed and all workloads are Ready.

pod ci-minecraft-server-sfs-0   1/1 Running   restarts 0
[16:14:10] Starting minecraft server version 1.20.1
[16:14:20] Done (10.004s)! For help, type "help"
```

Since the probes run the image's own `mc-health` (a real server-list ping), "Ready" here means 1.20.1 actually came up on the java17 image.

**The pin resolves to the digest checked upstream before the change** — same cross-check as in PR A, now for this line:

```
$ kubectl get pod ci-minecraft-server-sfs-0 -o jsonpath='{.status.containerStatuses[0].imageID}'
docker.io/itzg/minecraft-server@sha256:1a6efb48c6f40abaef8b4ee8eb6b5e786dcdb0c5a9bd1199262bee6734f13127
```

which is exactly the `2026.8.2-java17` manifest digest listed in #79, confirming that the release covers this line too.

Whitelist defaults on the fresh volume, for completeness:

```
server.properties:  white-list=false   enforce-whitelist=false
image log:          [init] Disabling whitelist functionality
```

- `helm lint --strict minecraft-server`: **no findings**.
- `helm package` → `minecraft-server-2.0.0+up2026.8.2.java17.tgz`, matching the publish glob `minecraft-server-*.tgz`.
- `helm template` with the CI values renders `itzg/minecraft-server:2026.8.2-java17` and `VERSION=1.20.1`.
- Rebased on `main` (`8c0fb01`) before pushing; commit is SSH-signed via 1Password, `verified=true` server-side.

C (`2026.8.2-java21`, `minecraft.version: 1.21.1`) follows after this one is merged and published, so `main` ends up resting on the line of the only running server.
