### PR TITLE
Update minecraft-server to the java17 line (3.0.0+up2026.8.2.java17)

### DIFF
--- a/minecraft-server/Chart.yaml
+++ b/minecraft-server/Chart.yaml
@@ -13,8 +13,8 @@ type: application
 # continuously, so a pod restart could pull a different image than the last one
 # without anything being recorded anywhere. The dated tags are immutable, so the
 # image is now pinned by the chart version like every other chart in this repo.
-version: 3.0.0+up2026.8.2.java8
-appVersion: "2026.8.2-java8"
+version: 3.0.0+up2026.8.2.java17
+appVersion: "2026.8.2-java17"
 
 maintainers:
   - name: jklein

--- a/minecraft-server/values.yaml
+++ b/minecraft-server/values.yaml
@@ -226,8 +226,8 @@ minecraft:
   # This value must match the Java line of the chart version: the image tag
   # comes from .Chart.AppVersion, so the JVM is fixed per published chart
   # version. Java 8 runs Minecraft up to 1.16.5, 1.18-1.20.4 need Java 17 and
-  # 1.20.5+ need Java 21. This chart publishes appVersion "2026.8.2-java8".
-  version: "1.12.2"
+  # 1.20.5+ need Java 21. This chart publishes appVersion "2026.8.2-java17".
+  version: "1.20.1"
 
 # curseforge, ftb and curseforgeServerpack are mutually exclusive - enabling
 # more than one is rejected by the chart (before 1.0.0 it silently rendered a


### PR DESCRIPTION
Zweite von drei Veröffentlichungen für minecraft-server. Inhaltlich identisch zu [#88](https://github.com/jk-cluster/helm-charts/pull/88) (`3.0.0+up2026.8.2.java8`) — es wechselt **nur die veröffentlichte Java-Linie**:

- `appVersion`: `2026.8.2-java8` → `2026.8.2-java17` (dated, immutable)
- `version`: `3.0.0+up2026.8.2.java8` → `3.0.0+up2026.8.2.java17`
- `minecraft.version`-Default: `1.12.2` → `1.20.1` (Java 8 läuft bis 1.16.5, 1.18–1.20.4 brauchen Java 17, 1.20.5+ Java 21)

Der Diff ist vier Zeilen in zwei Dateien — exakt derselbe Umfang wie beim historischen Linienwechsel `0b3ea77`. An den Templates ändert sich nichts.

## Was dieser Chart-Stand mitbringt

Die beiden Annotationen aus #88, hier nur der Vollständigkeit halber:

- `checksum/config` über die ConfigMap (`init.sh`) — vollständig, Helm sieht den ganzen Inhalt.
- `checksum/secret-ref` über die gerenderte `OnePasswordItem`-Ressource — bewusst nur der `op://`-Pfad. Ein geänderter Secret-**Inhalt** bei gleichem Pfad rollt weiterhin nichts; diese Grenze ist in `values.yaml` dokumentiert, samt des nötigen Handgriffs nach einer Rotation im Tresor.

`operator.1password.io/auto-restart` bleibt bewusst ungesetzt: Der Operator restartet nachweislich nur Deployments (`restartWorkloadsWithUpdatedSecrets` listet ausschließlich `appsv1.DeploymentList`, `getPodTemplate` hat genau einen `case *appsv1.Deployment`), dieser Chart ist ein StatefulSet.

## Major-Bump und Preis

Weiterhin **major** aus demselben Grund wie #88: Eine Konfigurationsänderung führt jetzt zu einem Neustart. Für die java17-Linie gilt derselbe gemessene Preis — **124 s** für ftb-skies auf Longhorn.

## Verifikation

- `helm lint --strict minecraft-server` → 0 chart(s) failed, mit und ohne `ci/`-Werte.
- `helm template` gegen `ci/minecraft-server/test-values.yaml`: Das Image zieht auf `itzg/minecraft-server:2026.8.2-java17`, und beide Checksummen sind unverändert gegenüber #88 (`d30d2a48…` / `5fdd97cb…`) — der Linienwechsel berührt weder ConfigMap noch Secret-Pfad, wie er soll.
- Der Wirknachweis der Annotationen (neun `helm template`-Varianten plus vollständiger Install-/Upgrade-Zyklus im k3d mit Pod-UID- und ControllerRevision-Beleg) steht in #88 und gilt unverändert, da die Templates identisch sind.

Teil von #82 (Strang B, PR 3 von 4). Das Issue umfasst beide Stränge und bleibt offen.
