### PR TITLE
patchmon: strict values.schema.json + Ingress-Gate + Null-Absicherung (Welle 1, #68/#93/#99)

### DIFF
--- a/patchmon/Chart.yaml
+++ b/patchmon/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://raw.githubusercontent.com/PatchMon/PatchMon/main/frontend/public/a
 
 type: application
 
-version: 5.2.0+up2.1.3
+version: 6.0.0+up2.1.3
 appVersion: "2.1.3"
 
 maintainers:

--- a/patchmon/templates/_helpers.tpl
+++ b/patchmon/templates/_helpers.tpl
@@ -114,3 +114,210 @@ template-chart is the reference implementation.
 1
 {{- end -}}
 {{- end -}}
+
+{{/*
+Merge a user-supplied values sub-tree onto a dict of chart defaults so that a
+null / empty override falls back to the defaults instead of erasing them.
+
+Input: dict "defaults" <dict> "given" <dict|nil> "path" <string, optional
+values path used in error messages>. Output: YAML of the merged dict (consume
+it with fromYaml).
+
+Why this exists (issue #99): Helm merges values maps recursively, but an
+override key written without children — e.g. a leftover
+
+  securityContext:
+
+after deleting its last remaining sub-key — is YAML null and replaces the
+whole default sub-tree. The container then renders with "securityContext:
+null": no readOnlyRootFilesystem, no dropped capabilities, no
+allowPrivilegeEscalation: false. The workload starts and reports healthy while
+being unhardened, so nothing points at the mistake. The same shape erases a
+probe (it disappears) or the resources block (no requests, no computed
+limits). This helper defines the opposite semantics: an empty block means
+"chart defaults apply".
+
+Rules:
+  - a nil "given" is treated as an empty dict (all defaults apply).
+  - a key whose override value is null keeps the default (nulls never delete).
+  - a key present in both as a map is merged recursively, so a partially
+    filled block only overrides the keys it actually sets.
+  - a scalar override for a key the defaults define as a map is rejected with
+    a message naming the values path, instead of failing later with a template
+    field error.
+  - any other set value wins as given, including an explicit false or 0 —
+    Helm's "default" and sprig's "mergeOverwrite" would both swallow those
+    zero values, hence the explicit kindIs "invalid" nil check.
+  - keys only present in the override are passed through unchanged.
+
+NOTE: like the helpers above, this is duplicated into every chart's
+templates/_helpers.tpl with the chart's name as define prefix, because charts
+in this repo deliberately have no dependencies.
+*/}}
+{{- define "patchmon.defaultedDict" -}}
+{{- $defaults := .defaults | default dict -}}
+{{- $given := .given -}}
+{{- $path := .path | default "value" -}}
+{{- if kindIs "invalid" $given -}}
+{{- $given = dict -}}
+{{- end -}}
+{{- if not (kindIs "map" $given) -}}
+{{- fail (printf "%s must be a mapping or null, got %s (%v)" $path (kindOf $given) $given) -}}
+{{- end -}}
+{{- $out := deepCopy $defaults -}}
+{{- range $key, $value := $given -}}
+{{- if not (kindIs "invalid" $value) -}}
+{{- $default := index $defaults $key -}}
+{{- if and (kindIs "map" $value) (kindIs "map" $default) -}}
+{{- $_ := set $out $key (fromYaml (include "patchmon.defaultedDict" (dict "defaults" $default "given" $value "path" (printf "%s.%s" $path $key)))) -}}
+{{- else if kindIs "map" $default -}}
+{{- fail (printf "%s.%s must be a mapping or null, got %s (%v)" $path $key (kindOf $value) $value) -}}
+{{- else -}}
+{{- $_ := set $out $key $value -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- toYaml $out -}}
+{{- end -}}
+
+{{/*
+Pick one sub-block out of a values block that may itself be null.
+
+Input: dict "block" <dict|nil> "key" <string> "path" <string>.
+Returns YAML of dict "value" <the sub-block, may be nil>, after rejecting a
+non-mapping block with a message that names the values path. Needed because
+".Values.patchmon.<workload>.securityContext" can itself be erased.
+*/}}
+{{- define "patchmon.subBlock" -}}
+{{- $block := .block -}}
+{{- if kindIs "invalid" $block -}}
+{{- $block = dict -}}
+{{- end -}}
+{{- if not (kindIs "map" $block) -}}
+{{- fail (printf "%s must be a mapping or null, got %s (%v)" .path (kindOf $block) $block) -}}
+{{- end -}}
+{{- toYaml (dict "value" (index $block .key)) -}}
+{{- end -}}
+
+{{/*
+The effective security contexts, probes and resources of both workloads
+(issue #99).
+
+The defaults below MUST stay in sync with the corresponding blocks in
+values.yaml, which stays the documented, user-facing place for them; this copy
+is only the fallback for the case where an override has erased the block.
+
+The server probes carry a Host header, because the 2.x server rejects requests
+whose Host is neither loopback nor a CORS_ORIGIN host. The default is built
+from .Values.ingress.domain via the passed-in root context, so the probe
+helpers take dict "given" <block|nil> "root" $.
+*/}}
+{{- define "patchmon.server.podSecurityContext" -}}
+{{- $given := (fromYaml (include "patchmon.subBlock" (dict "block" . "key" "pod" "path" "patchmon.server.securityContext"))).value -}}
+{{- $defaults := dict
+      "runAsNonRoot" true
+      "runAsUser" 65532
+      "runAsGroup" 65532 -}}
+{{- include "patchmon.defaultedDict" (dict "defaults" $defaults "given" $given "path" "patchmon.server.securityContext.pod") -}}
+{{- end -}}
+
+{{- define "patchmon.server.containerSecurityContext" -}}
+{{- $given := (fromYaml (include "patchmon.subBlock" (dict "block" . "key" "container" "path" "patchmon.server.securityContext"))).value -}}
+{{- $defaults := dict
+      "allowPrivilegeEscalation" false
+      "readOnlyRootFilesystem" true
+      "runAsNonRoot" true
+      "capabilities" (dict "drop" (list "ALL")) -}}
+{{- include "patchmon.defaultedDict" (dict "defaults" $defaults "given" $given "path" "patchmon.server.securityContext.container") -}}
+{{- end -}}
+
+{{- define "patchmon.guacd.containerSecurityContext" -}}
+{{- $given := (fromYaml (include "patchmon.subBlock" (dict "block" . "key" "container" "path" "patchmon.guacd.securityContext"))).value -}}
+{{- $defaults := dict
+      "allowPrivilegeEscalation" false
+      "readOnlyRootFilesystem" true
+      "runAsNonRoot" true
+      "runAsUser" 1000
+      "runAsGroup" 1000
+      "capabilities" (dict "drop" (list "ALL")) -}}
+{{- include "patchmon.defaultedDict" (dict "defaults" $defaults "given" $given "path" "patchmon.guacd.securityContext.container") -}}
+{{- end -}}
+
+{{- define "patchmon.server.httpGet" -}}
+{{- dict "path" "/health" "port" 3000 "httpHeaders" (list (dict "name" "Host" "value" (.root.Values.ingress.domain | default ""))) | toYaml -}}
+{{- end -}}
+
+{{- define "patchmon.server.livenessProbe" -}}
+{{- $defaults := dict
+      "httpGet" (fromYaml (include "patchmon.server.httpGet" .))
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 3 -}}
+{{- include "patchmon.defaultedDict" (dict "defaults" $defaults "given" .given "path" "patchmon.server.livenessProbe") -}}
+{{- end -}}
+
+{{- define "patchmon.server.readinessProbe" -}}
+{{- $defaults := dict
+      "httpGet" (fromYaml (include "patchmon.server.httpGet" .))
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 3 -}}
+{{- include "patchmon.defaultedDict" (dict "defaults" $defaults "given" .given "path" "patchmon.server.readinessProbe") -}}
+{{- end -}}
+
+{{- define "patchmon.server.startupProbe" -}}
+{{- $defaults := dict
+      "httpGet" (fromYaml (include "patchmon.server.httpGet" .))
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 60 -}}
+{{- include "patchmon.defaultedDict" (dict "defaults" $defaults "given" .given "path" "patchmon.server.startupProbe") -}}
+{{- end -}}
+
+{{- define "patchmon.guacd.livenessProbe" -}}
+{{- $defaults := dict
+      "tcpSocket" (dict "port" 4822)
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 3 -}}
+{{- include "patchmon.defaultedDict" (dict "defaults" $defaults "given" . "path" "patchmon.guacd.livenessProbe") -}}
+{{- end -}}
+
+{{- define "patchmon.guacd.readinessProbe" -}}
+{{- $defaults := dict
+      "tcpSocket" (dict "port" 4822)
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 3 -}}
+{{- include "patchmon.defaultedDict" (dict "defaults" $defaults "given" . "path" "patchmon.guacd.readinessProbe") -}}
+{{- end -}}
+
+{{- define "patchmon.guacd.startupProbe" -}}
+{{- $defaults := dict
+      "tcpSocket" (dict "port" 4822)
+      "periodSeconds" 5
+      "timeoutSeconds" 5
+      "failureThreshold" 30 -}}
+{{- include "patchmon.defaultedDict" (dict "defaults" $defaults "given" . "path" "patchmon.guacd.startupProbe") -}}
+{{- end -}}
+
+{{/*
+The effective resources blocks, fed into the resources helper above so that an
+erased "resources:" still yields the chart's requests and computed limits
+instead of a container without any resource accounting.
+*/}}
+{{- define "patchmon.server.effectiveResources" -}}
+{{- $defaults := dict
+      "limitFactor" 3
+      "requests" (dict "cpu" 0.1 "memory" "256Mi" "ephemeral-storage" "10Mi") -}}
+{{- $merged := fromYaml (include "patchmon.defaultedDict" (dict "defaults" $defaults "given" . "path" "patchmon.server.resources")) -}}
+{{- include "patchmon.resources" $merged -}}
+{{- end -}}
+
+{{- define "patchmon.guacd.effectiveResources" -}}
+{{- $defaults := dict
+      "limitFactor" 3
+      "requests" (dict "cpu" 0.05 "memory" "64Mi" "ephemeral-storage" "10Mi") -}}
+{{- $merged := fromYaml (include "patchmon.defaultedDict" (dict "defaults" $defaults "given" . "path" "patchmon.guacd.resources")) -}}
+{{- include "patchmon.resources" $merged -}}
+{{- end -}}

--- a/patchmon/templates/patchmon.deployment.yaml
+++ b/patchmon/templates/patchmon.deployment.yaml
@@ -23,13 +23,13 @@ spec:
       # for the same reason).
       hostname: {{ .Release.Name }}-{{ .Chart.Name }}-server
       securityContext:
-        {{- toYaml .Values.patchmon.server.securityContext.pod | nindent 8 }}
+        {{- include "patchmon.server.podSecurityContext" .Values.patchmon.server.securityContext | nindent 8 }}
       containers:
         - name: {{ .Release.Name }}-{{ .Chart.Name }}-server
           image: "ghcr.io/patchmon/patchmon-server:{{ .Chart.AppVersion }}"
           imagePullPolicy: IfNotPresent
           securityContext:
-            {{- toYaml .Values.patchmon.server.securityContext.container | nindent 12 }}
+            {{- include "patchmon.server.containerSecurityContext" .Values.patchmon.server.securityContext | nindent 12 }}
           ports:
             - containerPort: 3000
               protocol: TCP
@@ -166,13 +166,13 @@ spec:
           # Probe values are rendered through tpl (see values.yaml for the
           # defaults and why the probes send a Host header).
           livenessProbe:
-            {{- tpl (toYaml .Values.patchmon.server.livenessProbe) . | nindent 12 }}
+            {{- tpl (include "patchmon.server.livenessProbe" (dict "given" .Values.patchmon.server.livenessProbe "root" $)) . | nindent 12 }}
           readinessProbe:
-            {{- tpl (toYaml .Values.patchmon.server.readinessProbe) . | nindent 12 }}
+            {{- tpl (include "patchmon.server.readinessProbe" (dict "given" .Values.patchmon.server.readinessProbe "root" $)) . | nindent 12 }}
           startupProbe:
-            {{- tpl (toYaml .Values.patchmon.server.startupProbe) . | nindent 12 }}
+            {{- tpl (include "patchmon.server.startupProbe" (dict "given" .Values.patchmon.server.startupProbe "root" $)) . | nindent 12 }}
           resources:
-            {{- include "patchmon.resources" .Values.patchmon.server.resources | nindent 12 }}
+            {{- include "patchmon.server.effectiveResources" .Values.patchmon.server.resources | nindent 12 }}
           volumeMounts:
             # The image is stateless, but the Go server needs a writable /tmp
             # for scratch files with a read-only root filesystem.
@@ -206,19 +206,19 @@ spec:
             {{- end }}
           {{- end }}
           securityContext:
-            {{- toYaml .Values.patchmon.guacd.securityContext.container | nindent 12 }}
+            {{- include "patchmon.guacd.containerSecurityContext" .Values.patchmon.guacd.securityContext | nindent 12 }}
           ports:
             - containerPort: 4822
               protocol: TCP
               name: guacd
           livenessProbe:
-            {{- tpl (toYaml .Values.patchmon.guacd.livenessProbe) . | nindent 12 }}
+            {{- tpl (include "patchmon.guacd.livenessProbe" .Values.patchmon.guacd.livenessProbe) . | nindent 12 }}
           readinessProbe:
-            {{- tpl (toYaml .Values.patchmon.guacd.readinessProbe) . | nindent 12 }}
+            {{- tpl (include "patchmon.guacd.readinessProbe" .Values.patchmon.guacd.readinessProbe) . | nindent 12 }}
           startupProbe:
-            {{- tpl (toYaml .Values.patchmon.guacd.startupProbe) . | nindent 12 }}
+            {{- tpl (include "patchmon.guacd.startupProbe" .Values.patchmon.guacd.startupProbe) . | nindent 12 }}
           resources:
-            {{- include "patchmon.resources" .Values.patchmon.guacd.resources | nindent 12 }}
+            {{- include "patchmon.guacd.effectiveResources" .Values.patchmon.guacd.resources | nindent 12 }}
           volumeMounts:
             - name: guacd-tmp
               mountPath: /tmp

--- a/patchmon/templates/patchmon.ingress.yaml
+++ b/patchmon/templates/patchmon.ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -26,3 +27,4 @@ spec:
     - hosts:
         - {{ required "A Domain/Host must be provided" .Values.ingress.domain }}
       secretName: tls-{{ .Release.Name }}-{{ .Chart.Name }}-ingress
+{{- end }}

--- a/patchmon/values.schema.json
+++ b/patchmon/values.schema.json
@@ -57,13 +57,13 @@
               "type": "string"
             },
             "securityContext": {
-              "description": "guacd is a sidecar in the server pod, so only a container context applies - the pod context is the server's.",
-              "type": "object",
+              "description": "guacd is a sidecar in the server pod, so only a container context applies - the pod context is the server's. May be null / empty: the chart then falls back to its hardening defaults (issue #99).",
+              "type": ["object", "null"],
               "additionalProperties": false,
               "properties": {
                 "container": {
-                  "description": "Rendered verbatim as the container's securityContext; kept open because the chart does not interpret it.",
-                  "type": "object"
+                  "description": "Merged onto the chart's container hardening defaults and rendered as the container's securityContext; kept open because the chart does not interpret the individual fields.",
+                  "type": ["object", "null"]
                 }
               }
             },
@@ -130,7 +130,8 @@
   },
   "definitions": {
     "resources": {
-      "type": "object",
+      "description": "May be null / empty: the chart then falls back to its default requests and computed limits (issue #99) instead of rendering a container without resource accounting.",
+      "type": ["object", "null"],
       "additionalProperties": false,
       "properties": {
         "limitFactor": {
@@ -146,7 +147,7 @@
       }
     },
     "resourceList": {
-      "type": "object",
+      "type": ["object", "null"],
       "additionalProperties": false,
       "properties": {
         "cpu": {
@@ -205,22 +206,23 @@
       }
     },
     "securityContext": {
-      "type": "object",
+      "description": "May be null / empty at any level: the chart then falls back to its hardening defaults (issue #99) instead of rendering an unhardened workload.",
+      "type": ["object", "null"],
       "additionalProperties": false,
       "properties": {
         "pod": {
-          "description": "Rendered verbatim as the pod's securityContext; kept open because the chart does not interpret it.",
-          "type": "object"
+          "description": "Merged onto the chart's pod hardening defaults and rendered as the pod's securityContext; kept open because the chart does not interpret the individual fields.",
+          "type": ["object", "null"]
         },
         "container": {
-          "description": "Rendered verbatim as the container's securityContext; kept open because the chart does not interpret it.",
-          "type": "object"
+          "description": "Merged onto the chart's container hardening defaults and rendered as the container's securityContext; kept open because the chart does not interpret the individual fields.",
+          "type": ["object", "null"]
         }
       }
     },
     "probe": {
-      "description": "Rendered verbatim as a container probe; kept open because the chart does not interpret it.",
-      "type": "object"
+      "description": "Merged onto the chart's probe defaults and rendered as a container probe; kept open because the chart does not interpret the individual fields. May be null / empty, which means the defaults apply (issue #99) rather than the probe disappearing.",
+      "type": ["object", "null"]
     }
   }
 }

--- a/patchmon/values.schema.json
+++ b/patchmon/values.schema.json
@@ -1,0 +1,226 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "patchmon values",
+  "description": "Strict values schema (issue #68). additionalProperties is false on every chart-owned object level, so a key that the chart does not read is rejected at render time instead of being silently ignored. The only objects that stay open are the ones passed verbatim into the Kubernetes pod spec (probes, security contexts, global) - the chart does not interpret their contents, so it cannot judge which keys are meaningful.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "global": {
+      "description": "Helm's conventional cross-chart values. Unused by this chart, kept open so an umbrella install cannot break on it.",
+      "type": "object"
+    },
+    "scaleDown": {
+      "type": "boolean"
+    },
+    "patchmon": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "server": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "replicas": {
+              "description": "The server registers itself under a stable identity (the pinned pod hostname); more than one replica is not supported by this chart.",
+              "type": "integer",
+              "minimum": 0
+            },
+            "securityContext": {
+              "$ref": "#/definitions/securityContext"
+            },
+            "livenessProbe": {
+              "$ref": "#/definitions/probe"
+            },
+            "readinessProbe": {
+              "$ref": "#/definitions/probe"
+            },
+            "startupProbe": {
+              "$ref": "#/definitions/probe"
+            },
+            "env": {
+              "$ref": "#/definitions/env"
+            },
+            "resources": {
+              "$ref": "#/definitions/resources"
+            }
+          }
+        },
+        "guacd": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "image": {
+              "description": "guacd is an independent upstream application, so its image is pinned here instead of following the chart's appVersion.",
+              "type": "string"
+            },
+            "securityContext": {
+              "description": "guacd is a sidecar in the server pod, so only a container context applies - the pod context is the server's.",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "container": {
+                  "description": "Rendered verbatim as the container's securityContext; kept open because the chart does not interpret it.",
+                  "type": "object"
+                }
+              }
+            },
+            "livenessProbe": {
+              "$ref": "#/definitions/probe"
+            },
+            "readinessProbe": {
+              "$ref": "#/definitions/probe"
+            },
+            "startupProbe": {
+              "$ref": "#/definitions/probe"
+            },
+            "env": {
+              "$ref": "#/definitions/env"
+            },
+            "resources": {
+              "$ref": "#/definitions/resources"
+            }
+          }
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "description": "Gates the whole Ingress template (issue #93). false omits the Ingress, and the required domain/clusterIssuer values are then not needed either.",
+          "type": "boolean"
+        },
+        "clusterIssuer": {
+          "type": ["string", "null"]
+        },
+        "domain": {
+          "type": ["string", "null"]
+        },
+        "className": {
+          "type": ["string", "null"]
+        },
+        "annotations": {
+          "description": "Extra Ingress annotations, merged with the cert-manager annotation the chart always sets. Free-form keys by nature.",
+          "type": "object"
+        }
+      }
+    },
+    "secrets": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "redisSecretRef": {
+          "type": ["string", "null"]
+        },
+        "postgresSecretRef": {
+          "type": ["string", "null"]
+        },
+        "oidcSecretRef": {
+          "type": ["string", "null"]
+        },
+        "patchmonSecretRef": {
+          "type": ["string", "null"]
+        }
+      }
+    }
+  },
+  "definitions": {
+    "resources": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "limitFactor": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "requests": {
+          "$ref": "#/definitions/resourceList"
+        },
+        "limits": {
+          "$ref": "#/definitions/resourceList"
+        }
+      }
+    },
+    "resourceList": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "cpu": {
+          "type": ["string", "number", "null"]
+        },
+        "memory": {
+          "type": ["string", "number", "null"]
+        },
+        "ephemeral-storage": {
+          "type": ["string", "number", "null"]
+        },
+        "ephemeralStorage": {
+          "type": ["string", "number", "null"]
+        }
+      }
+    },
+    "env": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "valueFrom": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "secretKeyRef": {
+                "$ref": "#/definitions/keyRef"
+              },
+              "configMapKeyRef": {
+                "$ref": "#/definitions/keyRef"
+              }
+            }
+          }
+        }
+      }
+    },
+    "keyRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "key"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        }
+      }
+    },
+    "securityContext": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "pod": {
+          "description": "Rendered verbatim as the pod's securityContext; kept open because the chart does not interpret it.",
+          "type": "object"
+        },
+        "container": {
+          "description": "Rendered verbatim as the container's securityContext; kept open because the chart does not interpret it.",
+          "type": "object"
+        }
+      }
+    },
+    "probe": {
+      "description": "Rendered verbatim as a container probe; kept open because the chart does not interpret it.",
+      "type": "object"
+    }
+  }
+}

--- a/patchmon/values.yaml
+++ b/patchmon/values.yaml
@@ -136,6 +136,10 @@ patchmon:
     env: []
 
 ingress:
+  # Set to false to omit the Ingress entirely (the required domain and
+  # clusterIssuer values are then not needed either, because they are only
+  # read inside the Ingress template).
+  enabled: true
   clusterIssuer: null
   domain: null
   className: nginx


### PR DESCRIPTION
Viertes Chart der **Welle 1** aus #68 (nach #90 cyberchef, #94 gotenberg, #95 apache-tika) — und der erste PR mit **allen drei** Änderungen: #68, #93 und #99.

Der PR tut **drei Dinge**, unten getrennt ausgewiesen. Sie gehören derselben Klasse an: Werte, die nicht tun, was sie versprechen.

---

# 1. Strict `values.schema.json` (#68)

- `additionalProperties: false` auf **allen chart-eigenen Objektebenen** — oberste Ebene, `patchmon`, `patchmon.server`, `patchmon.guacd`, beider `resources`/`.requests`/`.limits`, `env[]`, `env[].valueFrom`, `.secretKeyRef`/`.configMapKeyRef`, beider `securityContext`, `ingress`, `secrets`.
- **Offen bleiben** die wörtlich in die Pod-Spec durchgereichten Objekte: alle sechs Probes, `securityContext.pod`/`.container`, `global`, sowie `ingress.annotations` (freie Annotation-Keys per Natur).

Erstes Chart der Welle mit **zwei Workload-Blöcken**, und das nutzt die Schärfe des Musters aus:

**`patchmon.guacd.securityContext` erlaubt nur `container`, nicht `pod`.** guacd ist ein Sidecar im Server-Pod; einen eigenen Pod-Context gibt es nicht, das Template liest ausschließlich `.securityContext.container`. Ein dort gesetzter `pod`-Block wäre exakt der Fehlertyp aus dem Piloten: plausibel aussehende Konfiguration, die nie wirkt.

# 2. Ingress-Gate (#93)

Das Ingress-Template beginnt jetzt mit `{{- if .Values.ingress.enabled }}` und endet auf `{{- end }}`, wie in `outline` und `urlaubsverwaltung`. Der Schlüssel fehlte in `patchmon/values.yaml` bislang ganz und kommt mit Default **`true`** hinzu — **am Verhalten ändert sich damit nichts**. Im Schema ist er entsprechend **erlaubt**.

### Änderung gegenüber meiner ursprünglichen Planung

In einer früheren Fassung dieses PRs hätte das Schema `ingress.enabled` **abgewiesen** — genau die Beobachtung, die laut #93 die Formulierung dort ausgelöst hat. Mit dem Gate ist der Schlüssel real und wird erlaubt. Die Negativprobe weicht deshalb auf einen **Tippfehler** dieses neuen Schlüssels aus (`ingress.enable`), was den Fall gleich mit absichert.

### Chart-spezifische Besonderheit: das Gate befreit hier nur von `clusterIssuer`, nicht von `domain`

Bei cyberchef entfällt mit dem Gate die Pflicht zu **beiden** Werten, weil beide `required()`-Aufrufe in der Ingress-Datei stehen. Bei patchmon ist das **nicht** so: `ingress.domain` wird zusätzlich im Deployment gelesen und speist `CORS_ORIGIN` —

```
- name: CORS_ORIGIN
  value: "https://{{ required "A Domain/Host must be provided" .Values.ingress.domain }}"
```

Der 2.x-Server weist Requests ab, deren Host-Header weder Loopback noch ein CORS_ORIGIN-Host ist (deshalb tragen auch die Probes den Host-Header). `domain` ist bei patchmon also **kein reiner Ingress-Wert** und bleibt zu Recht auch bei `enabled: false` erforderlich. Das ist kein Versehen, sondern das korrekte Verhalten für dieses Chart — belegt unten.

---

## Verifikation

**Lint**

```
$ helm lint --strict patchmon
1 chart(s) linted, 0 chart(s) failed
```

Keine Findings. Die `[INFO] Missing required value`-Zeilen sind vorbestehend (`secrets.*SecretRef` und die Ingress-Werte haben keine Defaults; `helm lint` rendert nach einem fehlenden `required` weiter).

**Rendern**

| Fall | Ergebnis |
|---|---|
| `ci/patchmon/test-values.yaml` | rendert, **1** Ingress-Objekt |
| `ci`-Werte + `patchmon.guacd.enabled=true` | rendert |
| archivierte produktive Werte | rendert |
| `ingress.enabled=false` + `domain`, **ohne `clusterIssuer`** | rendert, **0** Ingress-Objekte, `CORS_ORIGIN=https://patchmon.example.com` |
| `ingress.enabled=false` **ohne `domain`** | scheitert an `CORS_ORIGIN` — korrekt, siehe oben |
| Default-Values | scheitert an `required()` wie vor dieser Änderung (unverändert) |

Das Gate schaltet den Ingress also wirklich ab und macht `clusterIssuer` entbehrlich, ohne die inhaltlich nötige `domain` zu verlieren.

**Negativprobe — mehrere Ebenen, alle abgewiesen**

```
--set bogusTopLevel=true
  -> at '': additional properties 'bogusTopLevel' not allowed

--set patchmon.server.resources.requests.bogusCpu=1        (vierte Ebene)
  -> at '/patchmon/server/resources/requests': additional properties 'bogusCpu' not allowed

--set patchmon.guacd.securityContext.pod.runAsUser=1000    (Sidecar ohne Pod-Context)
  -> at '/patchmon/guacd/securityContext': additional properties 'pod' not allowed

--set ingress.enable=false                                 (Tippfehler des neuen Gate-Schlüssels)
  -> at '/ingress': additional properties 'enable' not allowed
```

Alle vier gegen die archivierten produktiven Werte gerendert, nicht gegen Chart-Defaults.

## Validierung gegen die real ausgerollten Werte

**Für patchmon gibt es kein produktives Bundle mehr** — ausdrücklich vermerkt statt stillschweigend übergangen:

- Unter `fleet-cd/` existiert kein patchmon-Bundle.
- Die Konfiguration liegt nur noch unter `cluster-config/archive/patchmon/` (gepinnt auf `1.4.0+up1.4.2`).
- Im Cluster gibt es keine patchmon-Helm-Release (`helm list -A` führt keine).

Validiert habe ich deshalb gegen die **archivierte** Werte-Datei `archive/patchmon/patchmon/patchmon.values.yaml`, die `ingress.{clusterIssuer,domain}` und alle vier `secrets.*SecretRef` setzt: **rendert durch, Liste abgewiesener Schlüssel leer.**

Für die Cluster-Seite ergibt sich **keine Arbeitsanweisung** — es gibt nichts, das hochgezogen werden müsste. Sollte patchmon je reaktiviert werden, validieren die archivierten Werte unverändert gegen das neue Schema.

# 3. Null-Absicherung für Härtung, Probes und Ressourcen (#99)

Der Helper `defaultedDict` aus #96 wird übernommen (chart-präfigiert, weil die Charts keine Dependencies haben), dazu ein `subBlock`-Helper für den Fall, dass `securityContext` **selbst** erased ist. Abgesichert sind **beide** Workloads: Server-Pod-Context, Server-Container-Context, guacd-Container-Context, alle sechs Probes und beide `resources`-Blöcke.

### Wechselwirkung mit Punkt 1

Das Schema hätte `null` für genau diese Blöcke sonst **abgewiesen** (`"type": "object"`), und der Helper wäre nie zum Zug gekommen. Die Typen sind deshalb auf `["object", "null"]` erweitert — die beiden Änderungen müssen zusammenpassen, sonst lehnt das Schema ab, was die Absicherung auffangen soll. Bei allen übrigen Schlüsseln bleibt das Schema unverändert streng (siehe Negativproben oben).

### Besonderheit: die Server-Probes bauen ihren Host-Header neu auf

Die Server-Probes tragen einen `Host`-Header, weil der 2.x-Server Requests ablehnt, deren Host weder Loopback noch ein CORS_ORIGIN-Host ist. Der Default wird über den durchgereichten Root-Context aus `.Values.ingress.domain` gebaut, damit er auch dann korrekt ist, wenn der Probe-Block erased wurde:

**Vorher**, `--set patchmon.server.livenessProbe=null`:

```yaml
          livenessProbe:
            null
```

Die Probe verschwindet ersatzlos. **Nachher**, identischer Aufruf:

```yaml
          livenessProbe:
            failureThreshold: 3
            httpGet:
              httpHeaders:
              - name: Host
                value: patchmon.ci.local     # <- aus ingress.domain rekonstruiert
              path: /health
              port: 3000
            periodSeconds: 10
            timeoutSeconds: 5
```

## Nachweis 1: erased Block → vorher ungehärtet, nachher Defaults

`--set patchmon.server.securityContext.container=null` — **vorher**:

```yaml
          securityContext:
            null
```

**nachher**:

```yaml
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: true
            runAsNonRoot: true
```

Und für die Ressourcen, `--set patchmon.server.resources=null` — vorher `resources: {}` (keine Requests, keine berechneten Limits), nachher:

```yaml
          resources:
            limits:
              ephemeral-storage: 30Mi
              memory: 768Mi
            requests:
              cpu: 0.1
              ephemeral-storage: 10Mi
              memory: 256Mi
```

## Nachweis 2: ein bewusst gesetztes `false` / `0` gewinnt weiterhin

Die Stelle, an der `default` und `mergeOverwrite` scheitern.

`--set patchmon.server.securityContext.container.readOnlyRootFilesystem=false`:

```yaml
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: false     # <- gesetzter Zero-Value gewinnt
            runAsNonRoot: true                # <- übrige Defaults überleben
```

`--set patchmon.guacd.livenessProbe.failureThreshold=0`:

```yaml
          livenessProbe:
            failureThreshold: 0               # <- explizite 0 gewinnt
            periodSeconds: 10
            tcpSocket:
              port: 4822
            timeoutSeconds: 5
```

Beide zeigen zugleich den rekursiven Teilmerge: Ein teilweise gefüllter Block überschreibt nur die Schlüssel, die er wirklich setzt.

## Nachweis 3: im Normalfall ändert sich nichts

Weder die Absicherung noch das Gate dürfen Verhalten verschieben, solange nichts erased ist. Alter Chart-Stand (`origin/main`) gegen neuen, mit `ci/patchmon/test-values.yaml`:

```
$ diff <(helm template t <origin/main-Stand> …) <(helm template t patchmon …)
(keine Ausgabe — byte-identisch)

$ # dasselbe mit --set patchmon.guacd.enabled=true
(keine Ausgabe — byte-identisch)
```

Das belegt zugleich, dass das Gate aus Punkt 2 mit Default `true` verhaltensneutral ist.

Refs #68, Refs #93, Refs #99 (alle drei Issues umfassen mehr als dieses Chart und bleiben offen).
