### PR TITLE
paperless-ngx: leerer barcodes-Block faellt auf die Chart-Defaults zurueck

### DIFF
--- a/ci/paperless-ngx/test-values.yaml
+++ b/ci/paperless-ngx/test-values.yaml
@@ -9,5 +9,12 @@ ingress:
   # apply - there is no cert-manager in the CI cluster.
   clusterIssuer: ci
 
+paperless:
+  files:
+    # Regression guard for issue #61: a childless "barcodes:" key is YAML null.
+    # It must fall back to the chart defaults (barcodes enabled, "PATCHT") and
+    # neither erase them nor break rendering.
+    barcodes:
+
 # smbConnection and oidc stay disabled (defaults): the SMB CSI driver and a
 # real OIDC login flow are out of scope for the CI install-test.

--- a/paperless-ngx/Chart.yaml
+++ b/paperless-ngx/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://raw.githubusercontent.com/paperless-ngx/paperless-ngx/dev/src-ui/s
 
 type: application
 
-version: 10.0.0+up3.0.5
+version: 11.0.0+up3.0.5
 
 appVersion: 3.0.5
 

--- a/paperless-ngx/templates/_helpers.tpl
+++ b/paperless-ngx/templates/_helpers.tpl
@@ -114,3 +114,78 @@ template-chart is the reference implementation.
 1
 {{- end -}}
 {{- end -}}
+
+{{/*
+Merge a user-supplied values sub-tree onto a dict of chart defaults so that a
+null / empty override falls back to the defaults instead of erasing them.
+
+Input: dict "defaults" <dict> "given" <dict|nil> "path" <string, optional
+values path used in error messages>. Output: YAML of the merged dict (consume
+it with fromYaml).
+
+Why this exists (issue #61): Helm merges values maps recursively, but an
+override key written without children — e.g. a leftover
+
+  barcodes:
+
+after deleting its last remaining sub-key — is YAML null and replaces the
+whole default sub-tree. The chart then renders with no barcode settings at
+all. This helper defines the opposite semantics: an empty block means "chart
+defaults apply".
+
+Rules:
+  - a nil "given" is treated as an empty dict (all defaults apply).
+  - a key whose override value is null keeps the default (nulls never delete).
+  - a key present in both as a map is merged recursively, so a partially
+    filled block only overrides the keys it actually sets.
+  - a scalar override for a key the defaults define as a map is rejected with
+    a message naming the values path, instead of failing later with a template
+    field error.
+  - any other set value wins as given, including an explicit false or 0 —
+    Helm's "default" and sprig's "mergeOverwrite" would both swallow those
+    zero values, hence the explicit kindIs "invalid" nil check.
+  - keys only present in the override are passed through unchanged.
+*/}}
+{{- define "paperless-ngx.defaultedDict" -}}
+{{- $defaults := .defaults | default dict -}}
+{{- $given := .given -}}
+{{- $path := .path | default "value" -}}
+{{- if kindIs "invalid" $given -}}
+{{- $given = dict -}}
+{{- end -}}
+{{- if not (kindIs "map" $given) -}}
+{{- fail (printf "%s must be a mapping or null, got %s (%v)" $path (kindOf $given) $given) -}}
+{{- end -}}
+{{- $out := deepCopy $defaults -}}
+{{- range $key, $value := $given -}}
+{{- if not (kindIs "invalid" $value) -}}
+{{- $default := index $defaults $key -}}
+{{- if and (kindIs "map" $value) (kindIs "map" $default) -}}
+{{- $_ := set $out $key (fromYaml (include "paperless-ngx.defaultedDict" (dict "defaults" $default "given" $value "path" (printf "%s.%s" $path $key)))) -}}
+{{- else if kindIs "map" $default -}}
+{{- fail (printf "%s.%s must be a mapping or null, got %s (%v)" $path $key (kindOf $value) $value) -}}
+{{- else -}}
+{{- $_ := set $out $key $value -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- toYaml $out -}}
+{{- end -}}
+
+{{/*
+The effective barcode settings, rendered as YAML (consume with fromYaml).
+
+Input: .Values.paperless.files.barcodes (may be nil, empty or partial).
+
+The defaults below MUST stay in sync with the barcodes block in values.yaml,
+which stays the documented, user-facing place for them; this copy is only the
+fallback for the case where an override has erased the block.
+*/}}
+{{- define "paperless-ngx.barcodes" -}}
+{{- $defaults := dict
+      "enabled" true
+      "barcodeString" "PATCHT"
+      "retainBarcodePage" false
+      "asn" (dict "enabled" true) -}}
+{{- include "paperless-ngx.defaultedDict" (dict "defaults" $defaults "given" . "path" "paperless.files.barcodes") -}}
+{{- end -}}

--- a/paperless-ngx/templates/paperless-server.sfs.yaml
+++ b/paperless-ngx/templates/paperless-server.sfs.yaml
@@ -1,3 +1,8 @@
+{{- /*
+Barcode settings, defended against a null / empty "barcodes:" override:
+an empty block falls back to the chart defaults (issue #61).
+*/ -}}
+{{- $barcodes := fromYaml (include "paperless-ngx.barcodes" .Values.paperless.files.barcodes) -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -137,13 +142,13 @@ spec:
             - name: PAPERLESS_URL
               value: "https://{{ .Values.ingress.domain }}"
             - name: PAPERLESS_CONSUMER_ENABLE_ASN_BARCODE
-              value: "{{ .Values.paperless.files.barcodes.asn.enabled }}"
+              value: "{{ $barcodes.asn.enabled }}"
             - name: PAPERLESS_CONSUMER_ENABLE_BARCODES
-              value: "{{ .Values.paperless.files.barcodes.enabled }}"
+              value: "{{ $barcodes.enabled }}"
             - name: PAPERLESS_CONSUMER_BARCODE_STRING
-              value: "{{ .Values.paperless.files.barcodes.barcodeString }}"
+              value: "{{ $barcodes.barcodeString }}"
             - name: PAPERLESS_CONSUMER_BARCODE_RETAIN_SPLIT_PAGES
-              value: "{{ .Values.paperless.files.barcodes.retainBarcodePage }}"
+              value: "{{ $barcodes.retainBarcodePage }}"
             - name: PAPERLESS_CONSUMER_DELETE_DUPLICATES
               value: "{{ .Values.paperless.files.deleteDuplicates }}"
             {{- if .Values.paperless.files.tikaGotenberg.enabled }}

--- a/paperless-ngx/values.yaml
+++ b/paperless-ngx/values.yaml
@@ -48,6 +48,13 @@ paperless:
     # The barcode scanner backend is no longer configurable: paperless-ngx 3.0
     # removed pyzbar and PAPERLESS_CONSUMER_BARCODE_SCANNER; zxing-cpp is the
     # only backend now.
+    #
+    # An empty or null "barcodes:" block in an override means "the defaults
+    # below apply" — the chart merges the block onto these defaults instead of
+    # letting a childless key erase them (issue #61; the fallback copy lives in
+    # the paperless-ngx.barcodes helper and is kept in sync with this block).
+    # To switch barcode handling off, set barcodes.enabled: false explicitly;
+    # deleting the sub-keys does not disable it.
     barcodes:
       enabled: true
       barcodeString: "PATCHT"


### PR DESCRIPTION
Fixes #61

Ein `barcodes:`-Schlüssel ohne Kinder ist YAML-`null` und ersetzte beim Helm-Merge den kompletten Default-Block. Ab diesem PR gilt: **ein leerer oder `null`-Block bedeutet „die Chart-Defaults gelten"**.

## Lösung und warum diese

Der Merge läuft über einen neuen Helper `paperless-ngx.defaultedDict` in `paperless-ngx/templates/_helpers.tpl`; ein dünner Wrapper `paperless-ngx.barcodes` hält die Fallback-Defaults, die StatefulSet-Vorlage konsumiert das Ergebnis einmalig per `fromYaml`:

```
{{- $barcodes := fromYaml (include "paperless-ngx.barcodes" .Values.paperless.files.barcodes) -}}
```

Warum ein Helper und nicht `default`/`mergeOverwrite` inline:

- Das Repo löst genau solche Fälle bereits per Helper mit explizitem `kindIs "invalid"`-Nil-Check (`paperless-ngx.replicas`, `paperless-ngx.resources`) — dieser Helper folgt demselben Muster und derselben Kommentar-Form.
- `default` und sprigs `mergeOverwrite` sind hier **falsch**: beide schlucken Zero-Values, `mergeOverwrite` würde ein bewusst gesetztes `enabled: false` verwerfen und damit denselben Bug in anderer Richtung bauen. Der Helper prüft stattdessen explizit auf `kindIs "invalid"`.
- Der Helper ist generisch (`defaults`/`given`/`path`) und rekursiv, deckt also — wie im Plan gefordert — auch künftige Blöcke ab, statt nur diesen einen Fall zu flicken.

Regeln des Helpers: `nil` → alle Defaults; ein `null`-Wert löscht nie einen Default; verschachtelte Maps mergen rekursiv; gesetzte Werte gewinnen inklusive `false`/`0`; ein Skalar dort, wo die Defaults eine Map vorsehen, wird mit Nennung des Values-Pfads abgelehnt.

Die Fallback-Defaults im Helper sind eine zweite Kopie der Werte aus `values.yaml` — anders geht es nicht, denn wenn der Override den Block gelöscht hat, sind die `values.yaml`-Defaults zum Renderzeitpunkt bereits weg. Beide Stellen tragen einen Kommentar, der auf die jeweils andere zeigt.

## Migrationsnotiz

- Wer `barcodes:` leer (oder `barcodes: null`) in seinen Overrides stehen hat, bekommt ab 11.0.0 wieder die Chart-Defaults: Barcodes an, Trennstring `PATCHT`, ASN an, Barcode-Seite wird nicht behalten.
- **Barcodes abschalten geht nur noch explizit** über `paperless.files.barcodes.enabled: false`. Sub-Keys zu löschen schaltet nichts mehr ab.
- Teilweise gefüllte Blöcke verhalten sich unverändert: nur die gesetzten Keys überschreiben, der Rest bleibt Default.

## Nachweis: leerer Block, vorher/nachher

Overrides (`barcodes:` ohne Kinder, identisch zu `barcodes: null`):

```yaml
paperless:
  files:
    barcodes:
```

**Vorher (10.0.0, main):** der Default-Block ist weg, das Rendern bricht ab — der Release/Bundle aktualisiert damit gar nicht mehr:

```
$ helm template t paperless-ngx -f ci/paperless-ngx/test-values.yaml -f /tmp/empty.yaml
Error: template: paperless-ngx/templates/paperless-server.sfs.yaml:140:32:
  executing "paperless-ngx/templates/paperless-server.sfs.yaml"
  at <.Values.paperless.files.barcodes.asn.enabled>: nil pointer evaluating interface {}.asn
```

**Nachher (11.0.0, dieser Branch):** die Defaults greifen:

```
- name: PAPERLESS_CONSUMER_ENABLE_ASN_BARCODE
  value: "true"
- name: PAPERLESS_CONSUMER_ENABLE_BARCODES
  value: "true"
- name: PAPERLESS_CONSUMER_BARCODE_STRING
  value: "PATCHT"
- name: PAPERLESS_CONSUMER_BARCODE_RETAIN_SPLIT_PAGES
  value: "false"
```

## Nachweis: teilweise gesetzter Block mergt weiterhin

Override `barcodes: { enabled: false }` — nachher identisch zu vorher, `enabled` wirkt, der Rest bleibt Default:

```
PAPERLESS_CONSUMER_ENABLE_ASN_BARCODE=true      # Default
PAPERLESS_CONSUMER_ENABLE_BARCODES=false        # gesetzt
PAPERLESS_CONSUMER_BARCODE_STRING=PATCHT        # Default
PAPERLESS_CONSUMER_BARCODE_RETAIN_SPLIT_PAGES=false  # Default
```

Weitere geprüfte Fälle: `asn: null` behält `asn.enabled: true` (und ein daneben gesetztes `barcodeString` wirkt); ein vollständig gesetzter Block überschreibt alle vier Werte; `--set paperless.files.barcodes=oops` bzw. `...barcodes.asn=nope` scheitern mit `paperless.files.barcodes[.asn] must be a mapping or null, got string (…)`.

Als Regressionsschutz setzt `ci/paperless-ngx/test-values.yaml` jetzt selbst einen leeren `barcodes:`-Block — der Install-Test in CI fährt den Null-Pfad also mit.

## Die drei realen Instanzen

Geprüft sowohl in den Fleet-Bundle-Werten als auch am tatsächlich ausgerollten Stand (`helm get values`, alle drei aktuell auf Chart 8.0.0+up3.0.5):

| Instanz | Release / Namespace | `barcodes:` in Bundle-Werten | `barcodes:` im ausgerollten Stand | Ändert dieser PR etwas? |
| --- | --- | --- | --- | --- |
| paperless-cmk | `paperless-cmk` / `paperless-cmk` | nicht vorhanden | nicht vorhanden | nein |
| paperless-jk | `paperless-jk` / `paperless-jk` | nicht vorhanden | nicht vorhanden | nein |
| paperless-tb | `paperless-ngx-tb` / `paperless-ngx` | nicht vorhanden | nicht vorhanden | nein |

Kein leerer und kein teilbefüllter Block, in keiner der drei — der Schlüssel fehlt jeweils komplett, die Defaults greifen also schon heute. Bestätigt an den laufenden StatefulSets: alle drei tragen `PAPERLESS_CONSUMER_ENABLE_BARCODES=true`, `PAPERLESS_CONSUMER_ENABLE_ASN_BARCODE=true`, `PAPERLESS_CONSUMER_BARCODE_STRING=PATCHT`, `PAPERLESS_CONSUMER_BARCODE_RETAIN_SPLIT_PAGES=false`. Niemand hat hier absichtlich per leerem Block abgeschaltet, die Bedeutungsänderung schaltet also bei niemandem etwas wieder an.

## Verifikation

- `helm lint --strict paperless-ngx` → 0 Findings (nur die erwarteten `required`-INFO-Zeilen), `helm package` ok.
- Render-Fälle wie oben, jeweils vorher (main) und nachher.
- Install-Test in CI läuft mit dem neuen, absichtlich leeren `barcodes:`-Block in den CI-Werten.

## Version

`10.0.0+up3.0.5` → `11.0.0+up3.0.5`, `appVersion` unverändert. Major, weil sich die Bedeutung eines Werte-Overrides ändert.
