### PR TITLE
rallly: strict values.schema.json + Ingress-Gate + Null-Absicherung (Welle 2, #68/#93/#99)

### DIFF
--- a/rallly/Chart.yaml
+++ b/rallly/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://raw.githubusercontent.com/lukevella/rallly/main/apps/landing/publi
 
 type: application
 
-version: 5.0.0+up4.12.3
+version: 6.0.0+up4.12.3
 appVersion: "4.12.3"
 
 maintainers:

--- a/rallly/templates/_helpers.tpl
+++ b/rallly/templates/_helpers.tpl
@@ -114,3 +114,164 @@ template-chart is the reference implementation.
 1
 {{- end -}}
 {{- end -}}
+
+{{/*
+Merge a user-supplied values sub-tree onto a dict of chart defaults so that a
+null / empty override falls back to the defaults instead of erasing them.
+
+Input: dict "defaults" <dict> "given" <dict|nil> "path" <string, optional
+values path used in error messages>. Output: YAML of the merged dict (consume
+it with fromYaml).
+
+Why this exists (issue #99): Helm merges values maps recursively, but an
+override key written without children — e.g. a leftover
+
+  securityContext:
+
+after deleting its last remaining sub-key — is YAML null. Where the chart
+defines a default, Helm treats that null as a deletion of the default; the
+template then renders "securityContext: null": no readOnlyRootFilesystem, no
+dropped capabilities, no allowPrivilegeEscalation: false. The workload starts
+and reports healthy while being unhardened, so nothing points at the mistake.
+The same shape erases a probe (it disappears) or the resources block (no
+requests, no computed limits). This helper defines the opposite semantics: an
+empty block means "chart defaults apply".
+
+Rules:
+  - a nil "given" is treated as an empty dict (all defaults apply).
+  - a key whose override value is null keeps the default (nulls never delete).
+  - a key present in both as a map is merged recursively, so a partially
+    filled block only overrides the keys it actually sets.
+  - a scalar override for a key the defaults define as a map is rejected with
+    a message naming the values path, instead of failing later with a template
+    field error.
+  - any other set value wins as given, including an explicit false or 0 —
+    Helm's "default" and sprig's "mergeOverwrite" would both swallow those
+    zero values, hence the explicit kindIs "invalid" nil check.
+  - keys only present in the override are passed through unchanged.
+
+NOTE: like the helpers above, this is duplicated into every chart's
+templates/_helpers.tpl with the chart's name as define prefix, because charts
+in this repo deliberately have no dependencies.
+*/}}
+{{- define "rallly.defaultedDict" -}}
+{{- $defaults := .defaults | default dict -}}
+{{- $given := .given -}}
+{{- $path := .path | default "value" -}}
+{{- if kindIs "invalid" $given -}}
+{{- $given = dict -}}
+{{- end -}}
+{{- if not (kindIs "map" $given) -}}
+{{- fail (printf "%s must be a mapping or null, got %s (%v)" $path (kindOf $given) $given) -}}
+{{- end -}}
+{{- $out := deepCopy $defaults -}}
+{{- range $key, $value := $given -}}
+{{- if not (kindIs "invalid" $value) -}}
+{{- $default := index $defaults $key -}}
+{{- if and (kindIs "map" $value) (kindIs "map" $default) -}}
+{{- $_ := set $out $key (fromYaml (include "rallly.defaultedDict" (dict "defaults" $default "given" $value "path" (printf "%s.%s" $path $key)))) -}}
+{{- else if kindIs "map" $default -}}
+{{- fail (printf "%s.%s must be a mapping or null, got %s (%v)" $path $key (kindOf $value) $value) -}}
+{{- else -}}
+{{- $_ := set $out $key $value -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- toYaml $out -}}
+{{- end -}}
+
+{{/*
+Pick one sub-block out of a values block that may itself be null.
+
+Input: dict "block" <dict|nil> "key" <string> "path" <string>.
+Returns YAML of dict "value" <the sub-block, may be nil>, after rejecting a
+non-mapping block with a message that names the values path. Needed because
+".Values.rallly.securityContext" can itself be erased.
+*/}}
+{{- define "rallly.subBlock" -}}
+{{- $block := .block -}}
+{{- if kindIs "invalid" $block -}}
+{{- $block = dict -}}
+{{- end -}}
+{{- if not (kindIs "map" $block) -}}
+{{- fail (printf "%s must be a mapping or null, got %s (%v)" .path (kindOf $block) $block) -}}
+{{- end -}}
+{{- toYaml (dict "value" (index $block .key)) -}}
+{{- end -}}
+
+{{/*
+The effective security contexts, probes and resources (issue #99).
+
+The defaults below MUST stay in sync with the corresponding blocks in
+values.yaml, which stays the documented, user-facing place for them; this copy
+is only the fallback for the case where an override has erased the block.
+
+The probes address the container port by its name ("http"), so a rebuilt
+default probe needs no further context.
+
+Note on the container context: no "add:" key is defined here either. An empty
+list item under it renders as a null entry, which is what Trivy reported as
+AVD-KSV-0022 for the older deployed chart version (#84).
+*/}}
+{{- define "rallly.podSecurityContext" -}}
+{{- $given := (fromYaml (include "rallly.subBlock" (dict "block" . "key" "pod" "path" "rallly.securityContext"))).value -}}
+{{- $defaults := dict
+      "runAsNonRoot" true
+      "runAsUser" 20000
+      "runAsGroup" 1000
+      "fsGroup" 1000
+      "fsGroupChangePolicy" "Always" -}}
+{{- include "rallly.defaultedDict" (dict "defaults" $defaults "given" $given "path" "rallly.securityContext.pod") -}}
+{{- end -}}
+
+{{- define "rallly.containerSecurityContext" -}}
+{{- $given := (fromYaml (include "rallly.subBlock" (dict "block" . "key" "container" "path" "rallly.securityContext"))).value -}}
+{{- $defaults := dict
+      "allowPrivilegeEscalation" false
+      "readOnlyRootFilesystem" true
+      "runAsNonRoot" true
+      "capabilities" (dict "drop" (list "ALL")) -}}
+{{- include "rallly.defaultedDict" (dict "defaults" $defaults "given" $given "path" "rallly.securityContext.container") -}}
+{{- end -}}
+
+{{- define "rallly.livenessProbe" -}}
+{{- $defaults := dict
+      "httpGet" (dict "path" "/" "port" "http")
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 3 -}}
+{{- include "rallly.defaultedDict" (dict "defaults" $defaults "given" . "path" "rallly.livenessProbe") -}}
+{{- end -}}
+
+{{- define "rallly.readinessProbe" -}}
+{{- $defaults := dict
+      "httpGet" (dict "path" "/" "port" "http")
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 3 -}}
+{{- include "rallly.defaultedDict" (dict "defaults" $defaults "given" . "path" "rallly.readinessProbe") -}}
+{{- end -}}
+
+{{- define "rallly.startupProbe" -}}
+{{- $defaults := dict
+      "httpGet" (dict "path" "/" "port" "http")
+      "periodSeconds" 5
+      "timeoutSeconds" 5
+      "failureThreshold" 30 -}}
+{{- include "rallly.defaultedDict" (dict "defaults" $defaults "given" . "path" "rallly.startupProbe") -}}
+{{- end -}}
+
+{{/*
+The effective resources block, fed into the resources helper above so that an
+erased "resources:" still yields the chart's requests and computed limits
+instead of a container without any resource accounting. That matters more here
+than elsewhere: the Next.js cache is an emptyDir, and its usage counts against
+the container's ephemeral-storage limit.
+*/}}
+{{- define "rallly.effectiveResources" -}}
+{{- $defaults := dict
+      "limitFactor" 3
+      "requests" (dict "cpu" 0.1 "memory" "512Mi" "ephemeral-storage" "100Mi") -}}
+{{- $merged := fromYaml (include "rallly.defaultedDict" (dict "defaults" $defaults "given" . "path" "rallly.resources")) -}}
+{{- include "rallly.resources" $merged -}}
+{{- end -}}

--- a/rallly/templates/rallly.deployment.yaml
+++ b/rallly/templates/rallly.deployment.yaml
@@ -17,14 +17,18 @@ spec:
     spec:
       automountServiceAccountToken: false
       securityContext:
-        {{- toYaml .Values.rallly.securityContext.pod | nindent 8 }}
+        {{- include "rallly.podSecurityContext" .Values.rallly.securityContext | nindent 8 }}
       containers:
         - name: {{ .Release.Name }}-{{ .Chart.Name }}-deployment
           image: "lukevella/rallly:{{ .Chart.AppVersion }}"
           imagePullPolicy: IfNotPresent
           env:
+            # ingress.domain is not a pure Ingress value: it is also the app's
+            # public base URL, so it stays required even when the Ingress is
+            # switched off (an empty value would render "https://" and break
+            # every generated link silently).
             - name: NEXT_PUBLIC_BASE_URL
-              value: "https://{{ .Values.ingress.domain }}"
+              value: "https://{{ required "A Domain/Host must be provided (ingress.domain)" .Values.ingress.domain }}"
             - name: SECRET_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -141,15 +145,15 @@ spec:
               protocol: TCP
               name: http
           livenessProbe:
-            {{ toYaml .Values.rallly.livenessProbe | nindent 12}}
+            {{- include "rallly.livenessProbe" .Values.rallly.livenessProbe | nindent 12 }}
           readinessProbe:
-            {{ toYaml .Values.rallly.readinessProbe | nindent 12}}
+            {{- include "rallly.readinessProbe" .Values.rallly.readinessProbe | nindent 12 }}
           startupProbe:
-            {{ toYaml .Values.rallly.startupProbe | nindent 12}}
+            {{- include "rallly.startupProbe" .Values.rallly.startupProbe | nindent 12 }}
           resources:
-            {{- include "rallly.resources" .Values.rallly.resources | nindent 12 }}
+            {{- include "rallly.effectiveResources" .Values.rallly.resources | nindent 12 }}
           securityContext:
-            {{- toYaml .Values.rallly.securityContext.container | nindent 12 }}
+            {{- include "rallly.containerSecurityContext" .Values.rallly.securityContext | nindent 12 }}
           volumeMounts:
             # Next.js writes prerendered pages and optimized images into its
             # cache directory; with a read-only root filesystem this must be a

--- a/rallly/templates/rallly.ingress.yaml
+++ b/rallly/templates/rallly.ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -24,3 +25,4 @@ spec:
     - hosts:
         - {{ required "A Domain/Host must be provided" .Values.ingress.domain }}
       secretName: tls-{{ .Release.Name }}-{{ .Chart.Name }}-ingress
+{{- end }}

--- a/rallly/values.schema.json
+++ b/rallly/values.schema.json
@@ -1,0 +1,232 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "rallly values",
+  "description": "Strict values schema (issue #68). additionalProperties is false on every chart-owned object level, so a key that the chart does not read is rejected at render time instead of being silently ignored. The only objects that stay open are the ones passed verbatim into the Kubernetes pod spec (probes, security contexts, global) - the chart does not interpret their contents, so it cannot judge which keys are meaningful. The hardening, probe and resources blocks additionally accept null, because an erased block falls back to the chart defaults (issue #99).",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "global": {
+      "description": "Helm's conventional cross-chart values. Unused by this chart, kept open so an umbrella install cannot break on it.",
+      "type": "object"
+    },
+    "scaleDown": {
+      "type": "boolean"
+    },
+    "secrets": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ralllySecretRef": {
+          "type": ["string", "null"]
+        },
+        "oidcSecretRef": {
+          "type": ["string", "null"]
+        },
+        "databaseSecretRef": {
+          "type": ["string", "null"]
+        },
+        "smtpSecretRef": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "rallly": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "replicas": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "smtp": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "rejectUnauthorized": {
+              "description": "Passed to the app as SMTP_REJECT_UNAUTHORIZED. Read by the chart but deliberately without a default in values.yaml - see the note in the PR that introduced this schema.",
+              "type": ["boolean", "string", "null"]
+            }
+          }
+        },
+        "allowedEmails": {
+          "type": ["string", "null"]
+        },
+        "supportEmail": {
+          "type": ["string", "null"]
+        },
+        "oidc": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": ["string", "null"]
+            },
+            "pictureClaimPath": {
+              "type": ["string", "null"]
+            },
+            "emailClaimPath": {
+              "type": ["string", "null"]
+            },
+            "nameClaimPath": {
+              "type": ["string", "null"]
+            }
+          }
+        },
+        "cache": {
+          "description": "The writable emptyDir mounted over the Next.js cache directory. Not null-safe on purpose: cache.path is required(), so an erased block fails loudly instead of silently (issue #99 covers only the silent class).",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "type": ["string", "null"]
+            },
+            "sizeLimit": {
+              "type": ["string", "number", "null"]
+            }
+          }
+        },
+        "securityContext": {
+          "$ref": "#/definitions/securityContext"
+        },
+        "env": {
+          "$ref": "#/definitions/env"
+        },
+        "resources": {
+          "$ref": "#/definitions/resources"
+        },
+        "livenessProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "readinessProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "startupProbe": {
+          "$ref": "#/definitions/probe"
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "description": "Gates the whole Ingress template (issue #93). false omits the Ingress and makes clusterIssuer unnecessary - but NOT domain, which is also the app's public base URL.",
+          "type": "boolean"
+        },
+        "clusterIssuer": {
+          "type": ["string", "null"]
+        },
+        "domain": {
+          "type": ["string", "null"]
+        },
+        "className": {
+          "type": ["string", "null"]
+        },
+        "annotations": {
+          "description": "Extra Ingress annotations, merged with the cert-manager annotation the chart always sets. Free-form keys by nature.",
+          "type": "object"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "resources": {
+      "description": "May be null / empty: the chart then falls back to its default requests and computed limits (issue #99) instead of rendering a container without resource accounting.",
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "limitFactor": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "requests": {
+          "$ref": "#/definitions/resourceList"
+        },
+        "limits": {
+          "$ref": "#/definitions/resourceList"
+        }
+      }
+    },
+    "resourceList": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "cpu": {
+          "type": ["string", "number", "null"]
+        },
+        "memory": {
+          "type": ["string", "number", "null"]
+        },
+        "ephemeral-storage": {
+          "type": ["string", "number", "null"]
+        },
+        "ephemeralStorage": {
+          "type": ["string", "number", "null"]
+        }
+      }
+    },
+    "env": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "valueFrom": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "secretKeyRef": {
+                "$ref": "#/definitions/keyRef"
+              },
+              "configMapKeyRef": {
+                "$ref": "#/definitions/keyRef"
+              }
+            }
+          }
+        }
+      }
+    },
+    "keyRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "key"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        }
+      }
+    },
+    "securityContext": {
+      "description": "May be null / empty at any level: the chart then falls back to its hardening defaults (issue #99) instead of rendering an unhardened workload.",
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "pod": {
+          "description": "Merged onto the chart's pod hardening defaults and rendered as the pod's securityContext; kept open because the chart does not interpret the individual fields.",
+          "type": ["object", "null"]
+        },
+        "container": {
+          "description": "Merged onto the chart's container hardening defaults and rendered as the container's securityContext; kept open because the chart does not interpret the individual fields.",
+          "type": ["object", "null"]
+        }
+      }
+    },
+    "probe": {
+      "description": "Merged onto the chart's probe defaults and rendered as a container probe; kept open because the chart does not interpret the individual fields. May be null / empty, which means the defaults apply (issue #99) rather than the probe disappearing.",
+      "type": ["object", "null"]
+    }
+  }
+}

--- a/rallly/values.yaml
+++ b/rallly/values.yaml
@@ -101,6 +101,11 @@ rallly:
     failureThreshold: 30
 
 ingress:
+  # Set to false to omit the Ingress entirely. Note that ingress.domain stays
+  # required even then: it is also the app's public base URL
+  # (NEXT_PUBLIC_BASE_URL), not just the Ingress host. Only clusterIssuer
+  # becomes unnecessary.
+  enabled: true
   clusterIssuer: null
   domain: null
   className: nginx


### PR DESCRIPTION
Erstes Chart der **Welle 2** aus #68. Ausgangsstand ist `5.0.0+up4.12.3` (nach #60, emptyDir für den Next.js-Cache), Ziel **6.0.0** — major, appVersion unverändert bei 4.12.3.

Der PR trägt die inzwischen üblichen **drei Änderungen**, unten getrennt ausgewiesen, plus einen Fund, den ich nur melde und nicht behebe.

---

# 1. Strict `values.schema.json` (#68)

`additionalProperties: false` auf **allen chart-eigenen Objektebenen**: oberste Ebene, `rallly`, `rallly.smtp`, `rallly.oidc`, `rallly.cache`, `rallly.resources` mit `.requests`/`.limits`, `env[]` mit `valueFrom` und beiden KeyRefs, `securityContext`, `ingress`, `secrets`.

**Offen bleiben** die wörtlich durchgereichten Objekte: die drei Probes, `securityContext.pod`/`.container`, `global`, `ingress.annotations`.

`rallly.cache` (aus #60) ist vollständig erfasst — `path` und `sizeLimit`. Der Block ist bewusst **nicht** null-sicher: `cache.path` steht unter `required()`, ein geleerter Block scheitert also laut. #99 deckt ausdrücklich nur die stille Klasse ab, und ein Fehler, der sich selbst zeigt, braucht keine Absicherung.

# 2. Ingress-Gate (#93)

Ingress-Template in `{{- if .Values.ingress.enabled }}` gewickelt, Schlüssel mit Default `true` in `values.yaml`.

### Das Gate allein hätte hier ein neues stilles Loch gerissen

`ingress.domain` ist bei rallly **kein reiner Ingress-Wert**: Das Deployment baut daraus `NEXT_PUBLIC_BASE_URL`, und zwar bisher **ohne** `required()`. Dass der Wert trotzdem immer gesetzt war, lag allein daran, dass das ungegatete Ingress-Template ihn erzwang. Mit dem Gate wäre diese Garantie weggefallen.

Nachgestellt an einer Kopie des Charts **mit** Gate, aber **ohne** die Absicherung (`ingress.enabled=false`, kein `domain`):

```yaml
            - name: NEXT_PUBLIC_BASE_URL
              value: "https://"          # <- jeder generierte Link kaputt, lautlos
```

Der Lesezugriff im Deployment steht deshalb jetzt ebenfalls unter `required()`:

```
$ helm template t rallly --set ingress.enabled=false …   # ohne domain
Error: execution error at (rallly/templates/rallly.deployment.yaml:31:33):
A Domain/Host must be provided (ingress.domain)
```

Damit gilt für rallly — wie schon bei patchmon, aber aus einem anderen Grund: **Das Gate macht `clusterIssuer` entbehrlich, nicht `domain`.** Der Kommentar an `ingress.enabled` in `values.yaml` sagt das auch dort, wo man es sucht.

| Fall | Ergebnis |
|---|---|
| Gate an (Default) | 1 Ingress, `NEXT_PUBLIC_BASE_URL` wie bisher |
| Gate aus, `domain` gesetzt, **kein** `clusterIssuer` | rendert, **0** Ingress, `value: "https://rallly.ci.local"` |
| Gate aus, **kein** `domain` | scheitert laut (siehe oben) |

# 3. Null-Absicherung für Härtung, Probes und Ressourcen (#99)

`defaultedDict` und `subBlock` übernommen. Abgesichert: Pod- und Container-Context, die drei Probes, `resources`.

**Probe-Kontext geprüft:** Die Probes adressieren den Port über seinen **Namen** (`http`), kein Host-Header — eine rekonstruierte Default-Probe braucht hier also keinen zusätzlichen Kontext (anders als patchmon).

**Der Pod-Context ist bei rallly besonders heikel.** Er trägt `fsGroup: 1000` und `fsGroupChangePolicy: Always`, und genau das macht das Cache-`emptyDir` aus #60 für den Container (uid 20000) gruppenschreibbar. Ein geleerter Block hätte also nicht nur die Härtung entfernt, sondern den Next.js-Cache unbeschreibbar gemacht. Mit `rallly.securityContext=null`:

```yaml
      securityContext:
        fsGroup: 1000
        fsGroupChangePolicy: Always
        runAsGroup: 1000
        runAsNonRoot: true
        runAsUser: 20000
```

Im Container-Context bleibt es beim `drop: ALL` **ohne** `add:`-Schlüssel — der Hinweis aus #84 (leerer Listeneintrag → Null-Eintrag → Trivy AVD-KSV-0022) gilt für die Helper-Defaults genauso und steht dort als Kommentar.

---

## Nachweis 1: erased Block → vorher, nachher

Werte-Datei in der realistischen Form (letzter Unterschlüssel gelöscht, Kopfzeile stehen geblieben):

```yaml
rallly:
  securityContext:
    container:
  livenessProbe:
```

**Vorher** (`5.0.0`):

```yaml
          securityContext:
            null
          ...
          livenessProbe:
            null
```

**Nachher**:

```yaml
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: true
            runAsNonRoot: true
          ...
          livenessProbe:
            failureThreshold: 3
            httpGet:
              path: /
              port: http
            periodSeconds: 10
            timeoutSeconds: 5
```

## Nachweis 2: ein bewusst gesetztes `false` / `0` gewinnt weiterhin

`--set rallly.securityContext.container.readOnlyRootFilesystem=false` → `readOnlyRootFilesystem: false`, während `allowPrivilegeEscalation: false`, `drop: ALL` und `runAsNonRoot: true` erhalten bleiben.

`--set rallly.startupProbe.failureThreshold=0` → `failureThreshold: 0`, restliche Probe-Defaults intakt.

## Nachweis 3: das Rendering ändert sich nicht

```
$ diff <(helm template t <5.0.0> -f ci/rallly/test-values.yaml) \
       <(helm template t rallly   -f ci/rallly/test-values.yaml)
```

Einziger Unterschied ist der vierzeilige Kommentar, den ich über `NEXT_PUBLIC_BASE_URL` gesetzt habe. Sonst identisch — verglichen nach Entfernen reiner Leerzeilen, weil die Probe-Zeilen bisher `{{ toYaml … }}` **ohne** Trim-Marker verwendeten und je eine Zeile aus zwölf Leerzeichen erzeugten; die neuen `{{- include … }}` lassen sie weg. YAML-semantisch ist das dieselbe Datei.

## Verifikation

```
$ helm lint --strict rallly
1 chart(s) linted, 0 chart(s) failed
```

**Helper-Audit** (fester Schritt seit #103) — jeder aufgerufene Helper ist definiert, nichts umbenannt:

```
12 aufgerufene Namen, 12 definierte Namen, Schnittmenge vollständig
```

**Negativprobe — vier Ebenen, alle abgewiesen:**

```
--set bogusTopLevel=true                     -> at '': 'bogusTopLevel' not allowed
--set rallly.resources.requests.bogusCpu=1   -> at '/rallly/resources/requests': 'bogusCpu' not allowed
--set ingress.enable=false                   -> at '/ingress': 'enable' not allowed        (Tippfehler des Gate-Schlüssels)
--set rallly.oidc.nameClaim=x                -> at '/rallly/oidc': 'nameClaim' not allowed (Tippfehler von nameClaimPath)
```

## Validierung gegen die real ausgerollten Werte

Bundle `fleet-cd/rallly/` (Release `rallly`, gepinnt auf `5.0.0+up4.12.3`), zusätzlich gegen `helm get values rallly -n rallly` geprüft — beide deckungsgleich.

**Liste abgewiesener Schlüssel: leer.** Gesetzt werden nur `secrets.*`, `rallly.smtp.enabled`, `rallly.oidc.name`, `rallly.supportEmail`, `rallly.resources.{requests,limits}` und `ingress.{clusterIssuer,domain}` — alle bekannt, alle gefüllt, kein geleerter Block. Vor dem Hochziehen auf `6.0.0` ist **nichts zu bereinigen**.

---

## Fund, den ich nicht behebe: `SMTP_REJECT_UNAUTHORIZED` rendert leer

Beim Abgleich der Werte-Oberfläche gegen die Templates aufgefallen. Das Deployment liest

```
- name: SMTP_REJECT_UNAUTHORIZED
  value: "{{ .Values.rallly.smtp.rejectUnauthorized }}"
```

aber `rejectUnauthorized` steht **nicht** in `values.yaml` — es gibt keinen Default. Mit aktiviertem SMTP rendert die Variable deshalb heute als **leerer String**:

```
$ helm template t rallly … --set rallly.smtp.enabled=true
            - name: SMTP_REJECT_UNAUTHORIZED
              value: ""
```

Das ist die Umkehrung der Klasse, die #68 sucht: kein toter Schlüssel, den niemand liest, sondern ein **gelesener Schlüssel, den niemand dokumentiert hat**. Ein Schema findet das prinzipiell nicht — es prüft überzählige Schlüssel, nicht fehlende Defaults.

Warum ich es hier nicht mitrepariere: Ein Default wäre eine inhaltliche Entscheidung mit Sicherheitsbezug. `true` erzwingt Zertifikatsprüfung beim SMTP-Server und wäre die sichere Wahl, könnte aber Installationen mit selbstsigniertem Mailserver brechen; `false` schriebe den heutigen Zustand fest. Das gehört entschieden, nicht nebenbei in einem Schema-PR erledigt. Im Schema ist der Schlüssel erlaubt und dokumentiert, damit er ab jetzt gesetzt werden **kann**.

Für das Cluster-Bundle ist es derzeit folgenlos: dort steht `smtp.enabled: false`, der ganze SMTP-Block wird nicht gerendert.

Refs #68, Refs #93, Refs #99.
