### PR TITLE
Add NOTES.txt to the apache-tika chart

### DIFF
--- a/apache-tika/Chart.yaml
+++ b/apache-tika/Chart.yaml
@@ -5,5 +5,5 @@ icon: https://www.apache.org/logos/res/tika/default.png
 
 type: application
 
-version: 9.0.0+up3.3.1.0.full
+version: 9.1.0+up3.3.1.0.full
 appVersion: "3.3.1.0-full"

--- a/apache-tika/templates/NOTES.txt
+++ b/apache-tika/templates/NOTES.txt
@@ -1,0 +1,56 @@
+{{- $replicas := include "apache-tika.replicas" (dict "scaleDown" .Values.scaleDown "replicas" .Values.tika.replicas) -}}
+{{- $limits := (include "apache-tika.effectiveResources" .Values.tika.resources | fromYaml).limits | default dict -}}
+{{- $memLimit := index $limits "memory" -}}
+{{- $svc := printf "%s-%s-service" .Release.Name .Chart.Name -}}
+Apache Tika {{ .Chart.AppVersion }} — release {{ .Release.Name }} in namespace {{ .Release.Namespace }}.
+
+ACCESS
+  This chart creates no Ingress. The server is cluster-internal:
+
+    http://{{ $svc }}.{{ .Release.Namespace }}.svc.cluster.local
+
+  Mind the port. The Service listens on 80 and forwards to the container's
+  9998, so consumers are configured without a port — e.g. paperless-ngx:
+
+    PAPERLESS_TIKA_ENDPOINT: http://{{ $svc }}.{{ .Release.Namespace }}.svc.cluster.local
+
+  To reach it from your machine:
+
+    kubectl -n {{ .Release.Namespace }} port-forward svc/{{ $svc }} 9998:80
+    curl http://localhost:9998/version
+    curl http://localhost:9998/parsers
+
+  /parsers lists every parser the running server actually has — the honest
+  answer to "why did this file come back empty". This chart has no secrets
+  and no volumes.
+{{ if eq $replicas "0" }}
+SCALED TO ZERO
+  {{ if .Values.scaleDown }}scaleDown: true{{ else }}tika.replicas: 0{{ end }} — the deployment runs with replicas: 0. The Service
+  keeps its ClusterIP but has no endpoints, so callers fail with "connection
+  refused" rather than a timeout. Set it back and upgrade to return.
+{{ end }}
+NO AUTHENTICATION — AND IT PARSES WHATEVER IT IS SENT
+  Tika has no authentication, and this chart adds none. It is a parser for
+  untrusted input by nature, and its parsers have a long history of being the
+  soft spot. Anything that can reach the Service can make this pod open a
+  file. Keep it cluster-internal; do not put an Ingress in front of it.
+
+THE IMAGE TAG HAS TO KEEP ITS -full SUFFIX
+  appVersion is pinned to {{ .Chart.AppVersion }}. The "-full" variant is the one that
+  ships Tesseract OCR (5.5.0, with the languages deu, eng, fra, ita, jpn, osd
+  and spa) plus the extra parsers; the plain apache/tika:<version> image has
+  no tesseract binary at all. Overriding the tag without "-full" does not fail
+  loudly — OCR simply stops happening and scanned documents come back with
+  empty text.
+{{- if $memLimit }}
+
+THE JVM ONLY GETS A QUARTER OF THE MEMORY LIMIT
+  The server starts without -Xmx, so the JVM derives its maximum heap from the
+  container limit at MaxRAMPercentage=25. With this release's limit of
+  {{ $memLimit }} that is roughly {{ include "apache-tika.multiplyQuantity" (dict "quantity" $memLimit "factor" 0.25) }} of usable heap — the number to reason about when
+  sizing, not the limit itself. Raising tika.resources.requests.memory raises
+  the limit (limitFactor x request) and the heap along with it.
+  Text extraction streams rather than buffering, so ordinary documents stay
+  cheap regardless; the heap is what matters for parsers that have to build a
+  whole document in memory, and for OCR.
+{{- end }}

--- a/apache-tika/templates/NOTES.txt
+++ b/apache-tika/templates/NOTES.txt
@@ -1,4 +1,8 @@
 {{- $replicas := include "apache-tika.replicas" (dict "scaleDown" .Values.scaleDown "replicas" .Values.tika.replicas) -}}
+{{- /* effectiveResources, not resources: an erased "resources:" block falls back
+       to the chart defaults in the Deployment (#99), so the notes must report the
+       limits the release actually gets — and the heap figure below is derived from
+       that same effective limit, not from the raw value. */ -}}
 {{- $limits := (include "apache-tika.effectiveResources" .Values.tika.resources | fromYaml).limits | default dict -}}
 {{- $memLimit := index $limits "memory" -}}
 {{- $svc := printf "%s-%s-service" .Release.Name .Chart.Name -}}


### PR DESCRIPTION
Adds `apache-tika/templates/NOTES.txt`. Refs #43 (the issue covers all charts, so this PR does not close it).

Chart version `9.0.0+up3.3.1.0.full` → `9.1.0+up3.3.1.0.full` (minor, purely additive — a `NOTES.txt` renders no Kubernetes object).

## What it prints and why

- **Access** — the cluster-internal FQDN, plus the port trap: the Service listens on **80**, the container on **9998**, so consumers are configured without a port. `PAPERLESS_TIKA_ENDPOINT` is spelled out because paperless-ngx is the real consumer. `/parsers` is offered as the direct answer to "why did this file come back empty" — it lists what the running server actually has, rather than what it is supposed to have.
- **No authentication, and it parses whatever it is sent** — Tika is a parser for untrusted input by nature and its parsers have historically been the soft spot. Keep it cluster-internal.
- **The image tag has to keep its `-full` suffix** — see below; this is the one that bites silently.
- **The JVM only gets a quarter of the memory limit** — the number worth sizing against is not the limit.
- **Scaled to zero** (conditional) — names the cause and notes callers get "connection refused" rather than a timeout.

## The two findings, verified in both directions

**`-full` is load-bearing.** Verified rather than inferred from the tag name:

- In the chart's pinned `apache/tika:3.3.1.0-full`: `/usr/bin/tesseract`, **tesseract 5.5.0**, languages `deu eng fra ita jpn osd spa`, and `TesseractOCRParser` present in the running server's `/parsers` output.
- In the plain `apache/tika:3.3.1.0` (pulled and checked separately): **no tesseract binary at all**.

So overriding the tag without `-full` does not fail — OCR simply stops and scanned documents come back with empty text, which is the kind of thing noticed weeks later.

**The JVM never sees the container limit.** The server runs `java -cp /tika-server-standard-3.3.1.jar ... TikaServerCli` with no `-Xmx`, and in the container `UseContainerSupport=true` with `MaxRAMPercentage=25`. At the default `1536Mi` limit the JVM reports `MaxHeapSize = 402653184` — exactly **384Mi**, which is what the notes print.

**A claim I removed.** I intended to warn that oversized documents come back as HTTP 500 with an `OutOfMemoryError`. I could not reproduce it: even with the limit forced down to `400Mi` (≈100Mi heap), Tika parses the 25 MB test document in **0.45 s** with HTTP 200 and streams out 26 MB of text. It streams rather than buffering, so the warning was wrong and is not in the file.

## Null-safety: uses `effectiveResources`, and here is the difference

Per review guidance the notes read the limit through the chart's **null-safe** `apache-tika.effectiveResources`, not the raw `apache-tika.resources`. This is not cosmetic. With an erased block:

```yaml
tika:
  resources:
```

the Deployment still renders `memory: 1536Mi` / `ephemeral-storage: 30Mi` (the null-safety from #99). Rendered against the **raw** helper, the notes' memory value came out empty, so the guard around the section evaluated false and the **entire heap paragraph silently disappeared** — precisely when the operator has been editing resources and most needs it. Against `effectiveResources` the same input prints `1536Mi` / `384Mi`.

Confirmed end to end on a real install with that erased block: the live pod's limits are `{"ephemeral-storage":"30Mi","memory":"1536Mi"}` and its JVM reports `MaxHeapSize = 402653184` (384 MiB) — the same figures the notes printed.

## Verification

`helm lint --strict apache-tika` → `1 chart(s) linted, 0 chart(s) failed` (after rebasing onto `main` at `392fc6c3`). Helper names re-checked post-rebase: `apache-tika.replicas`, `apache-tika.multiplyQuantity` and `apache-tika.effectiveResources` all present.

`helm template` does not render `NOTES.txt`, so the output below comes from **real installs** with `--wait` into a throwaway k3d cluster (own cluster, explicit `--kube-context`; the global context was never used or changed).

### Variant A — defaults (`scaleDown: false`)

```
Apache Tika 3.3.1.0-full — release tk-notes in namespace tk-notes.

ACCESS
  This chart creates no Ingress. The server is cluster-internal:

    http://tk-notes-apache-tika-service.tk-notes.svc.cluster.local

  Mind the port. The Service listens on 80 and forwards to the container's
  9998, so consumers are configured without a port — e.g. paperless-ngx:

    PAPERLESS_TIKA_ENDPOINT: http://tk-notes-apache-tika-service.tk-notes.svc.cluster.local

  To reach it from your machine:

    kubectl -n tk-notes port-forward svc/tk-notes-apache-tika-service 9998:80
    curl http://localhost:9998/version
    curl http://localhost:9998/parsers

  /parsers lists every parser the running server actually has — the honest
  answer to "why did this file come back empty". This chart has no secrets
  and no volumes.

NO AUTHENTICATION — AND IT PARSES WHATEVER IT IS SENT
  Tika has no authentication, and this chart adds none. It is a parser for
  untrusted input by nature, and its parsers have a long history of being the
  soft spot. Anything that can reach the Service can make this pod open a
  file. Keep it cluster-internal; do not put an Ingress in front of it.

THE IMAGE TAG HAS TO KEEP ITS -full SUFFIX
  appVersion is pinned to 3.3.1.0-full. The "-full" variant is the one that
  ships Tesseract OCR (5.5.0, with the languages deu, eng, fra, ita, jpn, osd
  and spa) plus the extra parsers; the plain apache/tika:<version> image has
  no tesseract binary at all. Overriding the tag without "-full" does not fail
  loudly — OCR simply stops happening and scanned documents come back with
  empty text.

THE JVM ONLY GETS A QUARTER OF THE MEMORY LIMIT
  The server starts without -Xmx, so the JVM derives its maximum heap from the
  container limit at MaxRAMPercentage=25. With this release's limit of
  1536Mi that is roughly 384Mi of usable heap — the number to reason about when
  sizing, not the limit itself. Raising tika.resources.requests.memory raises
  the limit (limitFactor x request) and the heap along with it.
  Text extraction streams rather than buffering, so ordinary documents stay
  cheap regardless; the heap is what matters for parsers that have to build a
  whole document in memory, and for OCR.
```

The conditional block is correctly absent.

### Variant B — `scaleDown: true`

The conditional block appears:

```
SCALED TO ZERO
  scaleDown: true — the deployment runs with replicas: 0. The Service
  keeps its ClusterIP but has no endpoints, so callers fail with "connection
  refused" rather than a timeout. Set it back and upgrade to return.
```

### Variant C — erased `resources:` block

Prints the same `1536Mi` / `384Mi` as variant A, matching the live container (see above). The k3d cluster was deleted afterwards.
