### PR TITLE
urlaubsverwaltung: strict values.schema.json + Null-Absicherung (Welle 1, #68/#99)

### DIFF
--- a/urlaubsverwaltung/Chart.yaml
+++ b/urlaubsverwaltung/Chart.yaml
@@ -4,5 +4,5 @@ description: A Helm chart to deploy urlaubsverwaltung on Kubernetes
 icon: https://raw.githubusercontent.com/urlaubsverwaltung/urlaubsverwaltung/main/src/main/resources/static/favicons/apple-touch-icon.png
 type: application
 
-version: 6.0.0+up6.7.0
+version: 7.0.0+up6.7.0
 appVersion: 6.7.0

--- a/urlaubsverwaltung/templates/_helpers.tpl
+++ b/urlaubsverwaltung/templates/_helpers.tpl
@@ -114,3 +114,157 @@ template-chart is the reference implementation.
 1
 {{- end -}}
 {{- end -}}
+
+{{/*
+Merge a user-supplied values sub-tree onto a dict of chart defaults so that a
+null / empty override falls back to the defaults instead of erasing them.
+
+Input: dict "defaults" <dict> "given" <dict|nil> "path" <string, optional
+values path used in error messages>. Output: YAML of the merged dict (consume
+it with fromYaml).
+
+Why this exists (issue #99): Helm merges values maps recursively, but an
+override key written without children — e.g. a leftover
+
+  securityContext:
+
+after deleting its last remaining sub-key — is YAML null and replaces the
+whole default sub-tree. The container then renders with "securityContext:
+null": no readOnlyRootFilesystem, no dropped capabilities, no
+allowPrivilegeEscalation: false. The workload starts and reports healthy while
+being unhardened, so nothing points at the mistake. The same shape erases a
+probe (it disappears) or the resources block (no requests, no computed
+limits). This helper defines the opposite semantics: an empty block means
+"chart defaults apply".
+
+Rules:
+  - a nil "given" is treated as an empty dict (all defaults apply).
+  - a key whose override value is null keeps the default (nulls never delete).
+  - a key present in both as a map is merged recursively, so a partially
+    filled block only overrides the keys it actually sets.
+  - a scalar override for a key the defaults define as a map is rejected with
+    a message naming the values path, instead of failing later with a template
+    field error.
+  - any other set value wins as given, including an explicit false or 0 —
+    Helm's "default" and sprig's "mergeOverwrite" would both swallow those
+    zero values, hence the explicit kindIs "invalid" nil check.
+  - keys only present in the override are passed through unchanged.
+
+NOTE: like the helpers above, this is duplicated into every chart's
+templates/_helpers.tpl with the chart's name as define prefix, because charts
+in this repo deliberately have no dependencies.
+*/}}
+{{- define "urlaubsverwaltung.defaultedDict" -}}
+{{- $defaults := .defaults | default dict -}}
+{{- $given := .given -}}
+{{- $path := .path | default "value" -}}
+{{- if kindIs "invalid" $given -}}
+{{- $given = dict -}}
+{{- end -}}
+{{- if not (kindIs "map" $given) -}}
+{{- fail (printf "%s must be a mapping or null, got %s (%v)" $path (kindOf $given) $given) -}}
+{{- end -}}
+{{- $out := deepCopy $defaults -}}
+{{- range $key, $value := $given -}}
+{{- if not (kindIs "invalid" $value) -}}
+{{- $default := index $defaults $key -}}
+{{- if and (kindIs "map" $value) (kindIs "map" $default) -}}
+{{- $_ := set $out $key (fromYaml (include "urlaubsverwaltung.defaultedDict" (dict "defaults" $default "given" $value "path" (printf "%s.%s" $path $key)))) -}}
+{{- else if kindIs "map" $default -}}
+{{- fail (printf "%s.%s must be a mapping or null, got %s (%v)" $path $key (kindOf $value) $value) -}}
+{{- else -}}
+{{- $_ := set $out $key $value -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- toYaml $out -}}
+{{- end -}}
+
+{{/*
+Pick one sub-block out of a values block that may itself be null.
+
+Input: dict "block" <dict|nil> "key" <string> "path" <string>.
+Returns YAML of dict "value" <the sub-block, may be nil>, after rejecting a
+non-mapping block with a message that names the values path. Needed because
+".Values.<app>.securityContext" can itself be erased, and indexing into nil
+inside a template is not an error but silently yields nothing.
+*/}}
+{{- define "urlaubsverwaltung.subBlock" -}}
+{{- $block := .block -}}
+{{- if kindIs "invalid" $block -}}
+{{- $block = dict -}}
+{{- end -}}
+{{- if not (kindIs "map" $block) -}}
+{{- fail (printf "%s must be a mapping or null, got %s (%v)" .path (kindOf $block) $block) -}}
+{{- end -}}
+{{- toYaml (dict "value" (index $block .key)) -}}
+{{- end -}}
+
+{{/*
+The effective pod / container security contexts, probes and resources
+(issue #99).
+
+The defaults below MUST stay in sync with the corresponding blocks in
+values.yaml, which stays the documented, user-facing place for them; this copy
+is only the fallback for the case where an override has erased the block.
+*/}}
+{{- define "urlaubsverwaltung.podSecurityContext" -}}
+{{- $given := (fromYaml (include "urlaubsverwaltung.subBlock" (dict "block" . "key" "pod" "path" "urlaubsverwaltung.securityContext"))).value -}}
+{{- $defaults := dict
+      "runAsNonRoot" true
+      "runAsUser" 1002
+      "runAsGroup" 1001 -}}
+{{- include "urlaubsverwaltung.defaultedDict" (dict "defaults" $defaults "given" $given "path" "urlaubsverwaltung.securityContext.pod") -}}
+{{- end -}}
+
+{{- define "urlaubsverwaltung.containerSecurityContext" -}}
+{{- $given := (fromYaml (include "urlaubsverwaltung.subBlock" (dict "block" . "key" "container" "path" "urlaubsverwaltung.securityContext"))).value -}}
+{{- $defaults := dict
+      "allowPrivilegeEscalation" false
+      "readOnlyRootFilesystem" true
+      "runAsNonRoot" true
+      "capabilities" (dict "drop" (list "ALL")) -}}
+{{- include "urlaubsverwaltung.defaultedDict" (dict "defaults" $defaults "given" $given "path" "urlaubsverwaltung.securityContext.container") -}}
+{{- end -}}
+
+{{- define "urlaubsverwaltung.livenessProbe" -}}
+{{- $defaults := dict
+      "httpGet" (dict "port" 8080 "path" "/actuator/health/liveness")
+      "periodSeconds" 10
+      "failureThreshold" 3
+      "successThreshold" 1
+      "timeoutSeconds" 5 -}}
+{{- include "urlaubsverwaltung.defaultedDict" (dict "defaults" $defaults "given" . "path" "urlaubsverwaltung.livenessProbe") -}}
+{{- end -}}
+
+{{- define "urlaubsverwaltung.readinessProbe" -}}
+{{- $defaults := dict
+      "httpGet" (dict "port" 8080 "path" "/actuator/health/readiness")
+      "periodSeconds" 5
+      "failureThreshold" 3
+      "successThreshold" 1
+      "timeoutSeconds" 5 -}}
+{{- include "urlaubsverwaltung.defaultedDict" (dict "defaults" $defaults "given" . "path" "urlaubsverwaltung.readinessProbe") -}}
+{{- end -}}
+
+{{- define "urlaubsverwaltung.startupProbe" -}}
+{{- $defaults := dict
+      "httpGet" (dict "port" 8080 "path" "/actuator/health/liveness")
+      "periodSeconds" 10
+      "failureThreshold" 30
+      "timeoutSeconds" 5 -}}
+{{- include "urlaubsverwaltung.defaultedDict" (dict "defaults" $defaults "given" . "path" "urlaubsverwaltung.startupProbe") -}}
+{{- end -}}
+
+{{/*
+The effective resources block, fed into the resources helper above so that an
+erased "resources:" still yields the chart's requests and computed limits
+instead of a container without any resource accounting.
+*/}}
+{{- define "urlaubsverwaltung.effectiveResources" -}}
+{{- $defaults := dict
+      "limitFactor" 3
+      "requests" (dict "cpu" 0.1 "memory" "768Mi" "ephemeralStorage" "10Mi") -}}
+{{- $merged := fromYaml (include "urlaubsverwaltung.defaultedDict" (dict "defaults" $defaults "given" . "path" "urlaubsverwaltung.resources")) -}}
+{{- include "urlaubsverwaltung.resources" $merged -}}
+{{- end -}}

--- a/urlaubsverwaltung/templates/urlaubsverwaltung.deployment.yaml
+++ b/urlaubsverwaltung/templates/urlaubsverwaltung.deployment.yaml
@@ -17,13 +17,13 @@ spec:
     spec:
       automountServiceAccountToken: false
       securityContext:
-        {{- toYaml .Values.urlaubsverwaltung.securityContext.pod | nindent 8 }}
+        {{- include "urlaubsverwaltung.podSecurityContext" .Values.urlaubsverwaltung.securityContext | nindent 8 }}
       containers:
         - name: {{ .Release.Name }}-{{ .Chart.Name }}-deployment
           image: "urlaubsverwaltung/urlaubsverwaltung:{{ .Chart.AppVersion }}"
           imagePullPolicy: IfNotPresent
           securityContext:
-            {{- toYaml .Values.urlaubsverwaltung.securityContext.container | nindent 12 }}
+            {{- include "urlaubsverwaltung.containerSecurityContext" .Values.urlaubsverwaltung.securityContext | nindent 12 }}
           volumeMounts:
             # The JVM (Tomcat work dir, temp files) needs a writable /tmp with
             # a read-only root filesystem.
@@ -130,13 +130,13 @@ spec:
             {{- end }}
             {{- end }}
           resources:
-            {{- include "urlaubsverwaltung.resources" .Values.urlaubsverwaltung.resources | nindent 12 }}
+            {{- include "urlaubsverwaltung.effectiveResources" .Values.urlaubsverwaltung.resources | nindent 12 }}
           livenessProbe:
-            {{- toYaml .Values.urlaubsverwaltung.livenessProbe | nindent 12 }}
+            {{- include "urlaubsverwaltung.livenessProbe" .Values.urlaubsverwaltung.livenessProbe | nindent 12 }}
           readinessProbe:
-            {{- toYaml .Values.urlaubsverwaltung.readinessProbe | nindent 12 }}
+            {{- include "urlaubsverwaltung.readinessProbe" .Values.urlaubsverwaltung.readinessProbe | nindent 12 }}
           startupProbe:
-            {{- toYaml .Values.urlaubsverwaltung.startupProbe | nindent 12 }}
+            {{- include "urlaubsverwaltung.startupProbe" .Values.urlaubsverwaltung.startupProbe | nindent 12 }}
       volumes:
         - name: tmp
           emptyDir: {}

--- a/urlaubsverwaltung/values.schema.json
+++ b/urlaubsverwaltung/values.schema.json
@@ -1,0 +1,175 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "urlaubsverwaltung values",
+  "description": "Strict values schema (issue #68). additionalProperties is false on every chart-owned object level, so a key that the chart does not read is rejected at render time instead of being silently ignored. The only objects that stay open are the ones passed verbatim into the Kubernetes pod spec (probes, security contexts, global) - the chart does not interpret their contents, so it cannot judge which keys are meaningful.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "global": {
+      "description": "Helm's conventional cross-chart values. Unused by this chart, kept open so an umbrella install cannot break on it.",
+      "type": "object"
+    },
+    "scaleDown": {
+      "type": "boolean"
+    },
+    "secrets": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "databaseSecretRef": {
+          "type": ["string", "null"]
+        },
+        "oidcSecretRef": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "clusterIssuer": {
+          "type": ["string", "null"]
+        },
+        "domain": {
+          "type": ["string", "null"]
+        },
+        "className": {
+          "type": ["string", "null"]
+        },
+        "annotations": {
+          "description": "Extra Ingress annotations, merged with the cert-manager annotation the chart always sets. Free-form keys by nature.",
+          "type": "object"
+        }
+      }
+    },
+    "urlaubsverwaltung": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "replicas": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "securityContext": {
+          "$ref": "#/definitions/securityContext"
+        },
+        "livenessProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "readinessProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "startupProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "env": {
+          "$ref": "#/definitions/env"
+        },
+        "resources": {
+          "$ref": "#/definitions/resources"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "resources": {
+      "description": "May be null / empty: the chart then falls back to its default requests and computed limits (issue #99) instead of rendering a container without resource accounting.",
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "limitFactor": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "requests": {
+          "$ref": "#/definitions/resourceList"
+        },
+        "limits": {
+          "$ref": "#/definitions/resourceList"
+        }
+      }
+    },
+    "resourceList": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "cpu": {
+          "type": ["string", "number", "null"]
+        },
+        "memory": {
+          "type": ["string", "number", "null"]
+        },
+        "ephemeral-storage": {
+          "type": ["string", "number", "null"]
+        },
+        "ephemeralStorage": {
+          "type": ["string", "number", "null"]
+        }
+      }
+    },
+    "env": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "valueFrom": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "secretKeyRef": {
+                "$ref": "#/definitions/keyRef"
+              },
+              "configMapKeyRef": {
+                "$ref": "#/definitions/keyRef"
+              }
+            }
+          }
+        }
+      }
+    },
+    "keyRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "key"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        }
+      }
+    },
+    "securityContext": {
+      "description": "May be null / empty at any level: the chart then falls back to its hardening defaults (issue #99) instead of rendering an unhardened workload.",
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "pod": {
+          "description": "Merged onto the chart's pod hardening defaults and rendered as the pod's securityContext; kept open because the chart does not interpret the individual fields.",
+          "type": ["object", "null"]
+        },
+        "container": {
+          "description": "Merged onto the chart's container hardening defaults and rendered as the container's securityContext; kept open because the chart does not interpret the individual fields.",
+          "type": ["object", "null"]
+        }
+      }
+    },
+    "probe": {
+      "description": "Merged onto the chart's probe defaults and rendered as a container probe; kept open because the chart does not interpret the individual fields. May be null / empty, which means the defaults apply (issue #99) rather than the probe disappearing.",
+      "type": ["object", "null"]
+    }
+  }
+}


### PR DESCRIPTION
Letztes Chart der **Welle 1** aus #68 (nach #90 cyberchef, #94 gotenberg, #95 apache-tika, #98 patchmon).

Der PR trägt **zwei** der drei Änderungen, hier getrennt ausgewiesen. Das Ingress-Gate aus #93 entfällt: **dieses Chart gatet bereits korrekt** und wird laut #93 ausdrücklich nicht angefasst.

---

# 1. Strict `values.schema.json` (#68)

- `additionalProperties: false` auf **allen chart-eigenen Objektebenen** — oberste Ebene, `urlaubsverwaltung`, `.resources`, `.requests`/`.limits`, `env[]`, `env[].valueFrom`, `.secretKeyRef`/`.configMapKeyRef`, `securityContext`, `ingress`, `secrets`.
- **Offen bleiben** die wörtlich in die Pod-Spec durchgereichten Objekte: die drei Probes, `securityContext.pod`/`.container`, `global`, sowie `ingress.annotations`.
- `ingress.enabled` bleibt erlaubt — das Ingress-Template wertet es aus.

# 2. Null-Absicherung für Härtung, Probes und Ressourcen (#99)

Der Helper `defaultedDict` aus #96 wird übernommen (chart-präfigiert, wie alle Helper hier, weil die Charts keine Dependencies haben), dazu ein kleiner `subBlock`-Helper für den Fall, dass `securityContext` **selbst** erased ist.

### Wichtige Wechselwirkung mit Punkt 1

Das Schema hätte `null` für genau diese Blöcke sonst **abgewiesen** (`"type": "object"`), und der Helper wäre nie zum Zug gekommen. Die Typen sind deshalb auf `["object", "null"]` erweitert — die beiden Änderungen müssen zusammenpassen, sonst lehnt das Schema ab, was die Absicherung gerade auffangen soll. Bei den restlichen Schlüsseln bleibt das Schema unverändert streng.

Ein **Skalar** statt eines Mappings wird weiterhin laut abgelehnt, und zwar bereits vom Schema, noch vor dem Helper:

```
$ helm template … --set urlaubsverwaltung.securityContext.container=oops
- at '/urlaubsverwaltung/securityContext/container': got string, want null or object
```

---

## Nachweis 1: erased Block → vorher ungehärtet, nachher Defaults

**Vorher** (Chart-Stand auf `origin/main`), `--set urlaubsverwaltung.securityContext.container=null`:

```yaml
          securityContext:
            null
```

Der Container läuft ohne `readOnlyRootFilesystem`, ohne `drop: ALL`, ohne `allowPrivilegeEscalation: false` — und meldet dabei grün.

**Nachher**, identischer Aufruf:

```yaml
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: true
            runAsNonRoot: true
```

Dasselbe für die anderen beiden Klassen der stillen Gruppe:

| Override | vorher | nachher |
|---|---|---|
| `urlaubsverwaltung.securityContext=null` (ganzer Block) | Pod-Context leer | `runAsNonRoot/runAsUser/runAsGroup` |
| `urlaubsverwaltung.livenessProbe=null` | `livenessProbe: null` — Probe verschwindet | vollständige Default-Probe |
| `urlaubsverwaltung.resources=null` | `resources: {}` — keine Requests, keine berechneten Limits | `requests` + berechnete `limits` (`memory: 2304Mi`, `ephemeral-storage: 30Mi`) |

## Nachweis 2: ein bewusst gesetztes `false` / `0` gewinnt weiterhin

Das ist die Stelle, an der `default` und `mergeOverwrite` scheitern.

`--set urlaubsverwaltung.securityContext.container.readOnlyRootFilesystem=false`:

```yaml
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: false      # <- gesetzter Zero-Value gewinnt
            runAsNonRoot: true                 # <- übrige Defaults überleben
```

`--set urlaubsverwaltung.livenessProbe.failureThreshold=0`:

```yaml
          livenessProbe:
            failureThreshold: 0                # <- explizite 0 gewinnt
            httpGet:
              path: /actuator/health/liveness
              port: 8080
            periodSeconds: 10
            successThreshold: 1
            timeoutSeconds: 5
```

Beide zeigen zugleich den rekursiven Teilmerge: Ein teilweise gefüllter Block überschreibt **nur** die Schlüssel, die er wirklich setzt.

## Nachweis 3: im Normalfall ändert sich nichts

Die Absicherung darf kein Verhalten verschieben, wenn nichts erased ist. Gerendert mit `ci/urlaubsverwaltung/test-values.yaml`, alter Chart-Stand gegen neuen:

```
$ diff <(helm template t <origin/main-Stand> -f ci/urlaubsverwaltung/test-values.yaml) \
       <(helm template t urlaubsverwaltung        -f ci/urlaubsverwaltung/test-values.yaml)
(keine Ausgabe — byte-identisch)
```

## Verifikation

```
$ helm lint --strict urlaubsverwaltung
1 chart(s) linted, 0 chart(s) failed
```

**Negativprobe — beide Ebenen abgewiesen:**

```
--set bogusTopLevel=true
  -> at '': additional properties 'bogusTopLevel' not allowed

--set urlaubsverwaltung.resources.requests.bogusCpu=1
  -> at '/urlaubsverwaltung/resources/requests': additional properties 'bogusCpu' not allowed
```

Chart-Version **6.0.0 → 7.0.0** (major, appVersion unverändert bei 6.7.0).

## Validierung gegen die real ausgerollten Werte

Das Bundle liegt **verschachtelt** unter `fleet-cd/petrus-kh/urlaubsverwaltung/` (Release `urlaubsverwaltung-petrus-kh`, gepinnt auf `4.1.1+up6.7.0`) — nicht unter einem gleichnamigen Top-Level-Verzeichnis.

**Liste abgewiesener Schlüssel: leer.** Bundle-Datei und ausgerollter Stand (`helm get values`) sind deckungsgleich und setzen ausschließlich bekannte Schlüssel: `secrets.{databaseSecretRef,oidcSecretRef}`, `urlaubsverwaltung.resources.{requests,limits}`, `ingress.domain`.

### Aber: ein bestehender Blocker, der nichts mit diesem PR zu tun hat

Die realen Werte scheitern schon **heute** am aktuellen Chart — an `required()`, nicht am Schema:

```
$ helm template urlaubsverwaltung-petrus-kh urlaubsverwaltung -f <Bundle-Werte>
Error: execution error at (urlaubsverwaltung/templates/urlaubsverwaltung.ingress.yaml:7:39):
A Cluster-Issuer must be provided
```

Weder Bundle-Datei noch ausgerollter Stand setzen `ingress.clusterIssuer`. Seit `22fdb58` ("Strict clusterIssuer also for cyberchef and urlaubsverwaltung") ist der Wert strikt erforderlich; die ausgerollte Release stammt von davor und trägt ihren Issuer noch aus der alten Chart-Fassung im Live-Objekt (`cert-manager.io/cluster-issuer: letsencrypt-issuer`). Mit ergänztem Wert rendern die Bundle-Werte sauber durch (exit 0) — das Schema akzeptiert sie vollständig.

**Arbeitsanweisung für die Cluster-Seite:** `ingress.clusterIssuer: letsencrypt-issuer` in `fleet-cd/petrus-kh/urlaubsverwaltung/urlaubsverwaltung-petrus-kh.values.yaml` aufnehmen, **bevor** urlaubsverwaltung über `4.1.1+up6.7.0` hinaus hochgezogen wird. Der Blocker besteht unabhängig von diesem PR und wurde nur deshalb nie sichtbar, weil Fleet exakte Versionen pinnt und die Release nie neu gerendert wurde.

Genau der Nebenbefund-Typ, den #68 sucht: Eine gepflegte Datei sagt nichts über den ausgerollten Zustand.

Refs #68, Refs #99 (beide Issues umfassen mehr als dieses Chart und bleiben offen).
