### PR TITLE
gotenberg: strict values.schema.json (Welle 1, #68)

### DIFF
--- a/gotenberg/Chart.yaml
+++ b/gotenberg/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://gotenberg.dev/img/logo.png
 
 type: application
 
-version: 4.2.0+up8.36.0
+version: 5.0.0+up8.36.0
 appVersion: "8.36.0"
 
 maintainers:

--- a/gotenberg/values.schema.json
+++ b/gotenberg/values.schema.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "gotenberg values",
+  "description": "Strict values schema (issue #68). additionalProperties is false on every chart-owned object level, so a key that the chart does not read is rejected at render time instead of being silently ignored. The only objects that stay open are the ones passed verbatim into the Kubernetes pod spec (probes, security contexts, global) - the chart does not interpret their contents, so it cannot judge which keys are meaningful.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "global": {
+      "description": "Helm's conventional cross-chart values. Unused by this chart, kept open so an umbrella install cannot break on it.",
+      "type": "object"
+    },
+    "scaleDown": {
+      "type": "boolean"
+    },
+    "gotenberg": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "replicas": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "securityContext": {
+          "$ref": "#/definitions/securityContext"
+        },
+        "livenessProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "readinessProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "startupProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "env": {
+          "$ref": "#/definitions/env"
+        },
+        "resources": {
+          "$ref": "#/definitions/resources"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "resources": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "limitFactor": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "requests": {
+          "$ref": "#/definitions/resourceList"
+        },
+        "limits": {
+          "$ref": "#/definitions/resourceList"
+        }
+      }
+    },
+    "resourceList": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "cpu": {
+          "type": ["string", "number", "null"]
+        },
+        "memory": {
+          "type": ["string", "number", "null"]
+        },
+        "ephemeral-storage": {
+          "type": ["string", "number", "null"]
+        },
+        "ephemeralStorage": {
+          "type": ["string", "number", "null"]
+        }
+      }
+    },
+    "env": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "valueFrom": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "secretKeyRef": {
+                "$ref": "#/definitions/keyRef"
+              },
+              "configMapKeyRef": {
+                "$ref": "#/definitions/keyRef"
+              }
+            }
+          }
+        }
+      }
+    },
+    "keyRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "key"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        }
+      }
+    },
+    "securityContext": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "pod": {
+          "description": "Rendered verbatim as the pod's securityContext; kept open because the chart does not interpret it.",
+          "type": "object"
+        },
+        "container": {
+          "description": "Rendered verbatim as the container's securityContext; kept open because the chart does not interpret it.",
+          "type": "object"
+        }
+      }
+    },
+    "probe": {
+      "description": "Rendered verbatim as a container probe; kept open because the chart does not interpret it.",
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
Zweites Chart der **Welle 1** aus #68, gleiches Muster wie #90 (cyberchef) und der abgenommene Pilot `minecraft-server`.

## Was drin ist

- `gotenberg/values.schema.json`: `additionalProperties: false` auf **allen chart-eigenen Objektebenen** — oberste Ebene, `gotenberg`, `gotenberg.resources`, `.requests`/`.limits`, `env[]`, `env[].valueFrom`, `.secretKeyRef`/`.configMapKeyRef`, `securityContext`.
- **Offen bleiben** die wörtlich in die Pod-Spec durchgereichten Objekte: `livenessProbe`/`readinessProbe`/`startupProbe`, `securityContext.pod`, `securityContext.container`, `global`.
- Chart-Version **4.2.0 → 5.0.0** (major, appVersion unverändert bei 8.36.0).

Die Werte-Oberfläche ist vollständig abgedeckt: `scaleDown` plus `gotenberg.{replicas,securityContext,livenessProbe,readinessProbe,startupProbe,env,resources}` — abgeglichen gegen alle `.Values.*`-Referenzen in `gotenberg/templates/`. Das Chart hat keinen Ingress und keine Secrets.

`resources.requests`/`.limits` akzeptieren `cpu`, `memory` und **beide** Schreibweisen der Ephemeral-Storage-Angabe (`ephemeralStorage` und `ephemeral-storage`) — der `resources`-Helper normalisiert camelCase auf den Kubernetes-Key, und die produktiven Werte nutzen die camelCase-Form.

## Verifikation

**Lint**

```
$ helm lint --strict gotenberg
1 chart(s) linted, 0 chart(s) failed
```

Keine Findings. Anders als cyberchef hat gotenberg keine `required()`-Werte, deshalb auch keine INFO-Zeilen.

**Rendern**

| Fall | Ergebnis |
|---|---|
| Default-Values (ohne jede Angabe) | rendert |
| `ci/gotenberg/test-values.yaml` | rendert |
| Bundle-Werte `fleet-cd/cluster-tika-gotenberg/gotenberg/gotenberg.values.yaml` | rendert |

**Negativprobe — beide Ebenen werden abgewiesen**

Oberste Ebene:

```
$ helm template t gotenberg --set bogusTopLevel=true
Error: values don't meet the specifications of the schema(s) in the following chart(s):
gotenberg:
- at '': additional properties 'bogusTopLevel' not allowed
```

Tief verschachtelt (dritte Ebene, `gotenberg.resources.limits`):

```
$ helm template t gotenberg --set gotenberg.resources.limits.bogusMemory=1Gi
Error: values don't meet the specifications of the schema(s) in the following chart(s):
gotenberg:
- at '/gotenberg/resources/limits': additional properties 'bogusMemory' not allowed
```

## Validierung gegen die real ausgerollten Werte

Bundle `fleet-cd/cluster-tika-gotenberg/gotenberg/` (Release `cluster-gotenberg`, pinnt aktuell `4.1.1+up8.36.0`). Zusätzlich gegen den ausgerollten Stand geprüft:

```
$ helm get values cluster-gotenberg -n cluster-tika-gotenberg
gotenberg:
  resources:
    limits:      { cpu: 1, ephemeralStorage: 100Mi, memory: 1536Mi }
    requests:    { cpu: 0.1, ephemeralStorage: 10Mi, memory: 1024Mi }
```

**Liste abgewiesener Schlüssel: leer.** Bundle-Datei und ausgerollter Stand sind deckungsgleich und validieren beide gegen das Schema. Für die Cluster-Seite ist bei gotenberg vor dem Hochziehen auf `5.0.0` **nichts zu bereinigen**.

Refs #68 (das Issue umfasst alle drei Wellen und bleibt offen).
