### PR TITLE
Update minecraft-server to the java21 line (3.0.0+up2026.8.2.java21)

### DIFF
--- a/minecraft-server/Chart.yaml
+++ b/minecraft-server/Chart.yaml
@@ -13,8 +13,8 @@ type: application
 # continuously, so a pod restart could pull a different image than the last one
 # without anything being recorded anywhere. The dated tags are immutable, so the
 # image is now pinned by the chart version like every other chart in this repo.
-version: 3.0.0+up2026.8.2.java17
-appVersion: "2026.8.2-java17"
+version: 3.0.0+up2026.8.2.java21
+appVersion: "2026.8.2-java21"
 
 maintainers:
   - name: jklein

--- a/minecraft-server/values.yaml
+++ b/minecraft-server/values.yaml
@@ -226,8 +226,8 @@ minecraft:
   # This value must match the Java line of the chart version: the image tag
   # comes from .Chart.AppVersion, so the JVM is fixed per published chart
   # version. Java 8 runs Minecraft up to 1.16.5, 1.18-1.20.4 need Java 17 and
-  # 1.20.5+ need Java 21. This chart publishes appVersion "2026.8.2-java17".
-  version: "1.20.1"
+  # 1.20.5+ need Java 21. This chart publishes appVersion "2026.8.2-java21".
+  version: "1.21.1"
 
 # curseforge, ftb and curseforgeServerpack are mutually exclusive - enabling
 # more than one is rejected by the chart (before 1.0.0 it silently rendered a


### PR DESCRIPTION
Letzte von drei Veröffentlichungen für minecraft-server. Damit ruht `main` wieder auf der **java21-Linie** — der Linie des einzigen laufenden Servers (ftb-skies-2). Inhaltlich identisch zu [#88](https://github.com/jk-cluster/helm-charts/pull/88) und [#89](https://github.com/jk-cluster/helm-charts/pull/89), es wechselt nur die veröffentlichte Java-Linie:

- `appVersion`: `2026.8.2-java17` → `2026.8.2-java21` (dated, immutable)
- `version`: `3.0.0+up2026.8.2.java17` → `3.0.0+up2026.8.2.java21`
- `minecraft.version`-Default: `1.20.1` → `1.21.1` (die Version, die ftb-skies-2 tatsächlich fährt)

Vier Zeilen in zwei Dateien, an den Templates ändert sich nichts.

## Gegenprobe: der Endzustand gegen den Stand vor dieser Serie

Diff gegen `b41cc6e` (`2.0.0+up2026.8.2.java21`, der Stand vor Strang B) über `Chart.yaml` und `values.yaml`. Die **einzige ersetzte Zeile** ist die Chart-Version:

```
-version: 2.0.0+up2026.8.2.java21
+version: 3.0.0+up2026.8.2.java21
```

`appVersion` und der `minecraft.version`-Default sind byte-identisch zu vorher, alles Übrige ist rein additiv (die zwei Annotationen und die Kommentare). Die Serie landet also exakt auf derselben Java-Linie wie zuvor — nur mit der Korrektur und dem Major-Bump.

## Checksummen-Gegenprobe, jetzt für alle drei Linien

Wie in #89: `helm template` gegen `ci/minecraft-server/test-values.yaml` zieht das Image auf `itzg/minecraft-server:2026.8.2-java21`, und **beide Checksummen bleiben unverändert** — `checksum/config: d30d2a48…`, `checksum/secret-ref: 5fdd97cb…`, identisch zu java8 und java17.

Das ist ein beiläufiger, aber belastbarer Zusatzbeleg: Chart-Version, appVersion und der Minecraft-Default haben sich geändert, das gerenderte Image ebenso — und die Annotationen haben sich trotzdem nicht bewegt. Sie hängen nachweislich nur an ihren jeweiligen Quellen und springen nicht bei jedem Rendern an. Damit steht diese Probe für alle drei veröffentlichten Linien.

## Was dieser Chart-Stand mitbringt

- `checksum/config` über die ConfigMap (`init.sh`) — vollständig, Helm sieht den ganzen Inhalt.
- `checksum/secret-ref` über die gerenderte `OnePasswordItem`-Ressource — bewusst nur der `op://`-Pfad. Ein geänderter Secret-**Inhalt** bei gleichem Pfad rollt weiterhin nichts; die Grenze und der nötige Handgriff nach einer Rotation stehen in `values.yaml`.
- `operator.1password.io/auto-restart` bleibt ungesetzt: Der Operator restartet nachweislich nur Deployments, dieser Chart ist ein StatefulSet.

## Major-Bump und Preis

Weiterhin **major**: Eine Konfigurationsänderung führt jetzt zu einem Neustart. Für diese Linie ist der Preis der real gemessene — **124 s** für ftb-skies auf Longhorn. Die Cluster-Seite muss das beim Hochziehen einplanen.

## Verifikation

- `helm lint --strict minecraft-server` → 0 chart(s) failed, mit und ohne `ci/`-Werte.
- `helm template` gegen die CI-Werte (siehe Gegenprobe oben).
- Der Wirknachweis der Annotationen — neun `helm template`-Varianten plus vollständiger Install-/Upgrade-Zyklus im k3d mit Pod-UID- und ControllerRevision-Beleg — steht in #88 und gilt unverändert, da die Templates identisch sind.

Teil von #82 (Strang B, PR 4 von 4). Damit ist Strang B abgeschlossen; das Issue umfasst beide Stränge und bleibt offen.
