### PR TITLE
Update minecraft-server to the java21 line (2.0.0+up2026.8.2.java21)

### DIFF
--- a/minecraft-server/Chart.yaml
+++ b/minecraft-server/Chart.yaml
@@ -13,8 +13,8 @@ type: application
 # continuously, so a pod restart could pull a different image than the last one
 # without anything being recorded anywhere. The dated tags are immutable, so the
 # image is now pinned by the chart version like every other chart in this repo.
-version: 2.0.0+up2026.8.2.java17
-appVersion: "2026.8.2-java17"
+version: 2.0.0+up2026.8.2.java21
+appVersion: "2026.8.2-java21"
 
 maintainers:
   - name: jklein

--- a/minecraft-server/values.yaml
+++ b/minecraft-server/values.yaml
@@ -206,8 +206,8 @@ minecraft:
   # This value must match the Java line of the chart version: the image tag
   # comes from .Chart.AppVersion, so the JVM is fixed per published chart
   # version. Java 8 runs Minecraft up to 1.16.5, 1.18-1.20.4 need Java 17 and
-  # 1.20.5+ need Java 21. This chart publishes appVersion "2026.8.2-java17".
-  version: "1.20.1"
+  # 1.20.5+ need Java 21. This chart publishes appVersion "2026.8.2-java21".
+  version: "1.21.1"
 
 # curseforge, ftb and curseforgeServerpack are mutually exclusive - enabling
 # more than one is rejected by the chart (before 1.0.0 it silently rendered a


### PR DESCRIPTION
**PR C of three** — the last one of stage 3 (#78) and of the Fleet migration on the chart side. After this publish, `main` rests on the line of the only running server. Predecessors: #79 → `2.0.0+up2026.8.2.java8` (published), #80 → `2.0.0+up2026.8.2.java17` (published). No `Fixes` trailer — the issue was closed by PR A.

The chart content is **identical** to both published versions. Only the published Java line changes:

| | PR B (published) | this PR |
|---|---|---|
| `appVersion` | `2026.8.2-java17` | `2026.8.2-java21` |
| `version` | `2.0.0+up2026.8.2.java17` | `2.0.0+up2026.8.2.java21` |
| `minecraft.version` default | `1.20.1` | `1.21.1` |

Four changed lines in two files (`Chart.yaml`, `values.yaml`); no template, schema or `ci/` changes. For the content of the major bump — immutable dated image tags and the corrected whitelist semantics — see **#79**.

**This is the line that goes to production**: `1.21.1` is the version ftb-skies-2 actually runs, and it is the only one of the three servers that is up. So it got the most thorough check of the three, rather than the least.

## Verification

Throwaway cluster `mcs-s3c` (created with `--kubeconfig-switch-context=false`, isolated kubeconfig, deleted afterwards; the global context was never touched).

**1. The line boots, and the pin resolves to the digest checked upstream.**

```
$ ci/run-install-test.sh minecraft-server
OK: chart 'minecraft-server' installed and all workloads are Ready.
pod ci-minecraft-server-sfs-0   1/1 Running   restarts 0

[16:21:38] Starting minecraft server version 1.21.1
[16:21:42] Done (3.245s)! For help, type "help"

$ kubectl get pod ci-minecraft-server-sfs-0 -o jsonpath='{.status.containerStatuses[0].imageID}'
docker.io/itzg/minecraft-server@sha256:41041d799cee7743867f9a25bf12f2deeeb5a2392f3e4433d188cac4ad5e1e3a
```

That digest is exactly the `2026.8.2-java21` manifest digest resolved in #79 before any of this was written, so the release covers this line as a fact rather than an inference from the tag list.

Readiness is not merely "the process exists" — the image's own `mc-health` answers a real server-list ping with the running version:

```
$ kubectl exec ci-minecraft-server-sfs-0 -- mc-health
localhost:25565 : version=1.21.1 online=0 max=2 motd='Running §2§o%MODPACK_NAME% §0version §r%env:MODPACK_VERSION%'
```

(The `§` colour codes coming back intact also confirms the MOTD's Java-properties escapes still survive the round trip on this line.)

**2. The whitelist switch was re-verified on this line, not just inherited from #79** — because this is the line ftb-skies-2 will be pulled onto, and switching the whitelist off is the one change that touches persisted state. Same release, same volume, first enabled then disabled:

```
enabled: true, players "Notch,jeb_"
  white-list=true    enforce-whitelist=true
  whitelist.json     [{"name":"Notch",…},{"name":"jeb_",…}]

upgrade to enabled: false (against that persisted white-list=true)
  white-list=false   enforce-whitelist=false
  env                ENABLE_WHITELIST=false   ENFORCE_WHITELIST=false
  image log          [init] Disabling whitelist functionality
```

So the behaviour proven on java8 in #79 holds identically on java21. Defaults on a fresh volume: `white-list=false`, `enforce-whitelist=false`.

**3. Rest.**

- `helm lint --strict minecraft-server`: **no findings**.
- `helm package` → `minecraft-server-2.0.0+up2026.8.2.java21.tgz`, matching the publish glob `minecraft-server-*.tgz`.
- `helm template` with the CI values renders `itzg/minecraft-server:2026.8.2-java21` and `VERSION=1.21.1`.
- Rebased on `main` (`83e324e`) before pushing; commit is SSH-signed via 1Password, `verified=true` server-side.

## Reminder for the rollout

Unchanged from #79, repeated here because this is the version the running server will actually be pulled onto: `minecraft.whitelist.enabled: false` is no longer a no-op. ftb-skies-2 already runs `white-list=false`, so for it this is a no-op in effect — but **oceanblock and sultan-saladin were never measured** and may carry `white-list=true` on their PVCs, which this version would flip to `false` on their next start. If either is meant to keep a whitelist, set `enabled: true` **and** `players` before waking it.
