### PR TITLE
samba: Pod bei Änderung der smb.conf neu starten (#82)

### DIFF
--- a/samba/Chart.yaml
+++ b/samba/Chart.yaml
@@ -5,6 +5,6 @@ icon: https://avatars.githubusercontent.com/u/13281359
 
 type: application
 
-version: 4.0.0+up4.23.10
+version: 5.0.0+up4.23.10
 
 appVersion: 4.23.10

--- a/samba/templates/samba.sfs.yaml
+++ b/samba/templates/samba.sfs.yaml
@@ -15,6 +15,16 @@ spec:
       name: {{ .Release.Name }}-{{ .Chart.Name }}-sfs
       labels:
         app: {{ .Release.Name }}-{{ .Chart.Name }}-sfs
+      annotations:
+        # Hash of the rendered ConfigMap: a changed smb.conf (i.e. a changed
+        # samba.shares list) changes the pod template and thus restarts the
+        # pod. Without it a new or renamed share never reaches the running
+        # smbd - smb.conf is mounted with subPath (never refreshed by the
+        # kubelet) and is read once at start.
+        # users.conf is NOT covered: it comes from a 1Password-backed Secret
+        # whose content Helm never sees. See secrets.sambaUsersSecretRef in
+        # values.yaml.
+        checksum/config: {{ include (print $.Template.BasePath "/samba-config.configmap.yaml") . | sha256sum }}
     spec:
       containers:
         - name: {{ .Release.Name }}-{{ .Chart.Name }}-sfs

--- a/samba/values.yaml
+++ b/samba/values.yaml
@@ -5,6 +5,19 @@
 scaleDown: false
 
 secrets:
+  # users.conf is mounted into the samba container from the Secret the 1Password
+  # operator materializes from this item.
+  #
+  # Known limitation (#82): changing the item in the vault does NOT restart
+  # samba, so added, removed or re-passworded users stay invisible to the
+  # running smbd. Helm cannot hash the content (it never sees it - the operator
+  # fills the Secret in-cluster after rendering), so the checksum/config
+  # mechanism used for smb.conf does not apply here. The operator's own
+  # "operator.1password.io/auto-restart" annotation is no help either: it only
+  # ever restarts Deployments, and this workload is a StatefulSet (verified
+  # against onepassword-operator 1.12.0). After changing the users item,
+  # restart samba by hand:
+  #   kubectl rollout restart statefulset <release>-samba-sfs
   sambaUsersSecretRef: null
 
 samba:


### PR DESCRIPTION
## Warum

`smb.conf` wird aus `samba.shares` gerendert und per **`subPath`** gemountet. Eine neue, umbenannte oder anders freigegebene Share schrieb die ConfigMap korrekt neu — und der laufende `smbd` kannte sie trotzdem nicht: Das Pod-Template blieb identisch, also startete nichts neu, und `subPath`-Mounts aktualisiert das Kubelet nie. Für Clients existierte die Share schlicht nicht, während das Release gesund aussah. Dasselbe Muster wie in #82.

Dritter PR der Serie zu #82, Strang A, nach #83 (Guideline) und #86 (matrix-synapse).

## Was drin ist

- **`samba.sfs.yaml`**: `checksum/config` über die gerenderte ConfigMap am Pod-Template.
- **`values.yaml`**: die Grenze bei `users.conf` dokumentiert (siehe unten).
- **Version**: `4.0.0+up4.23.10` → **`5.0.0+up4.23.10`**.

## Kosten des Neustarts

Der samba-Pod startet neu, das **trennt offene SMB-Sitzungen** — laufende Kopiervorgänge brechen ab und müssen neu angestoßen werden. Die Daten der Shares liegen auf PVCs und sind nicht betroffen. Im k3d war der Pod nach wenigen Sekunden wieder Ready; mit dem für dieses Repo etablierten Faktor 3–4 auf Longhorn-Volumes bleibt das im Bereich von Sekunden. Der Preis ist bewusst: Ohne den Neustart wirkte die Share-Änderung überhaupt nicht.

## Korrektur zur Bestandsaufnahme in #82

Die Tabelle im Issue führt für samba `smb.conf` **und** `users.conf` als ConfigMap-Quellen. Tatsächlich kommt `users.conf` aus einem `OnePasswordItem`-Secret (`samba-users.secret.yaml`). samba ist also ein Mischfall: `checksum/config` deckt `smb.conf` ab, `users.conf` fällt unter dieselbe Operator-Grenze wie homeassistant.

## Nachweis: der Hash reagiert genau auf die ConfigMap, sonst nicht

```
# identische Eingabe, zweimal gerendert
checksum/config: 309b162320cb78414d5f03d13d1ca3f40295f03f39f93e347adc74d435c74c6e
checksum/config: 309b162320cb78414d5f03d13d1ca3f40295f03f39f93e347adc74d435c74c6e

# --set 'samba.shares[0].description=changed description'   (steht in smb.conf)
checksum/config: 8903bb25de518e9514e1820f32380aa3f81cdd78dc12312a5a8c838e241a854b

# --set 'samba.replicas=2'                                   (steht NICHT in smb.conf)
checksum/config: 309b162320cb78414d5f03d13d1ca3f40295f03f39f93e347adc74d435c74c6e
```

## Nachweis im laufenden Cluster (k3d)

matrix-synapse hat den Fall für ein **Deployment** belegt; hier kommt der Beleg für eine **StatefulSet**, weil sich die Rollout-Mechanik dort anders anfühlt. Wegwerf-Cluster `checksum-proof-b`, angelegt mit `--kubeconfig-update-default=false --kubeconfig-switch-context=false`, angesprochen über eine eigene `KUBECONFIG` plus explizites `--context k3d-checksum-proof-b`, danach gelöscht; der globale Context blieb unberührt. Installation über `ci/run-install-test.sh samba` (grün), Pods durchgehend per `--field-selector=status.phase=Running` ermittelt.

| Schritt | Hash am Pod-Template | `generation` | Pod-UID |
|---|---|---|---|
| 1. Install | `a1e5bc8d…` | 1 | `5ab5cf82…` |
| 2. `helm upgrade`, **unveränderte** Werte | `a1e5bc8d…` | 1 | `5ab5cf82…` — **unverändert**, `restartCount=0` |
| 3. `helm upgrade --set 'samba.shares[0].description=changed in upgrade'` | `6786be3d…` | 2 | `5849dfa9…` — **neu** |

**Achtung bei der Nachkontrolle**: Der Pod heißt vorher wie nachher `ci-samba-sfs-0` — bei einer StatefulSet bleibt der Name am Ordinal hängen. Nur die **UID** zeigt, dass es ein neuer Pod ist. Wer nach Namen prüft, hält den Neustart für ausgeblieben.

Und der Beleg, dass die neue Konfiguration tatsächlich ankommt:

```
$ kubectl exec ci-samba-sfs-0 -- grep -i comment /etc/samba/smb.conf
  comment = changed in upgrade
```

## Die Grenze, die bleibt: `users.conf`

`users.conf` kommt aus dem 1Password-Tresor. Helm sieht den Inhalt nie — das Secret entsteht erst in-cluster durch den Operator —, also gibt es nichts zu hashen. Der operatoreigene Ausweg `operator.1password.io/auto-restart` hilft hier ebenfalls nicht: Er startet ausschließlich **Deployments** neu, samba ist eine StatefulSet (verifiziert am Quellcode von onepassword-operator 1.12.0; Details im folgenden homeassistant-PR). Eine Annotation, die nichts tut, wäre schlimmer als keine — deshalb steht in der `values.yaml` die ehrliche Fassung: Nach einer Änderung an den Nutzern (neuer Nutzer, entfernter Nutzer, neues Passwort) bleibt der laufende `smbd` auf dem alten Stand, bis man von Hand nachhilft:

```
kubectl rollout restart statefulset <release>-samba-sfs
```

Bekannt ist auch der Weg über einen Reloader-artigen Controller — der Operator zählt beim Aktualisieren die `resourceVersion` des Secrets hoch, darauf ließe sich lauschen. In diesem Cluster läuft kein solcher Controller; ihn einzuführen wäre eine Infrastrukturentscheidung weit jenseits dieses Issues. Nur der Vollständigkeit halber genannt, **nicht** als Vorschlag.

## Weitere Verifikation

- `helm lint --strict samba` → `1 chart(s) linted, 0 chart(s) failed` (die `[INFO] Missing required value`-Zeilen sind die gewollten `required`-Werte).
- `ci/run-install-test.sh samba` lokal grün (siehe oben), CI-Ergebnis prüfe ich nach dem Öffnen auf Job-Ebene nach.

Teil von #82 (Strang A). Kein `Fixes`, das Issue umfasst beide Stränge. Als nächstes und letztes in diesem Strang: homeassistant.
