### PR TITLE
gotenberg: Null-Absicherung + Schema-Typen (Nachrüstung Welle 1, #99/#68)

### DIFF
--- a/gotenberg/Chart.yaml
+++ b/gotenberg/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://gotenberg.dev/img/logo.png
 
 type: application
 
-version: 5.1.0+up8.36.0
+version: 6.0.0+up8.36.0
 appVersion: "8.36.0"
 
 maintainers:

--- a/gotenberg/templates/NOTES.txt
+++ b/gotenberg/templates/NOTES.txt
@@ -1,5 +1,8 @@
 {{- $replicas := include "gotenberg.replicas" (dict "scaleDown" .Values.scaleDown "replicas" .Values.gotenberg.replicas) -}}
-{{- $limits := (include "gotenberg.resources" .Values.gotenberg.resources | fromYaml).limits | default dict -}}
+{{- /* effectiveResources, not resources: an erased "resources:" block falls back
+       to the chart defaults in the Deployment (#99), so the notes must report the
+       limits the release actually gets, not "(none set)". */ -}}
+{{- $limits := (include "gotenberg.effectiveResources" .Values.gotenberg.resources | fromYaml).limits | default dict -}}
 {{- $svc := printf "%s-%s-service" .Release.Name .Chart.Name -}}
 Gotenberg {{ .Chart.AppVersion }} — release {{ .Release.Name }} in namespace {{ .Release.Namespace }}.
 

--- a/gotenberg/templates/_helpers.tpl
+++ b/gotenberg/templates/_helpers.tpl
@@ -114,3 +114,156 @@ template-chart is the reference implementation.
 1
 {{- end -}}
 {{- end -}}
+
+{{/*
+Merge a user-supplied values sub-tree onto a dict of chart defaults so that a
+null / empty override falls back to the defaults instead of erasing them.
+
+Input: dict "defaults" <dict> "given" <dict|nil> "path" <string, optional
+values path used in error messages>. Output: YAML of the merged dict (consume
+it with fromYaml).
+
+Why this exists (issue #99): Helm merges values maps recursively, but an
+override key written without children — e.g. a leftover
+
+  securityContext:
+
+after deleting its last remaining sub-key — is YAML null. Where the chart
+defines a default, Helm treats that null as a deletion of the default; the
+template then renders "securityContext: null": no readOnlyRootFilesystem, no
+dropped capabilities, no allowPrivilegeEscalation: false. The workload starts
+and reports healthy while being unhardened, so nothing points at the mistake.
+The same shape erases a probe (it disappears) or the resources block (no
+requests, no computed limits). This helper defines the opposite semantics: an
+empty block means "chart defaults apply".
+
+Rules:
+  - a nil "given" is treated as an empty dict (all defaults apply).
+  - a key whose override value is null keeps the default (nulls never delete).
+  - a key present in both as a map is merged recursively, so a partially
+    filled block only overrides the keys it actually sets.
+  - a scalar override for a key the defaults define as a map is rejected with
+    a message naming the values path, instead of failing later with a template
+    field error.
+  - any other set value wins as given, including an explicit false or 0 —
+    Helm's "default" and sprig's "mergeOverwrite" would both swallow those
+    zero values, hence the explicit kindIs "invalid" nil check.
+  - keys only present in the override are passed through unchanged.
+
+NOTE: like the helpers above, this is duplicated into every chart's
+templates/_helpers.tpl with the chart's name as define prefix, because charts
+in this repo deliberately have no dependencies.
+*/}}
+{{- define "gotenberg.defaultedDict" -}}
+{{- $defaults := .defaults | default dict -}}
+{{- $given := .given -}}
+{{- $path := .path | default "value" -}}
+{{- if kindIs "invalid" $given -}}
+{{- $given = dict -}}
+{{- end -}}
+{{- if not (kindIs "map" $given) -}}
+{{- fail (printf "%s must be a mapping or null, got %s (%v)" $path (kindOf $given) $given) -}}
+{{- end -}}
+{{- $out := deepCopy $defaults -}}
+{{- range $key, $value := $given -}}
+{{- if not (kindIs "invalid" $value) -}}
+{{- $default := index $defaults $key -}}
+{{- if and (kindIs "map" $value) (kindIs "map" $default) -}}
+{{- $_ := set $out $key (fromYaml (include "gotenberg.defaultedDict" (dict "defaults" $default "given" $value "path" (printf "%s.%s" $path $key)))) -}}
+{{- else if kindIs "map" $default -}}
+{{- fail (printf "%s.%s must be a mapping or null, got %s (%v)" $path $key (kindOf $value) $value) -}}
+{{- else -}}
+{{- $_ := set $out $key $value -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- toYaml $out -}}
+{{- end -}}
+
+{{/*
+Pick one sub-block out of a values block that may itself be null.
+
+Input: dict "block" <dict|nil> "key" <string> "path" <string>.
+Returns YAML of dict "value" <the sub-block, may be nil>, after rejecting a
+non-mapping block with a message that names the values path. Needed because
+".Values.gotenberg.securityContext" can itself be erased.
+*/}}
+{{- define "gotenberg.subBlock" -}}
+{{- $block := .block -}}
+{{- if kindIs "invalid" $block -}}
+{{- $block = dict -}}
+{{- end -}}
+{{- if not (kindIs "map" $block) -}}
+{{- fail (printf "%s must be a mapping or null, got %s (%v)" .path (kindOf $block) $block) -}}
+{{- end -}}
+{{- toYaml (dict "value" (index $block .key)) -}}
+{{- end -}}
+
+{{/*
+The effective security contexts, probes and resources (issue #99).
+
+The defaults below MUST stay in sync with the corresponding blocks in
+values.yaml, which stays the documented, user-facing place for them; this copy
+is only the fallback for the case where an override has erased the block.
+
+The probes address the container port by its name ("gotenberg-port"), so a
+rebuilt default probe needs no further context.
+*/}}
+{{- define "gotenberg.podSecurityContext" -}}
+{{- $given := (fromYaml (include "gotenberg.subBlock" (dict "block" . "key" "pod" "path" "gotenberg.securityContext"))).value -}}
+{{- $defaults := dict
+      "runAsNonRoot" true
+      "runAsUser" 1001
+      "runAsGroup" 1001 -}}
+{{- include "gotenberg.defaultedDict" (dict "defaults" $defaults "given" $given "path" "gotenberg.securityContext.pod") -}}
+{{- end -}}
+
+{{- define "gotenberg.containerSecurityContext" -}}
+{{- $given := (fromYaml (include "gotenberg.subBlock" (dict "block" . "key" "container" "path" "gotenberg.securityContext"))).value -}}
+{{- $defaults := dict
+      "allowPrivilegeEscalation" false
+      "readOnlyRootFilesystem" true
+      "runAsNonRoot" true
+      "capabilities" (dict "drop" (list "ALL")) -}}
+{{- include "gotenberg.defaultedDict" (dict "defaults" $defaults "given" $given "path" "gotenberg.securityContext.container") -}}
+{{- end -}}
+
+{{- define "gotenberg.livenessProbe" -}}
+{{- $defaults := dict
+      "httpGet" (dict "path" "/health" "port" "gotenberg-port")
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 3 -}}
+{{- include "gotenberg.defaultedDict" (dict "defaults" $defaults "given" . "path" "gotenberg.livenessProbe") -}}
+{{- end -}}
+
+{{- define "gotenberg.readinessProbe" -}}
+{{- $defaults := dict
+      "httpGet" (dict "path" "/health" "port" "gotenberg-port")
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 3 -}}
+{{- include "gotenberg.defaultedDict" (dict "defaults" $defaults "given" . "path" "gotenberg.readinessProbe") -}}
+{{- end -}}
+
+{{- define "gotenberg.startupProbe" -}}
+{{- $defaults := dict
+      "httpGet" (dict "path" "/health" "port" "gotenberg-port")
+      "periodSeconds" 5
+      "timeoutSeconds" 5
+      "failureThreshold" 30 -}}
+{{- include "gotenberg.defaultedDict" (dict "defaults" $defaults "given" . "path" "gotenberg.startupProbe") -}}
+{{- end -}}
+
+{{/*
+The effective resources block, fed into the resources helper above so that an
+erased "resources:" still yields the chart's requests and computed limits
+instead of a container without any resource accounting.
+*/}}
+{{- define "gotenberg.effectiveResources" -}}
+{{- $defaults := dict
+      "limitFactor" 3
+      "requests" (dict "cpu" 0.1 "memory" "512Mi" "ephemeralStorage" "10Mi") -}}
+{{- $merged := fromYaml (include "gotenberg.defaultedDict" (dict "defaults" $defaults "given" . "path" "gotenberg.resources")) -}}
+{{- include "gotenberg.resources" $merged -}}
+{{- end -}}

--- a/gotenberg/templates/gotenberg.deployment.yaml
+++ b/gotenberg/templates/gotenberg.deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       automountServiceAccountToken: false
       securityContext:
-        {{- toYaml .Values.gotenberg.securityContext.pod | nindent 8 }}
+        {{- include "gotenberg.podSecurityContext" .Values.gotenberg.securityContext | nindent 8 }}
       containers:
         - name: {{ .Release.Name }}-{{ .Chart.Name }}-deployment
           image: "gotenberg/gotenberg:{{ .Chart.AppVersion }}"
@@ -46,7 +46,7 @@ spec:
             {{- end }}
           {{- end }}
           securityContext:
-            {{- toYaml .Values.gotenberg.securityContext.container | nindent 12 }}
+            {{- include "gotenberg.containerSecurityContext" .Values.gotenberg.securityContext | nindent 12 }}
           volumeMounts:
             # Gotenberg (and the Chromium/LibreOffice it drives) needs writable
             # /tmp and home directories; with a read-only root filesystem these
@@ -60,13 +60,13 @@ spec:
               protocol: TCP
               name: gotenberg-port
           livenessProbe:
-            {{- toYaml .Values.gotenberg.livenessProbe | nindent 12 }}
+            {{- include "gotenberg.livenessProbe" .Values.gotenberg.livenessProbe | nindent 12 }}
           readinessProbe:
-            {{- toYaml .Values.gotenberg.readinessProbe | nindent 12 }}
+            {{- include "gotenberg.readinessProbe" .Values.gotenberg.readinessProbe | nindent 12 }}
           startupProbe:
-            {{- toYaml .Values.gotenberg.startupProbe | nindent 12 }}
+            {{- include "gotenberg.startupProbe" .Values.gotenberg.startupProbe | nindent 12 }}
           resources:
-            {{- include "gotenberg.resources" .Values.gotenberg.resources | nindent 12 }}
+            {{- include "gotenberg.effectiveResources" .Values.gotenberg.resources | nindent 12 }}
       volumes:
         - name: tmp
           emptyDir: {}

--- a/gotenberg/values.schema.json
+++ b/gotenberg/values.schema.json
@@ -43,7 +43,8 @@
   },
   "definitions": {
     "resources": {
-      "type": "object",
+      "description": "May be null / empty: the chart then falls back to its default requests and computed limits (issue #99) instead of rendering a container without resource accounting.",
+      "type": ["object", "null"],
       "additionalProperties": false,
       "properties": {
         "limitFactor": {
@@ -59,7 +60,7 @@
       }
     },
     "resourceList": {
-      "type": "object",
+      "type": ["object", "null"],
       "additionalProperties": false,
       "properties": {
         "cpu": {
@@ -118,22 +119,23 @@
       }
     },
     "securityContext": {
-      "type": "object",
+      "description": "May be null / empty at any level: the chart then falls back to its hardening defaults (issue #99) instead of rendering an unhardened workload.",
+      "type": ["object", "null"],
       "additionalProperties": false,
       "properties": {
         "pod": {
-          "description": "Rendered verbatim as the pod's securityContext; kept open because the chart does not interpret it.",
-          "type": "object"
+          "description": "Merged onto the chart's pod hardening defaults and rendered as the pod's securityContext; kept open because the chart does not interpret the individual fields.",
+          "type": ["object", "null"]
         },
         "container": {
-          "description": "Rendered verbatim as the container's securityContext; kept open because the chart does not interpret it.",
-          "type": "object"
+          "description": "Merged onto the chart's container hardening defaults and rendered as the container's securityContext; kept open because the chart does not interpret the individual fields.",
+          "type": ["object", "null"]
         }
       }
     },
     "probe": {
-      "description": "Rendered verbatim as a container probe; kept open because the chart does not interpret it.",
-      "type": "object"
+      "description": "Merged onto the chart's probe defaults and rendered as a container probe; kept open because the chart does not interpret the individual fields. May be null / empty, which means the defaults apply (issue #99) rather than the probe disappearing.",
+      "type": ["object", "null"]
     }
   }
 }


### PR DESCRIPTION
Nachrüstung für ein Chart, das das Schema aus #68 schon trägt, aber noch keine Null-Absicherung. Version **5.1.0 → 6.0.0** (major, appVersion unverändert bei 8.36.0). Auf `origin/main` rebased, nachdem #104 die `NOTES.txt` und `5.1.0` gebracht hat.

Kein Ingress-Gate: gotenberg hat **keinen Ingress**. Also zwei Punkte statt drei — plus eine Folgeanpassung an der neuen `NOTES.txt`, siehe unten.

## Kein Helper wurde umbenannt — und eine Korrektur an der NOTES.txt, die trotzdem nötig war

Die neue `NOTES.txt` ruft `gotenberg.replicas` und `gotenberg.resources` auf. **Beide Helper behalten ihren Namen**; die Null-Absicherung *ergänzt* Helper (`effectiveResources`, `podSecurityContext`, …), statt bestehende umzubenennen. Geprüft über das gesamte Chart-Verzeichnis, jeder aufgerufene Helper ist definiert:

```
$ grep -rn 'include "gotenberg\.' gotenberg/   # aufgerufen
$ grep -rn 'define  "gotenberg\.' gotenberg/   # definiert
-> 12 aufgerufene Namen, 12 definierte Namen, Schnittmenge vollständig
```

**Eine inhaltliche Korrektur brauchte die NOTES.txt trotzdem.** Sie berechnete ihre Limits über `gotenberg.resources` auf den **rohen** Werten. Nach dieser Änderung fällt ein erased `resources:`-Block im Deployment auf die Chart-Defaults zurück — die Notes hätten dann etwas anderes behauptet als das Release tatsächlich bekommt:

| `gotenberg: { resources: }` (Block geleert) | Deployment | NOTES vorher | NOTES nachher |
|---|---|---|---|
| memory-Limit | `1536Mi` | `(none set)` | `1536Mi` |
| ephemeral-storage-Limit | `30Mi` | `(none set)` | `30Mi` |

Die Notes lesen jetzt `gotenberg.effectiveResources`, also denselben Wert, den der Container bekommt. Bei normalen Werten ist die Ausgabe **unverändert**. Das ist genau die Klasse, um die es in #68/#99 geht — eine Angabe, die nicht hält, was sie verspricht — nur diesmal in der Ausgabe an den Betreiber statt in der Pod-Spec.

---

# 1. Null-Absicherung für Härtung, Probes und Ressourcen (#99)

`defaultedDict` aus #96 übernommen (chart-präfigiert), dazu `subBlock` für den Fall, dass `securityContext` **selbst** erased ist. Abgesichert: Pod- und Container-Context, die drei Probes, `resources`.

**Probe-Kontext geprüft** (nach dem patchmon-Fall): Die Probes sprechen den Container-Port über seinen **Namen** an (`gotenberg-port`) und tragen keinen Host-Header. Eine rekonstruierte Default-Probe braucht hier also keinen zusätzlichen Kontext — anders als bei patchmon, wo der `Host`-Header aus `ingress.domain` mitrekonstruiert werden muss.

# 2. Schema-Typen (#68 + #99)

Die abgesicherten Blöcke akzeptieren jetzt `null`. Der Grund ist der in #99 dokumentierte Zwei-Fall-Mechanismus:

| Fall | Was Helm tut | Wer es auffängt |
|---|---|---|
| Schlüssel **mit** Chart-Default (z. B. `securityContext.container`) | Das `null` **löscht** den Default beim Coalescing, bevor die Validierung läuft — das Schema sieht es **nie** | der Helper (Punkt 1) |
| Schlüssel **ohne** Chart-Default (z. B. `resources.limits`) | Nichts zu löschen, das `null` **überlebt** bis in die Validierung | die Typ-Erweiterung |

Alle übrigen Schlüssel bleiben streng; `additionalProperties: false` ist an keiner Stelle gelockert (Negativprobe unten).

---

## Nachweis 1: erased Block → vorher, nachher

Werte-Datei in der realistischen Form (letzter Unterschlüssel gelöscht, Kopfzeile stehen geblieben):

```yaml
gotenberg:
  securityContext:
    container:
  livenessProbe:
```

**Vorher** (veröffentlichter Stand `5.0.0`, **mit** Schema):

```yaml
          securityContext:
            null
          ...
          livenessProbe:
            null
```

Der Container läuft ohne `readOnlyRootFilesystem`, ohne `drop: ALL`, ohne `allowPrivilegeEscalation: false`, und die Liveness-Probe ist ersatzlos weg. **Das vorhandene Schema fängt das nicht** — genau der Fall aus der linken Tabellenzeile.

**Nachher**, dieselbe Datei:

```yaml
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: true
            runAsNonRoot: true
          ...
          livenessProbe:
            failureThreshold: 3
            httpGet:
              path: /health
              port: gotenberg-port
            periodSeconds: 10
            timeoutSeconds: 5
```

Und der zweite Fall, Werte-Datei mit `resources: { limits: }` ohne Kinder — **vorher** ein harter Abbruch:

```
Error: values don't meet the specifications of the schema(s) in the following chart(s):
gotenberg:
- at '/gotenberg/resources/limits': got null, want object
```

**nachher** die Defaults samt berechneter Limits:

```yaml
          resources:
            limits:
              ephemeral-storage: 30Mi
              memory: 1536Mi
            requests:
              cpu: 0.1
              ephemeral-storage: 10Mi
              memory: 512Mi
```

## Nachweis 2: ein bewusst gesetztes `false` / `0` gewinnt weiterhin

Die Stelle, an der `default` und `mergeOverwrite` scheitern.

`--set gotenberg.securityContext.container.readOnlyRootFilesystem=false`:

```yaml
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: false     # <- gesetzter Zero-Value gewinnt
            runAsNonRoot: true                # <- übrige Defaults überleben
```

`--set gotenberg.startupProbe.failureThreshold=0`:

```yaml
          startupProbe:
            failureThreshold: 0               # <- explizite 0 gewinnt
            httpGet:
              path: /health
              port: gotenberg-port
            periodSeconds: 5
            timeoutSeconds: 5
```

Beide zeigen zugleich den rekursiven Teilmerge.

## Nachweis 3: im Normalfall ändert sich nichts

```
$ diff <(helm template t <origin/main-Stand> -f ci/gotenberg/test-values.yaml) \
       <(helm template t gotenberg           -f ci/gotenberg/test-values.yaml)
(keine Ausgabe — byte-identisch)
```

## Verifikation

```
$ helm lint --strict gotenberg
1 chart(s) linted, 0 chart(s) failed
```

| Fall | Ergebnis |
|---|---|
| Default-Values | rendert |
| `ci/gotenberg/test-values.yaml` | rendert |
| Bundle-Werte `fleet-cd/cluster-tika-gotenberg/gotenberg/` | rendert |

**Negativprobe — das Schema bleibt streng:**

```
--set gotenberg.resources.limits.bogusMemory=1Gi
  -> at '/gotenberg/resources/limits': additional properties 'bogusMemory' not allowed
```

## Cluster-Seite

Die produktiven Werte setzen nur `gotenberg.resources.{requests,limits}` — beide vollständig gefüllt, kein erased Block. **Liste abgewiesener Schlüssel: leer**, vor dem Hochziehen auf `6.0.0` nichts zu bereinigen.

Refs #68, Refs #99.
