### PR TITLE
Restart the router when its routing config changes (minecraft-router 2.0.0+up1.46.4)

### DIFF
--- a/minecraft-router/Chart.yaml
+++ b/minecraft-router/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://avatars.githubusercontent.com/u/988985
 
 type: application
 
-version: 1.0.1+up1.46.4
+version: 2.0.0+up1.46.4
 appVersion: "1.46.4"
 
 maintainers:

--- a/minecraft-router/templates/minecraft-router.deployment.yaml
+++ b/minecraft-router/templates/minecraft-router.deployment.yaml
@@ -14,6 +14,13 @@ spec:
       name: {{ .Release.Name }}-{{ .Chart.Name }}-deployment
       labels:
         app: {{ .Release.Name }}-{{ .Chart.Name }}-deployment
+      annotations:
+        # Rolls the pod whenever the rendered routing ConfigMap changes.
+        # Without it a changed routing table stays inert: the file is mounted
+        # with subPath (kubelet never refreshes those in a running container)
+        # and mc-router reads ROUTES_CONFIG only at startup, so the router
+        # would keep serving the old routes while everything looks healthy.
+        checksum/config: {{ include (print $.Template.BasePath "/minecraft-router.configmap.yaml") . | sha256sum }}
     spec:
       automountServiceAccountToken: false
       securityContext:

--- a/minecraft-router/values.yaml
+++ b/minecraft-router/values.yaml
@@ -15,6 +15,11 @@ scaleDown: false
 #     - domain: creative.example.com
 #       internalUrl: creative-service.minecraft.svc.cluster.local
 #       port: 25566
+# Since chart 2.0.0 a change here rolls the router pod: the deployment carries
+# a checksum/config annotation over the rendered ConfigMap. That restart is
+# required for the change to take effect at all - the config is mounted with
+# subPath and mc-router only reads it at startup - and costs a few seconds of
+# proxy downtime, during which clients cannot connect.
 mappings: null
 
 server:


### PR DESCRIPTION
## Was das behebt

Der Ausfall aus #82, an genau der Stelle, an der er entstanden ist.

Nach dem Umbenennen der Minecraft-Services zeigte die Router-ConfigMap korrekt auf die neuen Namen — der **laufende** Router proxyte weiter auf die alten, die es nicht mehr gab. Pod Ready, Bundles grün, niemand kam auf die Server. Zwei Dinge zusammen: kein `checksum/config` am Pod-Template, und die Datei ist per `subPath` gemountet — kubelet aktualisiert solche Mounts im laufenden Container nie, und mc-router liest `ROUTES_CONFIG` ohnehin nur beim Start.

Das Deployment trägt jetzt:

```yaml
checksum/config: {{ include (print $.Template.BasePath "/minecraft-router.configmap.yaml") . | sha256sum }}
```

**Eine Quelle, eine Annotation.** minecraft-router hat genau eine ConfigMap und keinerlei Secrets — weder gemountet noch als `secretKeyRef` —, also stellt sich die Frage nach mehreren Hashes hier nicht.

## Major-Bump: was sich am Laufzeitverhalten ändert

Eine Änderung an `mappings` rollt ab sofort den Router-Pod. Das ist der Zweck — vorher war die Änderung wirkungslos —, aber es ist eine echte Verhaltensänderung mit Preis: **~4,5 s gemessen im k3d**, nach der Faustregel aus #82 (Faktor 3–4) also grob 17–19 s im echten Cluster. In dieser Zeit kommen keine Clients durch. Der Wert deckt sich mit den 19 s, die beim Stufe-3-Rollout real gemessen wurden.

In `values.yaml` steht das jetzt bei `mappings` als Kommentar.

## Nachweis 1: Der Hash löst weder zu selten noch zu oft aus

`helm template`, jeweils `ci/minecraft-router/test-values.yaml` als Basis:

| Variante | `checksum/config` |
|---|---|
| Basis | `8ef10143e9b0bf09…` |
| Basis, zweiter Lauf, unverändert | `8ef10143e9b0bf09…` — **gleich** |
| `server.replicas=2` (ConfigMap unberührt) | `8ef10143e9b0bf09…` — **gleich** |
| `mappings[0].internalUrl` geändert | `2304f9aab4f519a6…` — **neu** |
| dritte Mapping-Zeile ergänzt | `1265fbbaec66d981…` — **neu** |
| nur `mappings[1].port` geändert | `925f2ae51f717f2e…` — **neu** |

Also: identische Eingabe → identischer Hash (kein Rollout bei jedem `helm upgrade`), jede Änderung an der Routing-Tabelle → neuer Hash. Auch eine Änderung, die die ConfigMap nicht berührt, lässt den Hash in Ruhe.

## Nachweis 2: Der ursprüngliche Ausfall, im k3d nachgestellt

Wegwerf-Cluster `mcrouter-checksum-b`, alle Aufrufe mit explizitem `--context`, angelegt mit `--kubeconfig-switch-context=false`, danach gelöscht. Beide Seiten im selben Cluster, in zwei Namespaces.

**Alter Chart (`origin/main`, 1.0.1) — der Ausfall:**

1. Install mit `internalUrl: old-survival-service…`, Log: `Created route mapping backend="old-survival-service.default.svc.cluster.local:25565"`
2. `helm upgrade` mit `internalUrl: renamed-survival-service…`
3. ConfigMap im Cluster danach: `"mc.example.com": "renamed-survival-service.default.svc.cluster.local:25565"` — **die Änderung ist angekommen**
4. Pod danach: `router-…-f485bc968-cl5gs`, `startTime 16:50:04Z`, `restartCount 0`, `Ready true` — **derselbe Pod, kein Neustart**
5. Live-Routingtabelle des laufenden Routers über die API:
   ```json
   {"mc.example.com":{"backend":"old-survival-service.default.svc.cluster.local:25565","scalingTarget":""}}
   ```

Genau der stille Ausfall: ConfigMap neu, Router alt, alles grün.

**Neuer Chart (dieser PR) — derselbe Ablauf:**

1. Install, Pod `…-7496d4947f-bl686`, Annotation `2962847f4926…`, Log: `old-survival-service`
2. `helm upgrade` **ohne Änderung** → Revision 2, Pod unverändert `…-7496d4947f-bl686`, `startTime 16:50:56Z` — **kein Neustart ohne Anlass**
3. `helm upgrade` **mit** geänderter Mapping → Revision 3, neuer Pod `…-6bbb67c4db-7tgft`, Annotation `524a5471ef6a…`
4. Log des neuen Pods: `Created route mapping backend="renamed-survival-service.default.svc.cluster.local:25565"`
5. Live-Routingtabelle:
   ```json
   {"mc.example.com":{"backend":"renamed-survival-service.default.svc.cluster.local:25565","scalingTarget":""}}
   ```
6. ReplicaSets: alte auf `desired 0` mit altem Hash, neue auf `desired 1` mit neuem Hash — ein sauberer Rollout, kein Zwangsneustart.

## Verifikation

- `helm lint --strict minecraft-router` → 0 chart(s) failed, mit und ohne `ci/`-Werte.
- `helm template` in sechs Varianten (Tabelle oben).
- Install-Test im k3d, beide Chart-Stände.

Teil von #82 (Strang B, PR 1 von 4). Das Issue umfasst beide Stränge und bleibt offen.
