### PR TITLE
rallly: emptyDir für den Next.js-Cache (5.0.0+up4.12.3)

### DIFF
--- a/rallly/Chart.yaml
+++ b/rallly/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://raw.githubusercontent.com/lukevella/rallly/main/apps/landing/publi
 
 type: application
 
-version: 4.0.0+up4.12.3
+version: 5.0.0+up4.12.3
 appVersion: "4.12.3"
 
 maintainers:

--- a/rallly/templates/rallly.deployment.yaml
+++ b/rallly/templates/rallly.deployment.yaml
@@ -150,4 +150,18 @@ spec:
             {{- include "rallly.resources" .Values.rallly.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.rallly.securityContext.container | nindent 12 }}
+          volumeMounts:
+            # Next.js writes prerendered pages and optimized images into its
+            # cache directory; with a read-only root filesystem this must be a
+            # writable volume (see rallly.cache in values.yaml).
+            - name: next-cache
+              mountPath: {{ required "A cache path must be provided (rallly.cache.path)" .Values.rallly.cache.path | quote }}
+      volumes:
+        - name: next-cache
+          {{- if .Values.rallly.cache.sizeLimit }}
+          emptyDir:
+            sizeLimit: {{ .Values.rallly.cache.sizeLimit | quote }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
       restartPolicy: Always

--- a/rallly/values.yaml
+++ b/rallly/values.yaml
@@ -23,6 +23,27 @@ rallly:
     pictureClaimPath: 'picture'
     emailClaimPath: 'email'
     nameClaimPath: 'name'
+  # Next.js writes its cache below the app directory (prerendered/ISR pages and
+  # the optimized images of /_next/image). The container runs as uid 20000
+  # while /app belongs to the image's own "nextjs" user, so that path is not
+  # writable for the app even without readOnlyRootFilesystem — the chart mounts
+  # a writable volume over it. The pod's fsGroup (1000) is what makes the
+  # mounted volume group-writable for the container.
+  #
+  # Deliberately an emptyDir, not a PVC: the cache is volatile. After every pod
+  # restart it starts out empty and Next.js rebuilds it on demand, which costs
+  # a little time on the first request after a restart. That is correct for a
+  # cache — its entries are derived data tied to the build id of the image, so
+  # a persistent volume would only carry stale entries across app updates.
+  cache:
+    # Mount path of the cache volume. Matches the Next.js cache directory of
+    # the upstream image; only needs changing if the image layout changes.
+    path: /app/apps/web/.next/cache
+    # Optional upper bound for the emptyDir, e.g. 512Mi. Unset means the volume
+    # is only bounded by the container's ephemeral-storage limit (computed as
+    # limitFactor x request, see resources below) — note that emptyDir usage
+    # counts against that limit, and exceeding either bound evicts the pod.
+    sizeLimit: null
   securityContext:
     pod:
       runAsNonRoot: true
@@ -34,10 +55,14 @@ rallly:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
+      # No capabilities are added: the app is a plain Node process listening on
+      # the unprivileged port 3000, verified to run with all capabilities
+      # dropped. Do not reintroduce an "add:" key here — an empty list item
+      # under it renders as a null entry, which is what Trivy reported as
+      # AVD-KSV-0022 for the older chart version deployed in the cluster (#84).
       capabilities:
         drop:
           - ALL
-        add: []
   # Extra environment variables, appended to the ones the chart always sets.
   # Values are rendered through tpl; value, secretKeyRef and configMapKeyRef
   # forms are supported.


### PR DESCRIPTION
Fixes #60

## Was das Chart hatte

`readOnlyRootFilesystem: true` und **kein einziges Volume** — weder `volumes:` noch `volumeMounts:`. Jeder Schreibversuch von Next.js nach `/app/apps/web/.next/cache` scheiterte.

Der Befund ist etwas schärfer als „das Log rauscht": Der Fehlschlag des Image-Optimizers schlägt als `unhandledRejection` durch:

```
Failed to update prerender cache for e483c108… Error: ENOENT: no such file or directory,
  mkdir '/app/apps/web/.next/cache'
⨯ unhandledRejection: Error: EACCES: permission denied, mkdir '/app/apps/web/.next/cache'
```

Nebenbefund aus dem k3d: Der Pfad ist für die Anwendung **auch ohne** `readOnlyRootFilesystem` nicht beschreibbar. Der Container läuft als uid 20000, `/app` gehört dem `nextjs`-User des Images (0755). Mit beschreibbarem Rootfs wird aus `EROFS`/`ENOENT` nur ein `EACCES` — der Mount ist also nicht bloß eine Umgehung der Härtung, sondern die eigentliche Lösung. Beschreibbar wird er durch die bereits vorhandene `fsGroup: 1000` des Pods.

## Die Änderung

`emptyDir` auf dem Cache-Pfad, Pfad und optionales `sizeLimit` über `rallly.cache` konfigurierbar. Härtung unverändert (`readOnlyRootFilesystem: true`, `drop: [ALL]`, non-root).

```yaml
rallly:
  cache:
    path: /app/apps/web/.next/cache
    sizeLimit: null   # z. B. 512Mi
```

In `values.yaml` steht als Kommentar, dass der Cache flüchtig ist (nach jedem Pod-Neustart leer, Next.js baut ihn neu auf — richtig für einen Cache, kostet beim ersten Aufruf danach etwas Zeit) und **warum daraus kein PVC werden soll**: Die Einträge sind abgeleitete Daten, an die Build-ID des Images gebunden; ein persistentes Volume trüge nur veraltete Einträge über App-Updates hinweg.

Ebenfalls dokumentiert: `emptyDir`-Verbrauch zählt gegen das `ephemeral-storage`-Limit des Containers (hier `limitFactor` × Request = 300Mi). Beide Grenzen führen bei Überschreitung zur Eviction — deshalb kein voreingestelltes `sizeLimit`, sondern eine bewusste Entscheidung des Betreibers.

## Suche nach weiteren Schreibpfaden

Ein Mount auf den bekannten Pfad ist die offensichtliche Hälfte. Deshalb wurde im k3d nicht nur der bekannte Pfad geprüft, sondern gemessen, **was die Anwendung überhaupt schreibt**.

Methode: Der Pod lief einmal mit **beschreibbarem** Rootfs *und* gemountetem Cache-Volume — so scheitert kein Schreibversuch früh und maskiert dabei spätere. Danach wurde der overlayfs-`upperdir` des Containers auf dem k3d-Node ausgewertet; der enthält jede Änderung am Root-Dateisystem, inklusive Whiteouts für wieder gelöschte Dateien. Getrieben wurde die Anwendung mit ~40 Requests über Seiten-Routen (`/`, `/login`, `/new`, `/poll/…`, `/invite/…`, Locales `de`/`fr`, `/settings/profile`), statischen Dateien, API-Routen sowie fünf Varianten des Image-Optimizers (`/_next/image` mit verschiedenen `w`/`q`) — also genau die Pfade, die ISR-Prerender-Cache und Bild-Cache füllen. Dazu ein Kaltstart gegen eine leere Datenbank, bei dem `docker-start.sh` alle 141 Prisma-Migrationen über `npx` ausführt.

Ergebnis — das ist der **vollständige** Inhalt des `upperdir` nach dem Lauf:

| Pfad | Bewertung |
|---|---|
| `/app/apps/web/.next/cache` | der Mountpoint selbst; alles Geschriebene (`images/`, `fetch-cache/`) landet **im** Volume |
| `/etc/hosts` | vom kubelet gemountet, kein App-Schreibvorgang |

Konkret geprüft und **nicht** beschrieben:

- **`/tmp`** — der übliche zweite Kandidat: nichts. Das im Image vorhandene `/tmp/node-compile-cache` stammt aus dem Build (root, Datum des Image-Builds); zur Laufzeit ist `NODE_COMPILE_CACHE` nicht gesetzt und Node schreibt dort nicht hinein.
- **`$HOME` (= `/app`)** — kein `.npm`, kein `_cacache`, keine npm-Logs, auch nicht während `npx prisma migrate deploy` beim Kaltstart.
- **`/app/apps/web/.next/` außerhalb von `cache/`**, `/app/node_modules`, `/var`, `/run`, `/home` — nichts.

Also: **kein zweiter Mount nötig.** Ein `/tmp`-emptyDir wäre hier Vorrat ohne Beleg. Ein Vorbehalt der Ehrlichkeit halber: Gemessen wurde der anonyme Betrieb — Login läuft über OIDC und E-Mail-Versand ist im Chart per Default aus. Datei-Uploads gehen bei rallly per S3-Client an einen externen Bucket, nicht über die lokale Platte (`# TODO: Add Storage Configuration` im Deployment ist unberührt).

## Vorher / Nachher im k3d

Wegwerf-Cluster `rallly-i60` (eigener Name, alle Aufrufe mit explizitem `--context`, Cluster gelöscht), Fixtures aus `ci/rallly/`.

**Vorher** (Chart-Stand `main`): Pod läuft und ist Ready, aber jeder Cache-Schreibversuch scheitert; 4 Fehlerblöcke im Log, davon einer als `unhandledRejection`, Verzeichnis `.next/cache` existiert nicht.

**Nachher** (dieser Stand), nach demselben Traffic:

```
error count (EACCES|EROFS|ENOENT|unhandledRejection|Failed to update prerender cache): 0

$ ls /app/apps/web/.next/cache
fetch-cache
images
```

Der Cache füllt sich also tatsächlich, statt nur nicht mehr zu lärmen. Der finale Pod trägt unverändert:

```json
{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},
 "readOnlyRootFilesystem":true,"runAsNonRoot":true}
```

Zusätzlich lief `ci/run-install-test.sh rallly` (die echte CI-Harness, gegen eine isolierte Kubeconfig des Wegwerf-Clusters) auf einem Kaltstart mit frischer Datenbank grün: Migrationen laufen durch, alle Workloads Ready, null Dateisystem-Fehler.

## Trivy-Befund AVD-KSV-0022 (#84)

Geprüft statt geraten — und der Befund ist ein **Cluster-Rückstand, keine Chart-Lücke**.

`main` setzte `capabilities: {drop: [ALL], add: []}`. Die im Cluster laufende ältere Version (3.1.x) rendert dagegen:

```yaml
              add:
                -        # Listeneintrag ohne Wert -> add: [null]
```

Mit `trivy config` gegen beide gerenderten Manifeste reproduziert:

| Rendering | KSV-0022 |
|---|---|
| `add: [null]` (alte, im Cluster laufende Version) | **gemeldet** (zusätzlich KSV-0106) |
| `add: []` (Stand `main`) | nicht gemeldet |
| ohne `add:` (dieser PR) | nicht gemeldet |

Die Capability wird also **nicht gebraucht** — es wurde nie eine ergänzt, der Befund entstand aus einem leeren Listeneintrag. Behoben ist er bereits durch die Härtungsrunde (#32, Batch 3); der Cluster muss dafür nur hochgezogen werden, was mit diesem Release ohnehin ansteht.

Da das Chart offen war, ist das übriggebliebene `add: []` mit entfernt und durch einen Kommentar ersetzt, der davor warnt, den Schlüssel wieder einzuführen — genau diese Form ist damals zum Null-Eintrag entartet. Belegt ist die Entbehrlichkeit auch praktisch: Die Anwendung läuft im k3d mit `drop: [ALL]` und ohne jedes `add` (Node-Prozess auf dem unprivilegierten Port 3000).

Die restlichen Trivy-Meldungen des gerenderten Charts sind vor und nach dieser Änderung identisch und gehören zu den repo-weiten Punkten aus #84 (kein CPU-Limit — bewusst; `seccompProfile` — repo-weit offen; UID/GID ≤ 10000; Registry-Policy). Sie werden hier nicht angefasst.

## Version

`4.0.0+up4.12.3` → **`5.0.0+up4.12.3`**, `appVersion` unverändert. Major, obwohl die Werte-Schnittstelle rein additiv bleibt: Es ändert sich Laufzeitverhalten — ein Volume kommt hinzu, und der Cache ist nach jedem Neustart leer und wird neu aufgebaut. Das soll sichtbar sein, statt in einem Minor unterzugehen.

## Geprüft

- `helm lint --strict rallly` → 0 Findings
- `helm template` in mehreren Varianten: Default, `cache.sizeLimit=512Mi` (rendert `emptyDir.sizeLimit`), abweichender `cache.path`, `scaleDown=true`, `smtp.enabled=true`; `cache.path=null` scheitert mit klarer `required`-Meldung
- k3d-Kaltstart über `ci/run-install-test.sh rallly` → grün
- Nur `rallly/` angefasst
