### PR TITLE
matrix-synapse: Delegation-nginx bei ConfigMap-Änderung neu starten (#82)

### DIFF
--- a/matrix-synapse/Chart.yaml
+++ b/matrix-synapse/Chart.yaml
@@ -3,7 +3,7 @@ name: matrix-synapse
 description: A Helm chart to deploy a Matrix Synapse server on Kubernetes
 icon: https://raw.githubusercontent.com/element-hq/synapse/develop/docs/favicon.png
 type: application
-version: 5.0.0+upv1.159.0
+version: 6.0.0+upv1.159.0
 appVersion: "v1.159.0"
 maintainers:
   - name: jklein

--- a/matrix-synapse/templates/matrix-delegation-nginx.deployment.yaml
+++ b/matrix-synapse/templates/matrix-delegation-nginx.deployment.yaml
@@ -14,6 +14,13 @@ spec:
     metadata:
       labels:
         app: {{ .Release.Name }}-{{ .Chart.Name }}-delegation-nginx-deployment
+      annotations:
+        # Hash of the rendered delegation ConfigMap: a changed nginx.conf
+        # changes the pod template and thus rolls the pods. Without it the
+        # running nginx keeps serving the old .well-known documents - the
+        # config is mounted with subPath (never refreshed by the kubelet) and
+        # nginx reads it only at start.
+        checksum/config: {{ include (print $.Template.BasePath "/matrix-delegation-nginx.configmap.yaml") . | sha256sum }}
     spec:
       automountServiceAccountToken: false
       securityContext:

--- a/matrix-synapse/values.yaml
+++ b/matrix-synapse/values.yaml
@@ -5,6 +5,18 @@
 scaleDown: false
 
 secrets:
+  # homeserver.yaml is mounted into the Synapse StatefulSet from the Secret the
+  # 1Password operator materializes from this item.
+  #
+  # Known limitation (#82): a change to the item in the vault does NOT restart
+  # Synapse. Helm cannot hash the content (it never sees it - the operator fills
+  # the Secret in-cluster after rendering), so the checksum/config mechanism the
+  # delegation nginx uses does not apply here. The operator's own
+  # "operator.1password.io/auto-restart" annotation is no help either: it only
+  # ever restarts Deployments, and this workload is a StatefulSet (verified
+  # against onepassword-operator 1.12.0). After changing the item, restart
+  # Synapse by hand:
+  #   kubectl rollout restart statefulset <release>-matrix-synapse-sfs
   configSecretRef: null
 
 matrix:


### PR DESCRIPTION
## Warum

Der Delegation-nginx liefert die `.well-known/matrix/*`-Dokumente aus einer `nginx.conf`, die aus `ingress.domain` gerendert und per **`subPath`** gemountet wird. Änderte man die Domain, wurde die ConfigMap korrekt neu geschrieben — und der laufende Pod lieferte weiter die alte Delegation. Kein Neustart (das Pod-Template blieb identisch), keine Aktualisierung des Mounts (Kubelet aktualisiert `subPath` nie), und nginx liest die Datei ohnehin nur beim Start. Genau das Muster aus #82: sieht erfolgreich aus, wirkt nicht.

Zweiter PR der Serie zu #82, Strang A, auf Basis der in #83 eingeführten Guideline.

## Was drin ist

- **`matrix-delegation-nginx.deployment.yaml`**: `checksum/config` über die gerenderte Delegation-ConfigMap am Pod-Template.
- **`values.yaml`**: Der Vollständigkeit halber die Grenze dokumentiert, die *bleibt* — `homeserver.yaml` kommt aus einem 1Password-Secret, siehe unten.
- **Version**: `5.0.0+upv1.159.0` → **`6.0.0+upv1.159.0`**.

## Kosten des Neustarts

Betroffen ist nur das nginx-Deployment: ein Pod, kein persistenter Zustand, im k3d in **wenigen Sekunden** wieder Ready (unten: 0 → Ready innerhalb eines `rollout status`-Durchlaufs). Real ist mit dem für dieses Repo etablierten Faktor 3–4 zu rechnen, also weiterhin Sekunden. Die Synapse-StatefulSet selbst wird **nicht** angefasst — die ConfigMap gehört ausschließlich zum nginx.

## Nachweis: der Hash reagiert genau auf die ConfigMap, sonst nicht

```
# identische Eingabe, zweimal gerendert
checksum/config: 444c465c2d75e73d8ceb691818f697d5ff10621e239e9fb4e38d2f95a9542540
checksum/config: 444c465c2d75e73d8ceb691818f697d5ff10621e239e9fb4e38d2f95a9542540

# --set ingress.domain=other.example.com   (steht in nginx.conf)
checksum/config: 8daa092ca523c117d2aa4027b8066a6259a10dea74edb00a3e04bd79a8417691

# --set matrix.delegation.replicas=2       (steht NICHT in nginx.conf)
checksum/config: 444c465c2d75e73d8ceb691818f697d5ff10621e239e9fb4e38d2f95a9542540
```

Der dritte Fall ist der wichtige: Eine Wertänderung, die die ConfigMap nicht berührt, lässt den Hash unverändert. Die Annotation löst also weder zu selten noch bei jedem Rendern aus.

## Nachweis im laufenden Cluster (k3d)

Wegwerf-Cluster `checksum-proof-a`, angelegt mit `--kubeconfig-update-default=false --kubeconfig-switch-context=false` und über eine eigene `KUBECONFIG` plus explizitem `--context k3d-checksum-proof-a` angesprochen; der globale Context blieb unverändert. Installation über `ci/run-install-test.sh matrix-synapse` (grün, beide Workloads Ready), danach drei Upgrades. Pods per `--field-selector=status.phase=Running` identifiziert, damit kein `Completed`-Seed-Pod mitgemessen wird.

| Schritt | ConfigMap-Hash am Pod-Template | `metadata.generation` | nginx-Pod (UID) |
|---|---|---|---|
| 1. Install | `4608c6c6…` | 1 | `…-c8bc789cb-vf5dr` (`dca1c9a4`) |
| 2. `helm upgrade`, **unveränderte** Werte | `4608c6c6…` | 1 | `dca1c9a4` — **unverändert** |
| 3. `helm upgrade --set ingress.domain=matrix2.ci.local` | `964cb317…` | 2 | `…-64f8d884c6-jw6cf` (`e1afebc8`) — **neu** |

Schritt 2 belegt: kein Neustart ohne Änderung. Schritt 3 belegt: Neustart bei Änderung, sauber über `rollout status` durchgelaufen.

### Gegenprobe — dass es wirklich die Annotation ist

Dieselbe Änderung gegen eine Kopie des Charts, aus der nur die eine Annotationszeile entfernt wurde:

```
$ helm upgrade ci /tmp/ms-noannot ... --set ingress.domain=matrix3.ci.local   # Revision 5
$ kubectl get configmap ci-matrix-synapse-delegation-nginx-configmap -o jsonpath='{.data.nginx\.conf}' | grep -o 'matrix[0-9]*\.ci\.local:443'
matrix3.ci.local:443
$ kubectl get pods --field-selector=status.phase=Running -l app=...-delegation-nginx-deployment
…-6bc9578647-57bss   uid=8c4164cb…      # derselbe Pod wie vor dem Upgrade
$ kubectl exec …-57bss -- grep -o 'matrix[0-9]*\.ci\.local:443' /etc/nginx/nginx.conf
matrix2.ci.local:443
```

Die ConfigMap im Cluster sagt `matrix3`, die Datei **im laufenden Pod** sagt weiter `matrix2`, der Pod ist Ready, `helm upgrade` meldet Erfolg. Das ist der Ausfall aus #82, im Kleinen reproduziert — und mit der Annotation tritt er nicht mehr auf.

## Die Grenze, die bleibt: `homeserver.yaml`

Synapse selbst bekommt seine Konfiguration aus einem `OnePasswordItem`-Secret, ebenfalls per `subPath`. Dafür gibt es **keinen** Hash: Helm sieht den Inhalt nie, das Secret entsteht erst in-cluster durch den Operator. Der operatoreigene Ausweg `operator.1password.io/auto-restart` hilft hier ebenfalls nicht — er startet ausschließlich **Deployments** neu, und Synapse ist ein StatefulSet (am Quellcode von onepassword-operator 1.12.0 verifiziert, Details im homeassistant-PR). Eine Annotation zu setzen, die nichts tut, wäre schlimmer als keine, deshalb steht in der `values.yaml` jetzt die ehrliche Fassung samt Handgriff:

```
kubectl rollout restart statefulset <release>-matrix-synapse-sfs
```

Bekannt ist auch der Weg über einen Reloader-artigen Controller — der Operator zählt beim Aktualisieren die `resourceVersion` des Secrets hoch, darauf ließe sich lauschen. In diesem Cluster läuft kein solcher Controller, und einen einzuführen wäre eine Infrastrukturentscheidung weit jenseits dieses Issues. Hier nur der Vollständigkeit halber genannt, **nicht** als Vorschlag.

## Weitere Verifikation

- `helm lint --strict matrix-synapse` → `1 chart(s) linted, 0 chart(s) failed` (die `[INFO] Missing required value`-Zeilen sind die gewollten `required`-Werte).
- `helm template` mit und ohne `matrix.delegation.enabled`: Ist die Delegation aus, rendert weder ConfigMap noch Deployment — die Annotation kann also nicht ins Leere zeigen.
- Install-Test lokal grün (siehe oben), CI-Ergebnis prüfe ich nach dem Öffnen auf Job-Ebene nach.

Teil von #82 (Strang A). Kein `Fixes`, das Issue umfasst beide Stränge. Als nächstes: samba, dann homeassistant.
