### PR TITLE
apache-tika: Null-Absicherung + Schema-Typen (Nachrüstung Welle 1, #99/#68)

### DIFF
--- a/apache-tika/Chart.yaml
+++ b/apache-tika/Chart.yaml
@@ -5,5 +5,5 @@ icon: https://www.apache.org/logos/res/tika/default.png
 
 type: application
 
-version: 8.0.0+up3.3.1.0.full
+version: 9.0.0+up3.3.1.0.full
 appVersion: "3.3.1.0-full"

--- a/apache-tika/templates/_helpers.tpl
+++ b/apache-tika/templates/_helpers.tpl
@@ -114,3 +114,156 @@ template-chart is the reference implementation.
 1
 {{- end -}}
 {{- end -}}
+
+{{/*
+Merge a user-supplied values sub-tree onto a dict of chart defaults so that a
+null / empty override falls back to the defaults instead of erasing them.
+
+Input: dict "defaults" <dict> "given" <dict|nil> "path" <string, optional
+values path used in error messages>. Output: YAML of the merged dict (consume
+it with fromYaml).
+
+Why this exists (issue #99): Helm merges values maps recursively, but an
+override key written without children — e.g. a leftover
+
+  securityContext:
+
+after deleting its last remaining sub-key — is YAML null. Where the chart
+defines a default, Helm treats that null as a deletion of the default; the
+template then renders "securityContext: null": no readOnlyRootFilesystem, no
+dropped capabilities, no allowPrivilegeEscalation: false. The workload starts
+and reports healthy while being unhardened, so nothing points at the mistake.
+The same shape erases a probe (it disappears) or the resources block (no
+requests, no computed limits). This helper defines the opposite semantics: an
+empty block means "chart defaults apply".
+
+Rules:
+  - a nil "given" is treated as an empty dict (all defaults apply).
+  - a key whose override value is null keeps the default (nulls never delete).
+  - a key present in both as a map is merged recursively, so a partially
+    filled block only overrides the keys it actually sets.
+  - a scalar override for a key the defaults define as a map is rejected with
+    a message naming the values path, instead of failing later with a template
+    field error.
+  - any other set value wins as given, including an explicit false or 0 —
+    Helm's "default" and sprig's "mergeOverwrite" would both swallow those
+    zero values, hence the explicit kindIs "invalid" nil check.
+  - keys only present in the override are passed through unchanged.
+
+NOTE: like the helpers above, this is duplicated into every chart's
+templates/_helpers.tpl with the chart's name as define prefix, because charts
+in this repo deliberately have no dependencies.
+*/}}
+{{- define "apache-tika.defaultedDict" -}}
+{{- $defaults := .defaults | default dict -}}
+{{- $given := .given -}}
+{{- $path := .path | default "value" -}}
+{{- if kindIs "invalid" $given -}}
+{{- $given = dict -}}
+{{- end -}}
+{{- if not (kindIs "map" $given) -}}
+{{- fail (printf "%s must be a mapping or null, got %s (%v)" $path (kindOf $given) $given) -}}
+{{- end -}}
+{{- $out := deepCopy $defaults -}}
+{{- range $key, $value := $given -}}
+{{- if not (kindIs "invalid" $value) -}}
+{{- $default := index $defaults $key -}}
+{{- if and (kindIs "map" $value) (kindIs "map" $default) -}}
+{{- $_ := set $out $key (fromYaml (include "apache-tika.defaultedDict" (dict "defaults" $default "given" $value "path" (printf "%s.%s" $path $key)))) -}}
+{{- else if kindIs "map" $default -}}
+{{- fail (printf "%s.%s must be a mapping or null, got %s (%v)" $path $key (kindOf $value) $value) -}}
+{{- else -}}
+{{- $_ := set $out $key $value -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- toYaml $out -}}
+{{- end -}}
+
+{{/*
+Pick one sub-block out of a values block that may itself be null.
+
+Input: dict "block" <dict|nil> "key" <string> "path" <string>.
+Returns YAML of dict "value" <the sub-block, may be nil>, after rejecting a
+non-mapping block with a message that names the values path. Needed because
+".Values.tika.securityContext" can itself be erased.
+*/}}
+{{- define "apache-tika.subBlock" -}}
+{{- $block := .block -}}
+{{- if kindIs "invalid" $block -}}
+{{- $block = dict -}}
+{{- end -}}
+{{- if not (kindIs "map" $block) -}}
+{{- fail (printf "%s must be a mapping or null, got %s (%v)" .path (kindOf $block) $block) -}}
+{{- end -}}
+{{- toYaml (dict "value" (index $block .key)) -}}
+{{- end -}}
+
+{{/*
+The effective security contexts, probes and resources (issue #99).
+
+The defaults below MUST stay in sync with the corresponding blocks in
+values.yaml, which stays the documented, user-facing place for them; this copy
+is only the fallback for the case where an override has erased the block.
+
+The probes address the container port by its name ("tika-port"), so a rebuilt
+default probe needs no further context.
+*/}}
+{{- define "apache-tika.podSecurityContext" -}}
+{{- $given := (fromYaml (include "apache-tika.subBlock" (dict "block" . "key" "pod" "path" "tika.securityContext"))).value -}}
+{{- $defaults := dict
+      "runAsNonRoot" true
+      "runAsUser" 35002
+      "runAsGroup" 35002 -}}
+{{- include "apache-tika.defaultedDict" (dict "defaults" $defaults "given" $given "path" "tika.securityContext.pod") -}}
+{{- end -}}
+
+{{- define "apache-tika.containerSecurityContext" -}}
+{{- $given := (fromYaml (include "apache-tika.subBlock" (dict "block" . "key" "container" "path" "tika.securityContext"))).value -}}
+{{- $defaults := dict
+      "allowPrivilegeEscalation" false
+      "readOnlyRootFilesystem" true
+      "runAsNonRoot" true
+      "capabilities" (dict "drop" (list "ALL")) -}}
+{{- include "apache-tika.defaultedDict" (dict "defaults" $defaults "given" $given "path" "tika.securityContext.container") -}}
+{{- end -}}
+
+{{- define "apache-tika.livenessProbe" -}}
+{{- $defaults := dict
+      "httpGet" (dict "path" "/" "port" "tika-port")
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 3 -}}
+{{- include "apache-tika.defaultedDict" (dict "defaults" $defaults "given" . "path" "tika.livenessProbe") -}}
+{{- end -}}
+
+{{- define "apache-tika.readinessProbe" -}}
+{{- $defaults := dict
+      "httpGet" (dict "path" "/" "port" "tika-port")
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 3 -}}
+{{- include "apache-tika.defaultedDict" (dict "defaults" $defaults "given" . "path" "tika.readinessProbe") -}}
+{{- end -}}
+
+{{- define "apache-tika.startupProbe" -}}
+{{- $defaults := dict
+      "httpGet" (dict "path" "/" "port" "tika-port")
+      "periodSeconds" 5
+      "timeoutSeconds" 5
+      "failureThreshold" 30 -}}
+{{- include "apache-tika.defaultedDict" (dict "defaults" $defaults "given" . "path" "tika.startupProbe") -}}
+{{- end -}}
+
+{{/*
+The effective resources block, fed into the resources helper above so that an
+erased "resources:" still yields the chart's requests and computed limits
+instead of a container without any resource accounting.
+*/}}
+{{- define "apache-tika.effectiveResources" -}}
+{{- $defaults := dict
+      "limitFactor" 3
+      "requests" (dict "cpu" 0.1 "memory" "512Mi" "ephemeralStorage" "10Mi") -}}
+{{- $merged := fromYaml (include "apache-tika.defaultedDict" (dict "defaults" $defaults "given" . "path" "tika.resources")) -}}
+{{- include "apache-tika.resources" $merged -}}
+{{- end -}}

--- a/apache-tika/templates/apache-tika.deployment.yaml
+++ b/apache-tika/templates/apache-tika.deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       automountServiceAccountToken: false
       securityContext:
-        {{- toYaml .Values.tika.securityContext.pod | nindent 8 }}
+        {{- include "apache-tika.podSecurityContext" .Values.tika.securityContext | nindent 8 }}
       containers:
         - name: {{ .Release.Name }}-{{ .Chart.Name }}-deployment
           image: "apache/tika:{{ .Chart.AppVersion }}"
@@ -46,7 +46,7 @@ spec:
             {{- end }}
           {{- end }}
           securityContext:
-            {{- toYaml .Values.tika.securityContext.container | nindent 12 }}
+            {{- include "apache-tika.containerSecurityContext" .Values.tika.securityContext | nindent 12 }}
           volumeMounts:
             # Tika writes temporary files during parsing; with a read-only
             # root filesystem /tmp must be a writable emptyDir.
@@ -57,13 +57,13 @@ spec:
               protocol: TCP
               name: tika-port
           livenessProbe:
-            {{- toYaml .Values.tika.livenessProbe | nindent 12 }}
+            {{- include "apache-tika.livenessProbe" .Values.tika.livenessProbe | nindent 12 }}
           readinessProbe:
-            {{- toYaml .Values.tika.readinessProbe | nindent 12 }}
+            {{- include "apache-tika.readinessProbe" .Values.tika.readinessProbe | nindent 12 }}
           startupProbe:
-            {{- toYaml .Values.tika.startupProbe | nindent 12 }}
+            {{- include "apache-tika.startupProbe" .Values.tika.startupProbe | nindent 12 }}
           resources:
-            {{- include "apache-tika.resources" .Values.tika.resources | nindent 12 }}
+            {{- include "apache-tika.effectiveResources" .Values.tika.resources | nindent 12 }}
       volumes:
         - name: tmp
           emptyDir: {}

--- a/apache-tika/values.schema.json
+++ b/apache-tika/values.schema.json
@@ -43,7 +43,8 @@
   },
   "definitions": {
     "resources": {
-      "type": "object",
+      "description": "May be null / empty: the chart then falls back to its default requests and computed limits (issue #99) instead of rendering a container without resource accounting.",
+      "type": ["object", "null"],
       "additionalProperties": false,
       "properties": {
         "limitFactor": {
@@ -59,7 +60,7 @@
       }
     },
     "resourceList": {
-      "type": "object",
+      "type": ["object", "null"],
       "additionalProperties": false,
       "properties": {
         "cpu": {
@@ -118,22 +119,23 @@
       }
     },
     "securityContext": {
-      "type": "object",
+      "description": "May be null / empty at any level: the chart then falls back to its hardening defaults (issue #99) instead of rendering an unhardened workload.",
+      "type": ["object", "null"],
       "additionalProperties": false,
       "properties": {
         "pod": {
-          "description": "Rendered verbatim as the pod's securityContext; kept open because the chart does not interpret it.",
-          "type": "object"
+          "description": "Merged onto the chart's pod hardening defaults and rendered as the pod's securityContext; kept open because the chart does not interpret the individual fields.",
+          "type": ["object", "null"]
         },
         "container": {
-          "description": "Rendered verbatim as the container's securityContext; kept open because the chart does not interpret it.",
-          "type": "object"
+          "description": "Merged onto the chart's container hardening defaults and rendered as the container's securityContext; kept open because the chart does not interpret the individual fields.",
+          "type": ["object", "null"]
         }
       }
     },
     "probe": {
-      "description": "Rendered verbatim as a container probe; kept open because the chart does not interpret it.",
-      "type": "object"
+      "description": "Merged onto the chart's probe defaults and rendered as a container probe; kept open because the chart does not interpret the individual fields. May be null / empty, which means the defaults apply (issue #99) rather than the probe disappearing.",
+      "type": ["object", "null"]
     }
   }
 }


### PR DESCRIPTION
Nachrüstung für ein Chart, das das Schema aus #68 schon trägt (`8.0.0`), aber noch keine Null-Absicherung. Version **8.0.0 → 9.0.0** (major, appVersion unverändert bei `3.3.1.0-full`).

Kein Ingress-Gate: apache-tika hat **keinen Ingress**. Also zwei Punkte statt drei. Damit ist Welle 1 vollständig und einheitlich.

Der Werte-Block heißt `tika`, nicht `apache-tika` — Helper und Schema folgen dem Chart, nicht dem Verzeichnisnamen.

---

# 1. Null-Absicherung für Härtung, Probes und Ressourcen (#99)

`defaultedDict` aus #96 übernommen (chart-präfigiert), dazu `subBlock` für den Fall, dass `securityContext` **selbst** erased ist. Abgesichert: Pod- und Container-Context, die drei Probes, `resources`.

**Probe-Kontext geprüft** (nach dem patchmon-Fall): Die Probes sprechen den Container-Port über seinen **Namen** an (`tika-port`) und tragen keinen Host-Header. Eine rekonstruierte Default-Probe braucht hier also keinen zusätzlichen Kontext — anders als bei patchmon, wo der `Host`-Header aus `ingress.domain` mitrekonstruiert werden muss.

# 2. Schema-Typen (#68 + #99)

Die abgesicherten Blöcke akzeptieren jetzt `null`. Grund ist der in #99 dokumentierte Zwei-Fall-Mechanismus:

| Fall | Was Helm tut | Wer es auffängt |
|---|---|---|
| Schlüssel **mit** Chart-Default (z. B. `tika.securityContext.container`) | Das `null` **löscht** den Default beim Coalescing, bevor die Validierung läuft — das Schema sieht es **nie** | der Helper (Punkt 1) |
| Schlüssel **ohne** Chart-Default (`tika.resources.limits`) | Nichts zu löschen, das `null` **überlebt** bis in die Validierung | die Typ-Erweiterung |

Alle übrigen Schlüssel bleiben streng; `additionalProperties: false` ist an keiner Stelle gelockert.

---

## Nachweis 1: erased Block → vorher, nachher

Werte-Datei in der realistischen Form (letzter Unterschlüssel gelöscht, Kopfzeile stehen geblieben):

```yaml
tika:
  securityContext:
    container:
  livenessProbe:
```

**Vorher** (veröffentlichter Stand `8.0.0`, **mit** Schema):

```yaml
          securityContext:
            null
          ...
          livenessProbe:
            null
```

Der Container läuft ohne `readOnlyRootFilesystem`, ohne `drop: ALL`, ohne `allowPrivilegeEscalation: false`, und die Liveness-Probe ist ersatzlos weg. **Das vorhandene Schema fängt das nicht** — der Fall aus der oberen Tabellenzeile.

**Nachher**, dieselbe Datei:

```yaml
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: true
            runAsNonRoot: true
```

Und der zweite Fall, `tika: { resources: { limits: } }` ohne Kinder — **vorher** ein harter Abbruch:

```
Error: values don't meet the specifications of the schema(s) in the following chart(s):
apache-tika:
- at '/tika/resources/limits': got null, want object
```

**nachher** die Defaults samt berechneter Limits:

```yaml
          resources:
            limits:
              ephemeral-storage: 30Mi
              memory: 1536Mi
            requests:
              cpu: 0.1
              ephemeral-storage: 10Mi
              memory: 512Mi
```

## Nachweis 2: ein bewusst gesetztes `false` / `0` gewinnt weiterhin

Die Stelle, an der `default` und `mergeOverwrite` scheitern.

`--set tika.securityContext.container.readOnlyRootFilesystem=false`:

```yaml
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: false     # <- gesetzter Zero-Value gewinnt
            runAsNonRoot: true                # <- übrige Defaults überleben
```

`--set tika.startupProbe.failureThreshold=0`:

```yaml
          startupProbe:
            failureThreshold: 0               # <- explizite 0 gewinnt
            httpGet:
              path: /
              port: tika-port
            periodSeconds: 5
            timeoutSeconds: 5
```

Beide zeigen zugleich den rekursiven Teilmerge: Ein teilweise gefüllter Block überschreibt nur, was er wirklich setzt.

## Nachweis 3: im Normalfall ändert sich nichts

```
$ diff <(helm template t <origin/main-Stand> -f ci/apache-tika/test-values.yaml) \
       <(helm template t apache-tika          -f ci/apache-tika/test-values.yaml)
(keine Ausgabe — byte-identisch)
```

## Verifikation

```
$ helm lint --strict apache-tika
1 chart(s) linted, 0 chart(s) failed
```

| Fall | Ergebnis |
|---|---|
| Default-Values | rendert |
| `ci/apache-tika/test-values.yaml` (`{}`) | rendert |

**Negativprobe — das Schema bleibt streng:**

```
--set tika.resources.requests.bogusCpu=1
  -> at '/tika/resources/requests': additional properties 'bogusCpu' not allowed
```

## Cluster-Seite

Unverändert wie in #95 beschrieben: Das Bundle `fleet-cd/cluster-tika-gotenberg/tika/` besteht nur aus einer `fleet.yaml` **ohne `valuesFiles`**, der ausgerollte Stand meldet `USER-SUPPLIED VALUES: null`. Es gibt keine benutzerdefinierten Werte — also weder abgewiesene Schlüssel noch erased Blöcke. **Vor dem Hochziehen auf `9.0.0` nichts zu bereinigen.**

Refs #68, Refs #99.
