### PR TITLE
cyberchef: strict values.schema.json (Welle 1, #68)

### DIFF
--- a/cyberchef/Chart.yaml
+++ b/cyberchef/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://raw.githubusercontent.com/gchq/CyberChef/master/src/web/static/ima
 
 type: application
 
-version: 6.0.0+up11.4.0
+version: 7.0.0+up11.4.0
 appVersion: "11.4.0"
 
 maintainers:

--- a/cyberchef/values.schema.json
+++ b/cyberchef/values.schema.json
@@ -1,0 +1,161 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "cyberchef values",
+  "description": "Strict values schema (issue #68). additionalProperties is false on every chart-owned object level, so a key that the chart does not read is rejected at render time instead of being silently ignored. The only objects that stay open are the ones passed verbatim into the Kubernetes pod spec (probes, security contexts, global) - the chart does not interpret their contents, so it cannot judge which keys are meaningful.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "global": {
+      "description": "Helm's conventional cross-chart values. Unused by this chart, kept open so an umbrella install cannot break on it.",
+      "type": "object"
+    },
+    "scaleDown": {
+      "type": "boolean"
+    },
+    "cyberchef": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "replicas": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "securityContext": {
+          "$ref": "#/definitions/securityContext"
+        },
+        "livenessProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "readinessProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "startupProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "env": {
+          "$ref": "#/definitions/env"
+        },
+        "resources": {
+          "$ref": "#/definitions/resources"
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "clusterIssuer": {
+          "type": ["string", "null"]
+        },
+        "domain": {
+          "type": ["string", "null"]
+        },
+        "className": {
+          "type": ["string", "null"]
+        },
+        "annotations": {
+          "description": "Extra Ingress annotations, merged with the cert-manager annotation the chart always sets. Free-form keys by nature.",
+          "type": "object"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "resources": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "limitFactor": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "requests": {
+          "$ref": "#/definitions/resourceList"
+        },
+        "limits": {
+          "$ref": "#/definitions/resourceList"
+        }
+      }
+    },
+    "resourceList": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "cpu": {
+          "type": ["string", "number", "null"]
+        },
+        "memory": {
+          "type": ["string", "number", "null"]
+        },
+        "ephemeral-storage": {
+          "type": ["string", "number", "null"]
+        },
+        "ephemeralStorage": {
+          "type": ["string", "number", "null"]
+        }
+      }
+    },
+    "env": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "valueFrom": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "secretKeyRef": {
+                "$ref": "#/definitions/keyRef"
+              },
+              "configMapKeyRef": {
+                "$ref": "#/definitions/keyRef"
+              }
+            }
+          }
+        }
+      }
+    },
+    "keyRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "key"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        }
+      }
+    },
+    "securityContext": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "pod": {
+          "description": "Rendered verbatim as the pod's securityContext; kept open because the chart does not interpret it.",
+          "type": "object"
+        },
+        "container": {
+          "description": "Rendered verbatim as the container's securityContext; kept open because the chart does not interpret it.",
+          "type": "object"
+        }
+      }
+    },
+    "probe": {
+      "description": "Rendered verbatim as a container probe; kept open because the chart does not interpret it.",
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
Erstes Chart der **Welle 1** aus #68 (klein: cyberchef, gotenberg, apache-tika, patchmon, urlaubsverwaltung). Muster ist der abgenommene Pilot `minecraft-server`.

## Was drin ist

- `cyberchef/values.schema.json`: `additionalProperties: false` auf **allen chart-eigenen Objektebenen** — oberste Ebene, `cyberchef`, `cyberchef.resources`, `.requests`/`.limits`, `env[]`, `env[].valueFrom`, `.secretKeyRef`/`.configMapKeyRef`, `securityContext`, `ingress`.
- **Offen bleiben** die Objekte, die wörtlich in die Pod-Spec durchgereicht werden: `livenessProbe`/`readinessProbe`/`startupProbe`, `securityContext.pod`, `securityContext.container`, `global` sowie `ingress.annotations` (freie Annotation-Keys per Natur).
- Chart-Version **6.0.0 → 7.0.0** (major, appVersion unverändert bei 11.4.0). Ein Schema kann bestehende Deployments brechen — keine additive Änderung, auch wenn kein Template angefasst wurde.

Das Schema **ergänzt** die `required()`-Aufrufe im Ingress-Template, es ersetzt sie nicht.

## Verifikation

**Lint**

```
$ helm lint --strict cyberchef
1 chart(s) linted, 0 chart(s) failed
```

(Die drei `[INFO] Missing required value`-Zeilen sind vorbestehend: `helm lint` rendert nach einem fehlenden `required`-Wert weiter, weil `ingress.domain`/`ingress.clusterIssuer` keine Defaults haben. Keine Findings, kein Fehler.)

**Rendern**

| Fall | Ergebnis |
|---|---|
| Default-Values ohne Ingress-Werte | scheitert an `required()` wie vor dieser Änderung (unverändertes Verhalten, nicht schemabedingt) |
| `--set ingress.domain=… --set ingress.clusterIssuer=…` | rendert |
| `ci/cyberchef/test-values.yaml` | rendert |
| Bundle-Werte `fleet-cd/cyberchef/cyberchef.values.yaml` | rendert |

**Negativprobe — beide Ebenen werden abgewiesen**

Oberste Ebene:

```
$ helm template t cyberchef --set ingress.domain=example.com \
    --set ingress.clusterIssuer=letsencrypt --set bogusTopLevel=true
Error: values don't meet the specifications of the schema(s) in the following chart(s):
cyberchef:
- at '': additional properties 'bogusTopLevel' not allowed
```

Tief verschachtelt (dritte Ebene, `cyberchef.resources.requests`):

```
$ helm template t cyberchef --set ingress.domain=example.com \
    --set ingress.clusterIssuer=letsencrypt --set cyberchef.resources.requests.bogusCpu=1
Error: values don't meet the specifications of the schema(s) in the following chart(s):
cyberchef:
- at '/cyberchef/resources/requests': additional properties 'bogusCpu' not allowed
```

Damit ist belegt, dass `additionalProperties: false` nicht nur oben greift.

## Validierung gegen die real ausgerollten Werte

Bundle `fleet-cd/cyberchef/` (pinnt aktuell `5.0.0+up11.4.0`), zusätzlich gegen den Live-Stand geprüft:

```
$ helm get values cyberchef -n cyberchef
ingress:
  clusterIssuer: letsencrypt-issuer
  domain: cyberchef.jk-dev.de
  enabled: true
```

**Liste abgewiesener Schlüssel: leer.** Bundle-Datei und ausgerollter Stand sind deckungsgleich und validieren beide. Für die Cluster-Seite ist vor dem Hochziehen auf `7.0.0` bei diesem Chart **nichts zu bereinigen**.

## Nebenbefund (nicht in diesem PR behoben)

`ingress.enabled` steht in `cyberchef/values.yaml`, wird vom Ingress-Template aber **nicht ausgewertet** — anders als in `urlaubsverwaltung`, `outline` und `template-chart`, die mit `{{- if .Values.ingress.enabled }}` beginnen. `ingress.enabled: false` schaltet den Ingress hier also nicht ab, sondern rendert ihn trotzdem; es steht auch so in den produktiven Bundle-Werten (dort auf `true`, deshalb heute folgenlos).

Das Schema kann den Schlüssel nicht abweisen, weil er in den Chart-Defaults steht. Die Korrektur ist eine Verhaltensänderung am Template und gehört nicht in diesen PR — ich melde sie an den Manager zur Ablage als eigenes Issue.

Refs #68 (das Issue umfasst alle drei Wellen und bleibt offen).
