### PR TITLE
homeassistant: Secret-Verweis abdecken, Inhalts-Lücke dokumentieren (#82)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,15 @@ These guidelines are **binding for every current and future chart** in this repo
 - **The annotation is content-based, not time-based**: the hash is taken over the rendered ConfigMap, so an unchanged config renders an identical hash and `helm upgrade` is a no-op. It never degenerates into a restart-on-every-upgrade.
 - Adding the annotation to an existing chart is a **major** bump (§2): runtime behavior changes — a config change now costs a restart. Name that cost in the PR (some workloads take minutes to come back).
 - **Secrets from `OnePasswordItem` cannot use this mechanism.** Helm never sees their content — the 1Password operator fills the Secret in-cluster after rendering, so there is nothing to hash. A chart that mounts such a Secret as a file documents the limitation in its `values.yaml` where it cannot close the gap.
+- **What *can* be covered is the secret's `op://` path**, via a **separately named** `checksum/secret-ref` annotation over the rendered `OnePasswordItem`:
+
+  ```yaml
+  checksum/secret-ref: {{ include (print $.Template.BasePath "/<chart>.secret.yaml") . | sha256sum }}
+  ```
+
+  Repointing `secrets.<name>SecretRef` at a different vault item then takes effect instead of silently leaving the old credentials in the running pod. The separate name is deliberate: `checksum/config` promises "the config changed", `checksum/secret-ref` only "the config *source* changed" — merging them into one annotation would overstate the weaker guarantee. Reference implementations: `minecraft-server`, `homeassistant`.
+- **`operator.1password.io/auto-restart` only works for Deployments — do not set it on a StatefulSet.** Verified against onepassword-operator **1.12.0** (`pkg/onepassword/secret_update_handler.go`): `restartWorkloadsWithUpdatedSecrets` enumerates exactly one workload type, `appsv1.DeploymentList`, and `getPodTemplate` accepts only `*appsv1.Deployment`. The RBAC role grants `statefulsets`, and v1.11.0 generalized the restart code (`restartWorkload`, pod-template stamping via `operator.1password.io/last-restarted`), but the PR that would add StatefulSets is still open — so the annotation on a StatefulSet is a silent no-op. Setting it there is **worse than not setting it**: it advertises a guarantee that does not exist. Affected charts (`matrix-synapse`, `samba`, `homeassistant`) instead document the manual `kubectl rollout restart statefulset <release>-<chart>-sfs`. Re-check this when the operator version is bumped; a Deployment-based chart may set the annotation.
+- If a Deployment-based chart ever does set it, mind the precedence: the annotation on the **`OnePasswordItem`** is copied onto the Kubernetes Secret and read first, so a `false` there **overrides** a `true` on the workload — the opposite of what the operator's usage guide suggests. Lookup order is Secret (from the `OnePasswordItem`) → workload → namespace → the operator-global `AUTO_RESTART` env var. The trigger is the 1Password item's **version counter**, not its content, so a re-save with identical values still restarts.
 
 ### 10. Environment variables
 

--- a/homeassistant/Chart.yaml
+++ b/homeassistant/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to deploy Home Assistant on Kubernetes
 icon: https://www.home-assistant.io/images/home-assistant-logo.svg
 type: application
 
-version: 4.2.0+up2026.8.3
+version: 5.0.0+up2026.8.3
 
 appVersion: "2026.8.3"
 

--- a/homeassistant/templates/homeassistant.sfs.yaml
+++ b/homeassistant/templates/homeassistant.sfs.yaml
@@ -15,6 +15,18 @@ spec:
       labels:
         app: "{{ .Release.Name }}-{{ .Chart.Name }}"
       name: "{{ .Release.Name }}-{{ .Chart.Name }}-sfs"
+      annotations:
+        # Deliberately NOT a hash of the secret's content: the Kubernetes Secret
+        # is materialized by the 1Password operator, so Helm never sees what is
+        # in it. This hash covers the rendered OnePasswordItem, i.e. the op://
+        # item path - repointing secrets.configSecretRef at a different item now
+        # takes effect instead of silently leaving the old configuration in the
+        # running pod. A change of the item's CONTENT inside the vault is not
+        # covered; see the comment on secrets in values.yaml for why that gap
+        # cannot be closed here and what it means operationally.
+        # The name differs from checksum/config on purpose - that one promises
+        # "the config changed", this one only "the config source changed".
+        checksum/secret-ref: {{ include (print $.Template.BasePath "/homeassistant-core-config.secret.yaml") . | sha256sum }}
     spec:
       automountServiceAccountToken: false
       securityContext:

--- a/homeassistant/values.yaml
+++ b/homeassistant/values.yaml
@@ -122,5 +122,32 @@ core:
 # - config
 # - http-config
 # - recorder-config
+#
+# Changing the op:// path below IS covered: the StatefulSet carries a
+# checksum/secret-ref annotation over the rendered OnePasswordItem, so pointing
+# this value at a different vault item restarts the pod.
+#
+# Known limitation (#82): changing the CONTENT of that item in the vault does
+# NOT restart Home Assistant. The operator updates the Kubernetes Secret, but
+# the running pod keeps the old files - they are mounted with subPath, which the
+# kubelet never refreshes, and Home Assistant reads its configuration only at
+# start. The change then takes effect at some unrelated later restart, possibly
+# months afterwards, and a broken value surfaces long after the edit that caused
+# it. That is especially likely for this release, which is currently kept at
+# zero replicas via scaleDown: whoever brings it back up gets whatever the vault
+# holds at that moment.
+#
+# The checksum/config mechanism the other charts use cannot close this gap:
+# Helm never sees the content (the operator fills the Secret in-cluster after
+# rendering), so there is nothing to hash. The operator's own
+# "operator.1password.io/auto-restart" annotation does not close it either - it
+# only ever restarts Deployments, never StatefulSets. Verified against
+# onepassword-operator 1.12.0: pkg/onepassword/secret_update_handler.go lists
+# exactly one workload type (appsv1.DeploymentList), and the PR adding
+# StatefulSets is still open. Setting the annotation here would look like a fix
+# and do nothing, so this chart deliberately does not set it.
+#
+# After changing the item, restart Home Assistant by hand:
+#   kubectl rollout restart statefulset <release>-homeassistant-sfs
 secrets:
   configSecretRef: null


### PR DESCRIPTION
> **Zur Version, weil ich mich in diesem Punkt selbst korrigiere:** Ich hatte hier zunächst einen **Patch**-Bump angesetzt und abgestimmt, weil das Chart weder ConfigMap noch Annotation bekommen sollte — reine Dokumentation, gerenderte Manifeste byte-identisch. Nachdem ich das `checksum/secret-ref`-Muster aus minecraft-server übernommen habe (siehe unten), stimmt diese Begründung nicht mehr: Es gibt jetzt eine echte, wenn auch schmale Verhaltensänderung. Deshalb doch **Major**: `4.2.0+up2026.8.3` → **`5.0.0+up2026.8.3`**.

## Zwei Lücken, von denen sich nur eine schließen lässt

Home Assistant liest `configuration.yaml`, `http-config.yaml` und `recorder-config.yaml` aus einem 1Password-Secret, gemountet per `subPath`. Dahinter stecken zwei verschiedene Probleme:

1. **Jemand biegt `secrets.configSecretRef` auf ein anderes Tresor-Item um.** Bisher blieb der laufende Pod auf der alten Konfiguration. → **Wird jetzt abgedeckt.**
2. **Jemand ändert den Inhalt des Items im Tresor.** → **Lässt sich hier nicht abdecken.** Ehrlich dokumentiert statt kaschiert.

## Was drin ist

- **`homeassistant.sfs.yaml`**: `checksum/secret-ref` über die gerenderte `OnePasswordItem`-Ressource — also über den `op://`-**Pfad**, nicht über den Inhalt. Bewusst **anders benannt** als `checksum/config`, nach dem Muster, das minecraft-server in #88 eingeführt hat: `checksum/config` verspricht "die Konfiguration hat sich geändert", `checksum/secret-ref` nur "die *Quelle* der Konfiguration hat sich geändert". Beides in eine Annotation zu werfen würde die schwächere Zusage überhöhen.
- **`values.yaml`**: was abgedeckt ist, was nicht, warum nicht, und der Handgriff für den Rest.
- **README, Sektion 9**: das `checksum/secret-ref`-Muster als repo-weite Regel, das verifizierte Operator-Verhalten und die Präzedenz-Falle (siehe unten).
- **Version**: `4.2.0+up2026.8.3` → **`5.0.0+up2026.8.3`**.

## Kosten des Neustarts

Nur beim Umbiegen des Secret-Verweises, also einer seltenen, bewussten Aktion. Der Home-Assistant-Pod startet dann neu; das Startbudget des Charts liegt bei 300 s, real ist mit deutlich weniger zu rechnen (k3d unten: **107 s** bis Ready beim Erstinstall). Für dieses Release ist die Wirkung derzeit ohnehin **rein präventiv**: Es steht bewusst über `scaleDown: true` auf null Replicas.

Genau das macht den Fall aber zum unangenehmsten des Issues: Wer den Server irgendwann wieder hochfährt, bekommt die dann aktuelle Secret-Fassung. Zwischen einer Änderung im Tresor und ihrer Wirkung können **Monate** liegen, und eine Abweichung fiele niemandem auf.

## Nachweis: der Hash reagiert genau auf den Secret-Verweis

```
# identische Eingabe, zweimal gerendert  (--set secrets.configSecretRef=op://vault/item-a)
checksum/secret-ref: 77c284f799b45cc3c3e70d49b54af8d58ad8b8c193340ccba3055a07f6a2a5bf
checksum/secret-ref: 77c284f799b45cc3c3e70d49b54af8d58ad8b8c193340ccba3055a07f6a2a5bf

# --set secrets.configSecretRef=op://vault/item-b
checksum/secret-ref: 847a0fbbe2af13e2b40c6659bf933797b61fb187e96b1c55167417262d59399b

# --set core.timezone=Europe/Berlin   (berührt die OnePasswordItem-Ressource nicht)
checksum/secret-ref: 77c284f799b45cc3c3e70d49b54af8d58ad8b8c193340ccba3055a07f6a2a5bf
```

## Nachweis im laufenden Cluster (k3d)

Wegwerf-Cluster `checksum-proof-c`, angelegt mit `--kubeconfig-update-default=false --kubeconfig-switch-context=false`, angesprochen über eigene `KUBECONFIG` und explizites `--context k3d-checksum-proof-c`, danach gelöscht; der globale Context blieb unberührt. Installation über `ci/run-install-test.sh homeassistant` (grün, Pod nach 107 s Ready). Pods per `--field-selector=status.phase=Running` ermittelt; bei einer StatefulSet heißt der Pod immer `…-sfs-0`, nur die **UID** verrät den Neustart.

| Schritt | `checksum/secret-ref` | `generation` | Pod-UID |
|---|---|---|---|
| 1. Install | `5892c848…` | 1 | `ebac8ceb…` |
| 2. `helm upgrade`, **unveränderte** Werte | `5892c848…` | 1 | `ebac8ceb…` — **unverändert**, `restartCount=0` |
| 3. `helm upgrade --set secrets.configSecretRef=op://ci/homeassistant-config-rotated` | `1444a240…` | 2 | `78433e1a…` — **neu** |

### Und die Gegenprobe zur Lücke, die bleibt

Direkt im Anschluss das Kubernetes-Secret im Cluster verändert — also genau das, was der Operator bei einer Änderung im Tresor tut:

```
$ kubectl patch secret ci-homeassistant-config-secret ...      # fügt "# rotated-in-vault" hinzu
$ kubectl get secret ci-homeassistant-config-secret -o jsonpath='{.data.config}' | base64 -d
default_config:
http: !include http-config.yaml
recorder: !include recorder-config.yaml
# rotated-in-vault

$ kubectl exec ci-homeassistant-sfs-0 -- cat /config/configuration.yaml
default_config:
http: !include http-config.yaml
recorder: !include recorder-config.yaml            # <- die Zeile fehlt

$ kubectl get pods --field-selector=status.phase=Running -l app=ci-homeassistant
ci-homeassistant-sfs-0   uid=78433e1a…   restarts=0                 # derselbe Pod
```

Das Secret im Cluster ist neu, die Datei im laufenden Pod ist alt, nichts startet neu. Genau das steht jetzt in der `values.yaml` — samt Handgriff:

```
kubectl rollout restart statefulset <release>-homeassistant-sfs
```

## Warum hier keine Operator-Annotation steht

Der naheliegende Ausweg wäre `operator.1password.io/auto-restart: "true"`. Er funktioniert hier **nicht**, und eine Annotation, die nichts tut, wäre schlimmer als keine — sie würde eine Zusage behaupten, die es nicht gibt. Verifiziert am Quellcode, nicht an der Doku (`1Password/onepassword-operator`, main @ `9c3b1b94`, meldet sich als `OperatorVersion = "1.12.0"`, jüngster Release-Tag v1.12.0):

- `pkg/onepassword/secret_update_handler.go`, `restartWorkloadsWithUpdatedSecrets` zählt **genau einen** Workload-Typ auf: `workloadTypes := []client.ObjectList{ &appsv1.DeploymentList{} }`. Dazu passend `getPodTemplate`: `case *appsv1.Deployment: … default: return nil, fmt.Errorf("unsupported type %T", obj)`. Kein `StatefulSetList`, kein `DaemonSetList`.
- **Die RBAC-Rolle erlaubt `statefulsets` mit vollen Verben** (`config/rbac/role.yaml`) — der Code holt die Objekte nur nie. Die Rechte sehen aus wie Unterstützung; das erklärt einen Großteil der Verwirrung um dieses Feature.
- v1.11.0 (PR #195) hat die Logik ausdrücklich "as foundation for … StatefulSets" generalisiert (`restartDeployment` → `restartWorkload`, Stempel `operator.1password.io/last-restarted` aufs Pod-Template) — **ohne Verhaltensänderung**. Wer nur diesen Refactor sieht, schließt das Falsche.
- Der PR, der StatefulSets tatsächlich ergänzen würde (#272, Mai 2026), ist **offen**. Issue #18 "Support for all workloads" ist seit 2021 offen. Kein CHANGELOG-Eintrag eines 1.x-Releases nennt StatefulSets.
- Auch der Weg über die `OnePasswordItem`-Ressource hilft nicht: Deren Annotation wird nur auf das Kubernetes-Secret durchgeschrieben; die Auswahl der neu zu startenden Workloads bleibt Deployment-only.
- Am StatefulSet gesetzt ist die Annotation ein **folgenloser No-Op** — kein Fehler, keine Logzeile, keine Wirkung.

**Präzedenz-Falle für später**, falls je ein Deployment-basiertes Chart die Annotation setzt: Die Annotation an der `OnePasswordItem`-Ressource wird aufs Secret kopiert und **zuerst** gelesen — ein `false` dort **überstimmt** ein `true` am Workload, entgegen dem, was der Usage Guide nahelegt. Reihenfolge: Secret (vom OnePasswordItem) → Workload → Namespace → globales `AUTO_RESTART`. Ausgelöst wird über den **Versionszähler** des Items, nicht über dessen Inhalt: Ein erneutes Speichern mit identischen Werten startet trotzdem neu. Steht jetzt in der README-Guideline.

Bekannt ist außerdem der Weg über einen Reloader-artigen Controller — der Operator zählt beim Aktualisieren die `resourceVersion` des Secrets hoch, darauf ließe sich lauschen. In diesem Cluster läuft kein solcher Controller, und einen einzuführen wäre eine Infrastrukturentscheidung weit jenseits dieses Issues. Nur der Vollständigkeit halber genannt, **nicht** als Vorschlag.

## Weitere Verifikation

- `helm lint --strict homeassistant` → `1 chart(s) linted, 0 chart(s) failed`.
- `ci/run-install-test.sh homeassistant` lokal grün (siehe oben), CI-Ergebnis prüfe ich nach dem Öffnen auf Job-Ebene nach.

Letzter PR aus Strang A von #82. Kein `Fixes`, das Issue umfasst beide Stränge und wird am Ende manuell geschlossen.
