### PR TITLE
Restart the server when its config changes (minecraft-server 3.0.0+up2026.8.2.java8)

### DIFF
--- a/minecraft-server/Chart.yaml
+++ b/minecraft-server/Chart.yaml
@@ -13,8 +13,8 @@ type: application
 # continuously, so a pod restart could pull a different image than the last one
 # without anything being recorded anywhere. The dated tags are immutable, so the
 # image is now pinned by the chart version like every other chart in this repo.
-version: 2.0.0+up2026.8.2.java21
-appVersion: "2026.8.2-java21"
+version: 3.0.0+up2026.8.2.java8
+appVersion: "2026.8.2-java8"
 
 maintainers:
   - name: jklein

--- a/minecraft-server/templates/minecraft-server.sfs.yaml
+++ b/minecraft-server/templates/minecraft-server.sfs.yaml
@@ -15,6 +15,23 @@ spec:
     metadata:
       labels:
         app: {{ .Release.Name }}-{{ .Chart.Name }}-sfs
+      annotations:
+        # Rolls the pod whenever the rendered ConfigMap changes. init.sh is
+        # mounted with subPath (kubelet never refreshes those in a running
+        # container) and the init container only reads it at pod start, so
+        # without this a changed download URL or working directory would stay
+        # inert while the release still reported success.
+        checksum/config: {{ include (print $.Template.BasePath "/minecraft-server.configmap.yaml") . | sha256sum }}
+        # Deliberately a SEPARATE annotation, and deliberately NOT a hash of the
+        # secret's content: the Kubernetes Secret is materialized by the
+        # 1Password operator, so Helm never sees what is in it. This hash covers
+        # the rendered OnePasswordItem, i.e. the op:// item path - repointing
+        # secrets.minecraftServerRef at a different item now takes effect
+        # instead of silently leaving the old credentials in the running pod.
+        # A change of the item's CONTENT inside the vault is not covered; see
+        # the comment on secrets in values.yaml for why that gap cannot be
+        # closed here and what it means operationally.
+        checksum/secret-ref: {{ include (print $.Template.BasePath "/minecraft-server.secret.yaml") . | sha256sum }}
     spec:
       automountServiceAccountToken: false
       securityContext:

--- a/minecraft-server/values.yaml
+++ b/minecraft-server/values.yaml
@@ -8,6 +8,26 @@ secrets:
   # op:// item path for the 1Password operator. Only needs to carry a
   # "curseforge-api-key" key when curseforge.enabled is true and an
   # "rcon-password" key when server.rcon.enabled is true.
+  #
+  # Documented limit (chart 3.0.0): changing this path rolls the pod (the
+  # StatefulSet hashes the rendered OnePasswordItem into checksum/secret-ref),
+  # but changing the item's CONTENT in the vault does not. The operator updates
+  # the Kubernetes Secret, while the running pod keeps the values it read at
+  # startup - the keys are consumed as environment variables, which Kubernetes
+  # never refreshes in a running container.
+  #
+  # The operator's own "operator.1password.io/auto-restart: true" annotation
+  # does NOT close this gap here, and is therefore deliberately not set: it only
+  # restarts Deployments. Verified in the operator source (main, 9c3b1b9,
+  # 2026-08-11): restartWorkloadsWithUpdatedSecrets lists nothing but
+  # appsv1.DeploymentList, and getPodTemplate has a single case for
+  # *appsv1.Deployment and returns "unsupported type" for everything else. This
+  # chart is a StatefulSet, so the annotation would do nothing while suggesting
+  # the opposite.
+  #
+  # So after rotating rcon-password or curseforge-api-key in the vault, restart
+  # the workload by hand (kubectl rollout restart statefulset/...) - and expect
+  # the full startup cost of ~124 s measured for ftb-skies on Longhorn.
   minecraftServerRef: null
 
 server:
@@ -206,8 +226,8 @@ minecraft:
   # This value must match the Java line of the chart version: the image tag
   # comes from .Chart.AppVersion, so the JVM is fixed per published chart
   # version. Java 8 runs Minecraft up to 1.16.5, 1.18-1.20.4 need Java 17 and
-  # 1.20.5+ need Java 21. This chart publishes appVersion "2026.8.2-java21".
-  version: "1.21.1"
+  # 1.20.5+ need Java 21. This chart publishes appVersion "2026.8.2-java8".
+  version: "1.12.2"
 
 # curseforge, ftb and curseforgeServerpack are mutually exclusive - enabling
 # more than one is rejected by the chart (before 1.0.0 it silently rendered a
@@ -227,5 +247,10 @@ ftb:
   versionId: null
 curseforgeServerpack:
   enabled: false
+  # Both values below are rendered into the init.sh ConfigMap. Since chart 3.0.0
+  # a change here rolls the pod (checksum/config on the StatefulSet), which is
+  # what makes it take effect at all - init.sh is mounted with subPath and only
+  # read at pod start. The restart is not free: ~124 s measured for ftb-skies on
+  # Longhorn.
   downloadUrl: null
   workingDirectory: '/data/serverpack'


### PR DESCRIPTION
Erste von drei Veröffentlichungen für minecraft-server (java8 → java17 → java21), damit `main` am Ende auf der java21-Linie ruht — der Linie des einzigen laufenden Servers.

## Was sich ändert

Der StatefulSet trägt jetzt **zwei** Annotationen, eine je Konfigurationsquelle:

```yaml
checksum/config:     {{ include (print $.Template.BasePath "/minecraft-server.configmap.yaml") . | sha256sum }}
checksum/secret-ref: {{ include (print $.Template.BasePath "/minecraft-server.secret.yaml") . | sha256sum }}
```

**Warum zwei statt einem kombinierten Hash.** Die beiden Quellen geben unterschiedlich starke Zusagen, und ein einziger Wert würde diesen Unterschied unsichtbar machen:

- `checksum/config` ist **vollständig**: Helm sieht den gesamten ConfigMap-Inhalt (`init.sh`), jede Änderung ist erfasst.
- `checksum/secret-ref` ist **bewusst unvollständig**: gehasht wird die gerenderte `OnePasswordItem`-Ressource, also der `op://`-Pfad — nicht der Inhalt, den Helm zur Render-Zeit prinzipiell nicht kennt.

In einem `kubectl describe` ist damit ablesbar, *warum* ein Pod gerollt ist. Ein gemeinsamer Hash wäre eine Zahl, die „alles erfasst" und „nur den Pfad erfasst" zu etwas verschmilzt, das niemand mehr interpretieren kann.

Der Gewinn beim Secret ist real, nicht kosmetisch: `secrets.minecraftServerRef` auf ein anderes Item umzubiegen wirkte bisher gar nicht — der Operator schrieb das Kubernetes-Secret neu, der laufende Pod behielt die alten Werte. Das ist jetzt abgedeckt.

## Zur README-Guideline §9 (aus #86)

Die frisch gelandete Guideline sagt: Secrets aus `OnePasswordItem` können den Mechanismus nicht nutzen, weil Helm ihren Inhalt nicht sieht — die Grenze ist in `values.yaml` zu dokumentieren. Das steht hier nicht im Widerspruch: gehasht wird **nicht** der Inhalt (unmöglich), sondern nur der Pfad, und die verbleibende Lücke ist genau wie gefordert in `values.yaml` dokumentiert. Der Rest der Guideline ist eingehalten (`checksum/config` ohne Suffix, weil es genau eine ConfigMap gibt). Falls die Einheitlichkeit über den Zugewinn geht, nehme ich `checksum/secret-ref` auf Zuruf wieder heraus.

## `operator.1password.io/auto-restart` ist bewusst NICHT gesetzt

Geprüft, nicht vermutet — im Quellcode des Operators (`main`, Commit `9c3b1b9` vom 2026-08-11):

- `restartWorkloadsWithUpdatedSecrets` in `pkg/onepassword/secret_update_handler.go` iteriert über eine Liste, die **ausschließlich** `&appsv1.DeploymentList{}` enthält.
- `getPodTemplate` hat genau einen Fall, `case *appsv1.Deployment:`, und liefert für alles andere `fmt.Errorf("unsupported type %T", obj)`.
- Im gesamten Repo kommt der String `StatefulSet` in keiner einzigen `.go`-Datei vor.

Der Auto-Restart greift also bei StatefulSets nachweislich nicht. Dieser Chart **ist** ein StatefulSet — die Annotation wäre wirkungslos und würde Sicherheit vortäuschen, was laut #82 schlimmer wäre als gar nichts. Sie bleibt draußen; stattdessen benennt `values.yaml` die Grenze und den Handgriff (`kubectl rollout restart statefulset/...` nach einer Rotation im Tresor).

## Major-Bump und sein Preis

Eine Konfigurationsänderung kostet ab jetzt einen vollen Serverneustart: **124 s gemessen für ftb-skies auf Longhorn**. Genau dafür ist die Änderung da — vorher war die Konfigurationsänderung wirkungslos —, aber der Preis gehört benannt. Er steht auch in `values.yaml` an beiden betroffenen Stellen.

## Nachweis 1: Die Hashes lösen weder zu selten noch zu oft aus

`helm template`, Basis `ci/minecraft-server/test-values.yaml`:

| Variante | `checksum/config` | `checksum/secret-ref` |
|---|---|---|
| Basis | `d30d2a48291d…` | `5fdd97cb8edd…` |
| zweiter Lauf, unverändert | `d30d2a48291d…` **gleich** | `5fdd97cb8edd…` **gleich** |
| `curseforgeServerpack.downloadUrl` geändert | `6bf8347b8837…` **neu** | `5fdd97cb8edd…` gleich |
| `curseforgeServerpack.workingDirectory` geändert | `24968063a5ca…` **neu** | `5fdd97cb8edd…` gleich |
| `secrets.minecraftServerRef` umgebogen | `d30d2a48291d…` gleich | `d836945e4300…` **neu** |
| `minecraft.management.maxPlayers=20` | gleich | gleich |
| `server.rcon.enabled=true` | gleich | gleich |
| `ftb.enabled=true` | gleich | gleich |
| `scaleDown=true` | gleich | gleich |

Die beiden Annotationen bewegen sich also sauber getrennt: ConfigMap-Eingaben nur die eine, der Item-Pfad nur die andere, unbeteiligte Werte keine von beiden. Identische Eingabe → identischer Hash, also kein Neustart bei jedem `helm upgrade`.

## Nachweis 2: Der StatefulSet rollt tatsächlich — im k3d nachgewiesen

Ein StatefulSet ist kein Deployment, deshalb nicht nur gerendert, sondern in einem echten Cluster geprüft. Wegwerf-Cluster `mcserver-checksum-b`, angelegt mit `--kubeconfig-switch-context=false`, alle Aufrufe mit explizitem `--context`, danach gelöscht; der globale Context blieb durchgehend `jk-cluster`. Fixtures wie in CI (`ci/common/`, `ci/minecraft-server/fixtures.yaml`, `test-values.yaml`).

Weil ein StatefulSet-Pod seinen Namen behält (`ci-minecraft-server-sfs-0`), ist die **Pod-UID** das Merkmal:

| Schritt | Pod-UID | `checksum/config` | `checksum/secret-ref` |
|---|---|---|---|
| Install (Rev 1) | `c72b1051-…` | `d30d2a48…` | `5fdd97cb…` |
| `upgrade` **ohne Änderung** (Rev 2) | `c72b1051-…` **unverändert**, `restartCount 0` | `d30d2a48…` | `5fdd97cb…` |
| `upgrade` mit geänderter `downloadUrl` (Rev 3) | `d3346302-…` **neuer Pod** | `75a7a5af…` **neu** | `5fdd97cb…` |
| `upgrade` mit umgebogener `minecraftServerRef` (Rev 4) | `abd1fb76-…` **neuer Pod** | `75a7a5af…` unverändert | `26066957…` **neu** |

Die StatefulSet-Revision zog jeweils mit (`currentRevision …-7785cff878` → `updateRevision …-fccf44548`), und es existieren genau **drei** ControllerRevisions — der No-Op-Upgrade hat keine erzeugt. Der letzte Schritt zeigt den Punkt am deutlichsten: Der Pod wurde **allein** wegen der Secret-Pfad-Annotation neu erstellt, bei unverändertem ConfigMap-Hash.

Zur Einordnung der Kosten: Der Neustart dauerte im k3d rund 19 s — das ist ein Vanilla-1.12.2-Server auf einem hostPath-Volume und **kein** Vorhersagewert für Produktion. Maßgeblich bleibt der real gemessene Wert von 124 s für ftb-skies auf Longhorn.

## Verifikation

- `helm lint --strict minecraft-server` → 0 chart(s) failed, mit und ohne `ci/`-Werte.
- `helm template` in neun Varianten (Tabelle oben), inklusive aktiviertem Serverpack-Init-Container, FTB-Modus und `scaleDown`.
- Vollständiger Install- und Upgrade-Zyklus im k3d (Tabelle oben).

## Java-Linie

Nur die veröffentlichte Linie unterscheidet die drei PRs; der Chart-Inhalt ist identisch. Hier: `appVersion: 2026.8.2-java8` und der passende Default `minecraft.version: "1.12.2"` (Java 8 läuft bis 1.16.5).

Teil von #82 (Strang B, PR 2 von 4). Das Issue umfasst beide Stränge und bleibt offen.
