### PR TITLE
Add NOTES.txt to the gotenberg chart

### DIFF
--- a/gotenberg/Chart.yaml
+++ b/gotenberg/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://gotenberg.dev/img/logo.png
 
 type: application
 
-version: 5.0.0+up8.36.0
+version: 5.1.0+up8.36.0
 appVersion: "8.36.0"
 
 maintainers:

--- a/gotenberg/templates/NOTES.txt
+++ b/gotenberg/templates/NOTES.txt
@@ -1,0 +1,62 @@
+{{- $replicas := include "gotenberg.replicas" (dict "scaleDown" .Values.scaleDown "replicas" .Values.gotenberg.replicas) -}}
+{{- $limits := (include "gotenberg.resources" .Values.gotenberg.resources | fromYaml).limits | default dict -}}
+{{- $svc := printf "%s-%s-service" .Release.Name .Chart.Name -}}
+Gotenberg {{ .Chart.AppVersion }} — release {{ .Release.Name }} in namespace {{ .Release.Namespace }}.
+
+ACCESS
+  This chart creates no Ingress. The API is cluster-internal:
+
+    http://{{ $svc }}.{{ .Release.Namespace }}.svc.cluster.local
+
+  Mind the port. The Service listens on 80 and forwards to the container's
+  3000, so consumers are configured without a port — e.g. paperless-ngx:
+
+    PAPERLESS_TIKA_GOTENBERG_ENDPOINT: http://{{ $svc }}.{{ .Release.Namespace }}.svc.cluster.local
+
+  To reach it from your machine:
+
+    kubectl -n {{ .Release.Namespace }} port-forward svc/{{ $svc }} 3000:80
+    curl http://localhost:3000/health
+
+  The health route reports Chromium and LibreOffice separately — it is the
+  quickest way to tell a broken converter from a broken caller. This chart has
+  no secrets and no volumes.
+{{ if eq $replicas "0" }}
+SCALED TO ZERO
+  {{ if .Values.scaleDown }}scaleDown: true{{ else }}gotenberg.replicas: 0{{ end }} — the deployment runs with replicas: 0. The Service
+  keeps its ClusterIP but has no endpoints, so callers fail with "connection
+  refused" rather than a timeout. Set it back and upgrade to return.
+{{ end }}
+NO AUTHENTICATION, AND THIS CHART CANNOT ADD ANY
+  Gotenberg's basic auth and OIDC, its SSRF guards for the downloadFrom
+  feature, and its request timeout are all command-line flags. This chart
+  passes no flags — it only offers gotenberg.env — so none of them can be
+  switched on through values. Everything that reaches the Service may convert,
+  and the URL routes make the server fetch whatever URL they are handed. Keep
+  it cluster-internal; do not put an Ingress in front of it without auth.
+
+MEMORY IS THE LIMIT YOU HIT FIRST
+  Chromium and LibreOffice hold the whole document in memory. With this
+  release's limit of {{ index $limits "memory" | default "(none set)" }}, a 20-page HTML converts in well under a second,
+  while a 25 MB HTML is enough to get the container OOM-killed.
+  How you notice: the caller gets no HTTP error — the connection is dropped
+  mid-request — and the pod's RESTARTS counter goes up. Confirm with
+
+    kubectl -n {{ .Release.Namespace }} get pod -l app={{ .Release.Name }}-{{ .Chart.Name }}-deployment -o jsonpath='{.items[*].status.containerStatuses[*].lastState.terminated.reason}'
+
+  which then prints OOMKilled. Raise gotenberg.resources.requests.memory (the
+  limit follows at limitFactor x request) or set an explicit limit.
+
+TEMP SPACE IS TIGHT, AND RUNNING OUT LOOKS DIFFERENT
+  /tmp and /home/gotenberg are emptyDirs, so they count against the container's
+  ephemeral-storage limit of {{ index $limits "ephemeral-storage" | default "(none set)" }}. Chromium's profile alone takes about 4 MB,
+  and the uploaded file plus the rendered PDF come on top.
+  How you notice: the pod does not restart, it disappears — a fresh one takes
+  its place and the old one is left in status Evicted, with the message naming
+  ephemeral-storage. Raise gotenberg.resources.requests.ephemeralStorage.
+
+REQUESTS TIME OUT AFTER 30 SECONDS
+  That is Gotenberg's own default, and since the chart passes no flags it
+  cannot be changed here. Large conversions get close: the 25 MB document
+  above still needed 19 seconds once it had memory enough to finish. Callers
+  that need longer must split the document instead.


### PR DESCRIPTION
Adds `gotenberg/templates/NOTES.txt`. Refs #43 (the issue covers all charts, so this PR does not close it).

Chart version `5.0.0+up8.36.0` → `5.1.0+up8.36.0` (minor, purely additive — a `NOTES.txt` renders no Kubernetes object).

## What it prints and why

Gotenberg has no Ingress and no secrets, so the interesting information is different from cyberchef's: how to address it, and how it fails.

- **Access** — the cluster-internal FQDN, plus the port trap: the Service listens on **80** while the container listens on **3000**, so a consumer must be configured *without* a port. The `PAPERLESS_TIKA_GOTENBERG_ENDPOINT` line is spelled out because paperless-ngx is the actual consumer, and a wrong port there fails silently at conversion time. Also the `port-forward` command and the hint that `/health` reports Chromium and LibreOffice separately, which is what tells a broken converter from a broken caller.
- **No authentication, and this chart cannot add any** — Gotenberg's basic auth, OIDC, SSRF guards and request timeout are all *command-line flags*; this chart passes no flags and offers only `gotenberg.env`, so none of them are reachable through values. That is not obvious from the values file and is the sort of thing that gets discovered at the worst possible moment.
- **Memory is the limit you hit first** — with the resulting warning that the caller sees a dropped connection rather than an HTTP error, and the exact `kubectl` command that prints `OOMKilled`.
- **Temp space is tight, and running out looks different** — the emptyDir/ephemeral-storage path, spelled out as a *symptom*: the pod is not restarted, it disappears and is replaced, with the old one left in `Evicted` naming `ephemeral-storage`.
- **Requests time out after 30 seconds** — Gotenberg's own default, unchangeable here for the same no-flags reason.
- **Scaled to zero** (conditional) — names the cause, and notes callers get "connection refused" rather than a timeout.

Both resource figures are read back through the chart's own `gotenberg.resources` helper with `fromYaml`, so they follow `limitFactor` and any override instead of being hardcoded (demonstrated below).

## Where the numbers come from

Everything the notes assert was measured against this chart running in a throwaway k3d cluster, not estimated:

| Input | Memory limit | Result |
| --- | --- | --- |
| 75 KB HTML, ~20 pages | `1536Mi` (chart default) | HTTP 200 in **0.5 s**, 62 KB PDF; temp peaked at **3.7 MB** |
| 25 MB HTML | `1536Mi` (chart default) | **OOMKilled**, exit 137, container restarted; caller got an empty reply (curl exit 52) after ~8 s |
| 25 MB HTML | `4Gi` | HTTP 200 in **18.7 s**, 5.5 MB PDF, no restart, no eviction |

Notable: during the failing run temp usage peaked at **46.4 MB**, past the `30Mi` ephemeral-storage limit — but the kubelet did not evict, because the OOM kill happened first. So at chart defaults **memory is the binding constraint, not disk**, which is why the notes order the two warnings that way. Sampling was `du -sb /tmp /home/gotenberg` at 4 Hz inside the container.

The `19 seconds` in the timeout paragraph is the third row above — a real conversion getting within striking distance of the 30 s default.

## Verification

`helm lint --strict gotenberg` → `1 chart(s) linted, 0 chart(s) failed` (re-run after rebasing onto current `main`).

`helm template` does not render `NOTES.txt`, so the output below is from **real installs** with `--wait` into a throwaway k3d cluster (own cluster, explicit `--kube-context`; the global context was never used or changed).

Claims verified individually rather than assumed:

- The printed `curl .../health` really answers through the Service on port 80: `{"status":"up","details":{"chromium":{"status":"up"...},"libreoffice":{"status":"up"...}}}`
- The `kubectl ... jsonpath` command printed in the notes really prints `OOMKilled` — reproduced on the release below by replaying the 25 MB conversion.
- "Connection refused rather than a timeout" on a scaled-down release: curl exits **7** (connect failure), not 28 (timeout).
- `--api-timeout` default of `30s` read from `gotenberg --help` in the running container.

### Variant A — defaults (`scaleDown: false`)

```
Gotenberg 8.36.0 — release gb-notes in namespace gb-notes.

ACCESS
  This chart creates no Ingress. The API is cluster-internal:

    http://gb-notes-gotenberg-service.gb-notes.svc.cluster.local

  Mind the port. The Service listens on 80 and forwards to the container's
  3000, so consumers are configured without a port — e.g. paperless-ngx:

    PAPERLESS_TIKA_GOTENBERG_ENDPOINT: http://gb-notes-gotenberg-service.gb-notes.svc.cluster.local

  To reach it from your machine:

    kubectl -n gb-notes port-forward svc/gb-notes-gotenberg-service 3000:80
    curl http://localhost:3000/health

  The health route reports Chromium and LibreOffice separately — it is the
  quickest way to tell a broken converter from a broken caller. This chart has
  no secrets and no volumes.

NO AUTHENTICATION, AND THIS CHART CANNOT ADD ANY
  Gotenberg's basic auth and OIDC, its SSRF guards for the downloadFrom
  feature, and its request timeout are all command-line flags. This chart
  passes no flags — it only offers gotenberg.env — so none of them can be
  switched on through values. Everything that reaches the Service may convert,
  and the URL routes make the server fetch whatever URL they are handed. Keep
  it cluster-internal; do not put an Ingress in front of it without auth.

MEMORY IS THE LIMIT YOU HIT FIRST
  Chromium and LibreOffice hold the whole document in memory. With this
  release's limit of 1536Mi, a 20-page HTML converts in well under a second,
  while a 25 MB HTML is enough to get the container OOM-killed.
  How you notice: the caller gets no HTTP error — the connection is dropped
  mid-request — and the pod's RESTARTS counter goes up. Confirm with

    kubectl -n gb-notes get pod -l app=gb-notes-gotenberg-deployment -o jsonpath='{.items[*].status.containerStatuses[*].lastState.terminated.reason}'

  which then prints OOMKilled. Raise gotenberg.resources.requests.memory (the
  limit follows at limitFactor x request) or set an explicit limit.

TEMP SPACE IS TIGHT, AND RUNNING OUT LOOKS DIFFERENT
  /tmp and /home/gotenberg are emptyDirs, so they count against the container's
  ephemeral-storage limit of 30Mi. Chromium's profile alone takes about 4 MB,
  and the uploaded file plus the rendered PDF come on top.
  How you notice: the pod does not restart, it disappears — a fresh one takes
  its place and the old one is left in status Evicted, with the message naming
  ephemeral-storage. Raise gotenberg.resources.requests.ephemeralStorage.

REQUESTS TIME OUT AFTER 30 SECONDS
  That is Gotenberg's own default, and since the chart passes no flags it
  cannot be changed here. Large conversions get close: the 25 MB document
  above still needed 19 seconds once it had memory enough to finish. Callers
  that need longer must split the document instead.
```

The conditional block is correctly absent.

### Variant B — `scaleDown: true`, plus `gotenberg.resources.requests.memory=2Gi`

The conditional block appears:

```
SCALED TO ZERO
  scaleDown: true — the deployment runs with replicas: 0. The Service
  keeps its ClusterIP but has no endpoints, so callers fail with "connection
  refused" rather than a timeout. Set it back and upgrade to return.
```

and the same upgrade doubles as proof that the printed limits are computed, not hardcoded — the memory line now reads:

```
  release's limit of 6Gi, a 20-page HTML converts in well under a second,
```

`2Gi` request × `limitFactor: 3` = `6Gi`, straight out of the chart's own helper, while the ephemeral-storage line stays at `30Mi`.
