### PR TITLE
Add NOTES.txt to the cyberchef chart

### DIFF
--- a/cyberchef/Chart.yaml
+++ b/cyberchef/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://raw.githubusercontent.com/gchq/CyberChef/master/src/web/static/ima
 
 type: application
 
-version: 7.0.0+up11.4.0
+version: 7.1.0+up11.4.0
 appVersion: "11.4.0"
 
 maintainers:

--- a/cyberchef/templates/NOTES.txt
+++ b/cyberchef/templates/NOTES.txt
@@ -1,0 +1,37 @@
+{{- $replicas := include "cyberchef.replicas" (dict "scaleDown" .Values.scaleDown "replicas" .Values.cyberchef.replicas) -}}
+CyberChef {{ .Chart.AppVersion }} — release {{ .Release.Name }} in namespace {{ .Release.Namespace }}.
+
+ACCESS
+  https://{{ .Values.ingress.domain }}
+
+  The certificate is requested by cert-manager through the "{{ .Values.ingress.clusterIssuer }}"
+  cluster issuer. Until it has been issued the browser shows a warning; follow it with
+
+    kubectl -n {{ .Release.Namespace }} get certificate tls-{{ .Release.Name }}-{{ .Chart.Name }}-ingress
+
+  This chart has no secrets and no volumes — the two ingress values above are
+  everything an installation needs.
+{{ if eq $replicas "0" }}
+SCALED TO ZERO
+  {{ if .Values.scaleDown }}scaleDown: true{{ else }}cyberchef.replicas: 0{{ end }} — the deployment runs with replicas: 0, so the URL
+  above answers 503 until you set it back and upgrade again. Service and
+  Ingress stay in place, so the certificate is not re-issued.
+{{ end }}
+ANYONE WHO REACHES THE URL CAN USE IT
+  CyberChef has no login, and this chart adds none. If it must not be open to
+  everyone, put authentication in front of it via ingress.annotations — the
+  chart merges them into the Ingress, e.g. ingress-nginx external auth or
+  basic auth annotations.
+
+NOTHING TO BACK UP, NOTHING TO MIGRATE
+  CyberChef is a static web app: recipes and inputs are processed in the
+  visitor's browser and never reach the server. The pod only serves files and
+  holds no state, so app-version upgrades and rollbacks carry no data risk and
+  need no migration step.
+{{- if .Values.cyberchef.env }}
+
+cyberchef.env HAS NO EFFECT ON THE APP
+  cyberchef.env is set. The entries reach the nginx process that serves the
+  files, but the served CyberChef bundle is static and reads none of them —
+  configuration has to happen in the browser.
+{{- end }}


### PR DESCRIPTION
Adds `cyberchef/templates/NOTES.txt`. Refs #43 (the issue covers all charts, so this PR does not close it).

Chart version `7.0.0+up11.4.0` → `7.1.0+up11.4.0` (minor, purely additive — a `NOTES.txt` renders no Kubernetes object, so nothing in the cluster changes).

## What it prints and why

The bar for every line was: *would an operator installing this chart for the first time go looking for this?* Everything that only repeats a value was left out.

- **Access** — the URL, rendered from `.Values.ingress.domain`, plus the `kubectl get certificate` command for the TLS secret. "Browser shows a certificate warning right after install" is the first thing that happens on a fresh install, and the Certificate name (`tls-<release>-<chart>-ingress`) is otherwise only findable by reading the ingress template.
- **No secrets, no volumes** — states plainly that the two ingress values are the entire installation surface, so nobody goes hunting for an `op://` ref that does not exist.
- **No authentication** — CyberChef ships no login and the chart adds none. Anything that reaches the URL can use it; the note names `ingress.annotations` as the hook for putting auth in front.
- **No state, no migration** — the app is client-side only, so app-version upgrades and rollbacks carry no data risk. This is the reassuring counterpart to the usual "check the release notes before upgrading".
- **Scaled to zero** (conditional) — names whichever of `scaleDown` / `cyberchef.replicas` caused it, and says the URL answers 503 while Service and Ingress stay put.
- **`cyberchef.env` has no effect** (conditional) — env reaches nginx, but the served bundle is static and reads none of it. Only shown when someone actually set env entries.

No domain is stored anywhere in the chart — the URL exists only as `{{ .Values.ingress.domain }}` and comes into being at install time.

## Verification

`helm lint --strict cyberchef` → `1 chart(s) linted, 0 chart(s) failed`.

`helm template` does not render `NOTES.txt`, so the output below is from **real installs** into a throwaway k3d cluster (own cluster, explicit `--kube-context`, never the global context), each with `--wait`, i.e. the pod actually became Ready.

### Variant A — defaults (`scaleDown: false`, no `env`)

`helm install cc-demo ./cyberchef -n cc-demo --set ingress.domain=cyberchef.example.com --set ingress.clusterIssuer=letsencrypt-prod --wait`

```
CyberChef 11.4.0 — release cc-demo in namespace cc-demo.

ACCESS
  https://cyberchef.example.com

  The certificate is requested by cert-manager through the "letsencrypt-prod"
  cluster issuer. Until it has been issued the browser shows a warning; follow it with

    kubectl -n cc-demo get certificate tls-cc-demo-cyberchef-ingress

  This chart has no secrets and no volumes — the two ingress values above are
  everything an installation needs.

ANYONE WHO REACHES THE URL CAN USE IT
  CyberChef has no login, and this chart adds none. If it must not be open to
  everyone, put authentication in front of it via ingress.annotations — the
  chart merges them into the Ingress, e.g. ingress-nginx external auth or
  basic auth annotations.

NOTHING TO BACK UP, NOTHING TO MIGRATE
  CyberChef is a static web app: recipes and inputs are processed in the
  visitor's browser and never reach the server. The pod only serves files and
  holds no state, so app-version upgrades and rollbacks carry no data risk and
  need no migration step.
```

Both conditional blocks are correctly absent.

### Variant B — `scaleDown: true` plus one `env` entry

`helm upgrade ... --set scaleDown=true --set cyberchef.env[0].name=TZ --set cyberchef.env[0].value=Europe/Berlin --wait`

Identical header, plus the two conditional blocks:

```
SCALED TO ZERO
  scaleDown: true — the deployment runs with replicas: 0, so the URL
  above answers 503 until you set it back and upgrade again. Service and
  Ingress stay in place, so the certificate is not re-issued.
```

```
cyberchef.env HAS NO EFFECT ON THE APP
  cyberchef.env is set. The entries reach the nginx process that serves the
  files, but the served CyberChef bundle is static and reads none of them —
  configuration has to happen in the browser.
```

### Variant C — `cyberchef.replicas: 0` without `scaleDown`

The scale-down notice goes through the chart's own `cyberchef.replicas` helper, so it can never drift from the rendered Deployment, and it names the actual cause:

```
SCALED TO ZERO
  cyberchef.replicas: 0 — the deployment runs with replicas: 0, so the URL
  above answers 503 until you set it back and upgrade again. Service and
  Ingress stay in place, so the certificate is not re-issued.
```

Cluster state in variant C confirms what the text claims — workload at zero, Service and Ingress still there:

```
deployment.apps/cc-demo-cyberchef-deployment   0/0     0            0
service/cc-demo-cyberchef-service              ClusterIP   10.43.231.106   80/TCP
ingress.networking.k8s.io/cc-demo-cyberchef-ingress   nginx   cyberchef.example.com   80, 443
```

The k3d cluster was deleted afterwards.
