### PR TITLE
apache-tika: strict values.schema.json (Welle 1, #68)

### DIFF
--- a/apache-tika/Chart.yaml
+++ b/apache-tika/Chart.yaml
@@ -5,5 +5,5 @@ icon: https://www.apache.org/logos/res/tika/default.png
 
 type: application
 
-version: 7.2.0+up3.3.1.0.full
+version: 8.0.0+up3.3.1.0.full
 appVersion: "3.3.1.0-full"

--- a/apache-tika/values.schema.json
+++ b/apache-tika/values.schema.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "apache-tika values",
+  "description": "Strict values schema (issue #68). additionalProperties is false on every chart-owned object level, so a key that the chart does not read is rejected at render time instead of being silently ignored. The only objects that stay open are the ones passed verbatim into the Kubernetes pod spec (probes, security contexts, global) - the chart does not interpret their contents, so it cannot judge which keys are meaningful.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "global": {
+      "description": "Helm's conventional cross-chart values. Unused by this chart, kept open so an umbrella install cannot break on it.",
+      "type": "object"
+    },
+    "scaleDown": {
+      "type": "boolean"
+    },
+    "tika": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "replicas": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "securityContext": {
+          "$ref": "#/definitions/securityContext"
+        },
+        "livenessProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "readinessProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "startupProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "env": {
+          "$ref": "#/definitions/env"
+        },
+        "resources": {
+          "$ref": "#/definitions/resources"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "resources": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "limitFactor": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "requests": {
+          "$ref": "#/definitions/resourceList"
+        },
+        "limits": {
+          "$ref": "#/definitions/resourceList"
+        }
+      }
+    },
+    "resourceList": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "cpu": {
+          "type": ["string", "number", "null"]
+        },
+        "memory": {
+          "type": ["string", "number", "null"]
+        },
+        "ephemeral-storage": {
+          "type": ["string", "number", "null"]
+        },
+        "ephemeralStorage": {
+          "type": ["string", "number", "null"]
+        }
+      }
+    },
+    "env": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "valueFrom": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "secretKeyRef": {
+                "$ref": "#/definitions/keyRef"
+              },
+              "configMapKeyRef": {
+                "$ref": "#/definitions/keyRef"
+              }
+            }
+          }
+        }
+      }
+    },
+    "keyRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "key"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        }
+      }
+    },
+    "securityContext": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "pod": {
+          "description": "Rendered verbatim as the pod's securityContext; kept open because the chart does not interpret it.",
+          "type": "object"
+        },
+        "container": {
+          "description": "Rendered verbatim as the container's securityContext; kept open because the chart does not interpret it.",
+          "type": "object"
+        }
+      }
+    },
+    "probe": {
+      "description": "Rendered verbatim as a container probe; kept open because the chart does not interpret it.",
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
Drittes Chart der **Welle 1** aus #68, gleiches Muster wie #90 (cyberchef) und #94 (gotenberg).

## Was drin ist

- `apache-tika/values.schema.json`: `additionalProperties: false` auf **allen chart-eigenen Objektebenen** — oberste Ebene, `tika`, `tika.resources`, `.requests`/`.limits`, `env[]`, `env[].valueFrom`, `.secretKeyRef`/`.configMapKeyRef`, `securityContext`.
- **Offen bleiben** die wörtlich in die Pod-Spec durchgereichten Objekte: `livenessProbe`/`readinessProbe`/`startupProbe`, `securityContext.pod`, `securityContext.container`, `global`.
- Chart-Version **7.2.0 → 8.0.0** (major, appVersion unverändert bei `3.3.1.0-full`).

Der Werte-Block heißt `tika`, nicht `apache-tika` — das Schema folgt dem Chart, nicht dem Verzeichnisnamen. Abgedeckt ist `scaleDown` plus `tika.{replicas,securityContext,livenessProbe,readinessProbe,startupProbe,env,resources}`, abgeglichen gegen alle `.Values.*`-Referenzen in `apache-tika/templates/`. Das Chart hat keinen Ingress und keine Secrets.

## Verifikation

**Lint**

```
$ helm lint --strict apache-tika
1 chart(s) linted, 0 chart(s) failed
```

Keine Findings; das Chart hat keine `required()`-Werte, daher auch keine INFO-Zeilen.

**Rendern**

| Fall | Ergebnis |
|---|---|
| Default-Values (ohne jede Angabe) | rendert |
| `ci/apache-tika/test-values.yaml` (`{}`) | rendert |
| produktive Werte | siehe unten — das Bundle setzt gar keine Werte |

**Negativprobe — beide Ebenen werden abgewiesen**

Oberste Ebene:

```
$ helm template t apache-tika --set bogusTopLevel=true
Error: values don't meet the specifications of the schema(s) in the following chart(s):
apache-tika:
- at '': additional properties 'bogusTopLevel' not allowed
```

Tief verschachtelt (dritte Ebene, `tika.resources.requests`):

```
$ helm template t apache-tika --set tika.resources.requests.bogusCpu=1
Error: values don't meet the specifications of the schema(s) in the following chart(s):
apache-tika:
- at '/tika/resources/requests': additional properties 'bogusCpu' not allowed
```

## Validierung gegen die real ausgerollten Werte

Bundle `fleet-cd/cluster-tika-gotenberg/tika/` (Release `cluster-tika`, pinnt `7.1.1+up3.3.1.0.full`). Das Bundle besteht **nur aus einer `fleet.yaml` ohne `valuesFiles`** — die Installation fährt vollständig auf Chart-Defaults. Bestätigt am ausgerollten Stand:

```
$ helm get values cluster-tika -n cluster-tika-gotenberg
USER-SUPPLIED VALUES:
null
```

**Liste abgewiesener Schlüssel: leer** — es gibt keine benutzerdefinierten Werte, die abgewiesen werden könnten. Für die Cluster-Seite ist bei apache-tika vor dem Hochziehen auf `8.0.0` **nichts zu bereinigen**.

Refs #68 (das Issue umfasst alle drei Wellen und bleibt offen).
