### PR TITLE
zipline: strict values.schema.json + Ingress-Gate + Null-Absicherung (Welle 2, #68/#93/#99)

### DIFF
--- a/zipline/Chart.yaml
+++ b/zipline/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.0.0+up4.7.0
+version: 6.0.0+up4.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/zipline/templates/_helpers.tpl
+++ b/zipline/templates/_helpers.tpl
@@ -114,3 +114,160 @@ template-chart is the reference implementation.
 1
 {{- end -}}
 {{- end -}}
+
+{{/*
+Merge a user-supplied values sub-tree onto a dict of chart defaults so that a
+null / empty override falls back to the defaults instead of erasing them.
+
+Input: dict "defaults" <dict> "given" <dict|nil> "path" <string, optional
+values path used in error messages>. Output: YAML of the merged dict (consume
+it with fromYaml).
+
+Why this exists (issue #99): Helm merges values maps recursively, but an
+override key written without children — e.g. a leftover
+
+  securityContext:
+
+after deleting its last remaining sub-key — is YAML null. Where the chart
+defines a default, Helm treats that null as a deletion of the default; the
+template then renders "securityContext: null": no readOnlyRootFilesystem, no
+dropped capabilities, no allowPrivilegeEscalation: false. The workload starts
+and reports healthy while being unhardened, so nothing points at the mistake.
+The same shape erases a probe (it disappears) or the resources block (no
+requests, no computed limits). This helper defines the opposite semantics: an
+empty block means "chart defaults apply".
+
+Rules:
+  - a nil "given" is treated as an empty dict (all defaults apply).
+  - a key whose override value is null keeps the default (nulls never delete).
+  - a key present in both as a map is merged recursively, so a partially
+    filled block only overrides the keys it actually sets.
+  - a scalar override for a key the defaults define as a map is rejected with
+    a message naming the values path, instead of failing later with a template
+    field error.
+  - any other set value wins as given, including an explicit false or 0 —
+    Helm's "default" and sprig's "mergeOverwrite" would both swallow those
+    zero values, hence the explicit kindIs "invalid" nil check.
+  - keys only present in the override are passed through unchanged.
+
+NOTE: like the helpers above, this is duplicated into every chart's
+templates/_helpers.tpl with the chart's name as define prefix, because charts
+in this repo deliberately have no dependencies.
+*/}}
+{{- define "zipline.defaultedDict" -}}
+{{- $defaults := .defaults | default dict -}}
+{{- $given := .given -}}
+{{- $path := .path | default "value" -}}
+{{- if kindIs "invalid" $given -}}
+{{- $given = dict -}}
+{{- end -}}
+{{- if not (kindIs "map" $given) -}}
+{{- fail (printf "%s must be a mapping or null, got %s (%v)" $path (kindOf $given) $given) -}}
+{{- end -}}
+{{- $out := deepCopy $defaults -}}
+{{- range $key, $value := $given -}}
+{{- if not (kindIs "invalid" $value) -}}
+{{- $default := index $defaults $key -}}
+{{- if and (kindIs "map" $value) (kindIs "map" $default) -}}
+{{- $_ := set $out $key (fromYaml (include "zipline.defaultedDict" (dict "defaults" $default "given" $value "path" (printf "%s.%s" $path $key)))) -}}
+{{- else if kindIs "map" $default -}}
+{{- fail (printf "%s.%s must be a mapping or null, got %s (%v)" $path $key (kindOf $value) $value) -}}
+{{- else -}}
+{{- $_ := set $out $key $value -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- toYaml $out -}}
+{{- end -}}
+
+{{/*
+Pick one sub-block out of a values block that may itself be null.
+
+Input: dict "block" <dict|nil> "key" <string> "path" <string>.
+Returns YAML of dict "value" <the sub-block, may be nil>, after rejecting a
+non-mapping block with a message that names the values path. Needed because
+".Values.zipline.securityContext" can itself be erased.
+*/}}
+{{- define "zipline.subBlock" -}}
+{{- $block := .block -}}
+{{- if kindIs "invalid" $block -}}
+{{- $block = dict -}}
+{{- end -}}
+{{- if not (kindIs "map" $block) -}}
+{{- fail (printf "%s must be a mapping or null, got %s (%v)" .path (kindOf $block) $block) -}}
+{{- end -}}
+{{- toYaml (dict "value" (index $block .key)) -}}
+{{- end -}}
+
+{{/*
+The effective security contexts, probes and resources (issue #99).
+
+The defaults below MUST stay in sync with the corresponding blocks in
+values.yaml, which stays the documented, user-facing place for them; this copy
+is only the fallback for the case where an override has erased the block.
+
+The probes address the container port by its name ("zipline-server"), so a
+rebuilt default probe needs no further context. Liveness deliberately uses "/"
+while readiness/startup use /api/healthcheck, which also checks the database —
+a database outage must not restart the pod.
+*/}}
+{{- define "zipline.podSecurityContext" -}}
+{{- $given := (fromYaml (include "zipline.subBlock" (dict "block" . "key" "pod" "path" "zipline.securityContext"))).value -}}
+{{- $defaults := dict
+      "runAsNonRoot" true
+      "runAsUser" 1000
+      "runAsGroup" 1000
+      "fsGroup" 1000
+      "fsGroupChangePolicy" "Always" -}}
+{{- include "zipline.defaultedDict" (dict "defaults" $defaults "given" $given "path" "zipline.securityContext.pod") -}}
+{{- end -}}
+
+{{- define "zipline.containerSecurityContext" -}}
+{{- $given := (fromYaml (include "zipline.subBlock" (dict "block" . "key" "container" "path" "zipline.securityContext"))).value -}}
+{{- $defaults := dict
+      "allowPrivilegeEscalation" false
+      "readOnlyRootFilesystem" true
+      "runAsNonRoot" true
+      "capabilities" (dict "drop" (list "ALL")) -}}
+{{- include "zipline.defaultedDict" (dict "defaults" $defaults "given" $given "path" "zipline.securityContext.container") -}}
+{{- end -}}
+
+{{- define "zipline.livenessProbe" -}}
+{{- $defaults := dict
+      "httpGet" (dict "path" "/" "port" "zipline-server")
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 3 -}}
+{{- include "zipline.defaultedDict" (dict "defaults" $defaults "given" . "path" "zipline.livenessProbe") -}}
+{{- end -}}
+
+{{- define "zipline.readinessProbe" -}}
+{{- $defaults := dict
+      "httpGet" (dict "path" "/api/healthcheck" "port" "zipline-server")
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 3 -}}
+{{- include "zipline.defaultedDict" (dict "defaults" $defaults "given" . "path" "zipline.readinessProbe") -}}
+{{- end -}}
+
+{{- define "zipline.startupProbe" -}}
+{{- $defaults := dict
+      "httpGet" (dict "path" "/api/healthcheck" "port" "zipline-server")
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 30 -}}
+{{- include "zipline.defaultedDict" (dict "defaults" $defaults "given" . "path" "zipline.startupProbe") -}}
+{{- end -}}
+
+{{/*
+The effective resources block, fed into the resources helper above so that an
+erased "resources:" still yields the chart's requests and computed limits
+instead of a container without any resource accounting.
+*/}}
+{{- define "zipline.effectiveResources" -}}
+{{- $defaults := dict
+      "limitFactor" 3
+      "requests" (dict "cpu" 0.1 "memory" "265Mi" "ephemeralStorage" "100Mi") -}}
+{{- $merged := fromYaml (include "zipline.defaultedDict" (dict "defaults" $defaults "given" . "path" "zipline.resources")) -}}
+{{- include "zipline.resources" $merged -}}
+{{- end -}}

--- a/zipline/templates/zipline.ingress.yaml
+++ b/zipline/templates/zipline.ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -26,3 +27,4 @@ spec:
     - hosts:
         - {{ required "A Domain/Host must be provided" .Values.ingress.domain }}
       secretName: tls-{{ .Release.Name }}-{{ .Chart.Name }}-ingress
+{{- end }}

--- a/zipline/templates/zipline.sfs.yaml
+++ b/zipline/templates/zipline.sfs.yaml
@@ -14,20 +14,24 @@ spec:
         app: "{{ .Release.Name }}-{{ .Chart.Name }}-sfs"
     spec:
       securityContext:
-        {{- toYaml .Values.zipline.securityContext.pod | nindent 8 }}
+        {{- include "zipline.podSecurityContext" .Values.zipline.securityContext | nindent 8 }}
       containers:
         - name: "{{ .Release.Name }}-{{ .Chart.Name }}-sfs"
           image: "ghcr.io/diced/zipline:{{ .Chart.AppVersion }}"
           securityContext:
-            {{- toYaml .Values.zipline.securityContext.container | nindent 12 }}
+            {{- include "zipline.containerSecurityContext" .Values.zipline.securityContext | nindent 12 }}
           env:
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
                   name: {{ .Release.Name }}-{{ .Chart.Name }}-db-secret
                   key: connection-url
+            # ingress.domain is not a pure Ingress value: it is also the app's
+            # default domain for generated share links, so it stays required
+            # even when the Ingress is switched off (an empty value would hand
+            # out unusable links silently).
             - name: CORE_DEFAULT_DOMAIN
-              value: "{{ .Values.ingress.domain }}"
+              value: "{{ required "A Domain/Host must be provided (ingress.domain)" .Values.ingress.domain }}"
             - name: CORE_SECRET
               valueFrom:
                 secretKeyRef:
@@ -56,17 +60,17 @@ spec:
             {{- end }}
             {{- end }}
           resources:
-            {{- include "zipline.resources" .Values.zipline.resources | nindent 12 }}
+            {{- include "zipline.effectiveResources" .Values.zipline.resources | nindent 12 }}
           ports:
             - name: "zipline-server"
               containerPort: 3000
               protocol: TCP
           livenessProbe:
-            {{- toYaml .Values.zipline.livenessProbe | nindent 12 }}
+            {{- include "zipline.livenessProbe" .Values.zipline.livenessProbe | nindent 12 }}
           readinessProbe:
-            {{- toYaml .Values.zipline.readinessProbe | nindent 12 }}
+            {{- include "zipline.readinessProbe" .Values.zipline.readinessProbe | nindent 12 }}
           startupProbe:
-            {{- toYaml .Values.zipline.startupProbe | nindent 12 }}
+            {{- include "zipline.startupProbe" .Values.zipline.startupProbe | nindent 12 }}
           volumeMounts:
             - name: zipline-volume
               mountPath: /zipline/uploads

--- a/zipline/values.schema.json
+++ b/zipline/values.schema.json
@@ -1,0 +1,194 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "zipline values",
+  "description": "Strict values schema (issue #68). additionalProperties is false on every chart-owned object level, so a key that the chart does not read is rejected at render time instead of being silently ignored. The only objects that stay open are the ones passed verbatim into the Kubernetes pod spec (probes, security contexts, global) - the chart does not interpret their contents, so it cannot judge which keys are meaningful. The hardening, probe and resources blocks additionally accept null, because an erased block falls back to the chart defaults (issue #99).",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "global": {
+      "description": "Helm's conventional cross-chart values. Unused by this chart, kept open so an umbrella install cannot break on it.",
+      "type": "object"
+    },
+    "scaleDown": {
+      "type": "boolean"
+    },
+    "secrets": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "databaseSecretRef": {
+          "type": ["string", "null"]
+        },
+        "ziplineSecretRef": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "config": {
+      "description": "Storage and upload settings. Not null-safe on purpose: storage and storageClass are required(), so an erased block fails loudly - issue #99 covers only the silent class.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "storage": {
+          "description": "Size of the uploads PVC. Changing it on an existing release only takes effect if the StorageClass allows volume expansion.",
+          "type": ["string", "null"]
+        },
+        "storageClass": {
+          "type": ["string", "null"]
+        },
+        "maxUploadFileSize": {
+          "description": "Rendered into the ingress-nginx body-size annotations, so it only takes effect while the Ingress is enabled.",
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "zipline": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "replicas": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "securityContext": {
+          "$ref": "#/definitions/securityContext"
+        },
+        "livenessProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "readinessProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "startupProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "resources": {
+          "$ref": "#/definitions/resources"
+        },
+        "env": {
+          "$ref": "#/definitions/env"
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "description": "Gates the whole Ingress template (issue #93). false omits the Ingress and makes clusterIssuer unnecessary - but NOT domain, which is also the app's default domain for generated share links.",
+          "type": "boolean"
+        },
+        "clusterIssuer": {
+          "type": ["string", "null"]
+        },
+        "domain": {
+          "type": ["string", "null"]
+        },
+        "className": {
+          "type": ["string", "null"]
+        },
+        "annotations": {
+          "description": "Extra Ingress annotations, merged with the cert-manager and body-size annotations the chart always sets. Free-form keys by nature.",
+          "type": "object"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "resources": {
+      "description": "May be null / empty: the chart then falls back to its default requests and computed limits (issue #99) instead of rendering a container without resource accounting.",
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "limitFactor": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "requests": {
+          "$ref": "#/definitions/resourceList"
+        },
+        "limits": {
+          "$ref": "#/definitions/resourceList"
+        }
+      }
+    },
+    "resourceList": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "cpu": {
+          "type": ["string", "number", "null"]
+        },
+        "memory": {
+          "type": ["string", "number", "null"]
+        },
+        "ephemeral-storage": {
+          "type": ["string", "number", "null"]
+        },
+        "ephemeralStorage": {
+          "type": ["string", "number", "null"]
+        }
+      }
+    },
+    "env": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "valueFrom": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "secretKeyRef": {
+                "$ref": "#/definitions/keyRef"
+              },
+              "configMapKeyRef": {
+                "$ref": "#/definitions/keyRef"
+              }
+            }
+          }
+        }
+      }
+    },
+    "keyRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "key"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        }
+      }
+    },
+    "securityContext": {
+      "description": "May be null / empty at any level: the chart then falls back to its hardening defaults (issue #99) instead of rendering an unhardened workload.",
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "pod": {
+          "description": "Merged onto the chart's pod hardening defaults and rendered as the pod's securityContext; kept open because the chart does not interpret the individual fields.",
+          "type": ["object", "null"]
+        },
+        "container": {
+          "description": "Merged onto the chart's container hardening defaults and rendered as the container's securityContext; kept open because the chart does not interpret the individual fields.",
+          "type": ["object", "null"]
+        }
+      }
+    },
+    "probe": {
+      "description": "Merged onto the chart's probe defaults and rendered as a container probe; kept open because the chart does not interpret the individual fields. May be null / empty, which means the defaults apply (issue #99) rather than the probe disappearing.",
+      "type": ["object", "null"]
+    }
+  }
+}

--- a/zipline/values.yaml
+++ b/zipline/values.yaml
@@ -75,6 +75,11 @@ zipline:
   env: []
 
 ingress:
+  # Set to false to omit the Ingress entirely. Note that ingress.domain stays
+  # required even then: it is also the app's default domain for generated
+  # share links (CORE_DEFAULT_DOMAIN), not just the Ingress host. Only
+  # clusterIssuer becomes unnecessary.
+  enabled: true
   clusterIssuer: null
   domain: null
   className: nginx


### PR DESCRIPTION
Zweites Chart der **Welle 2** aus #68. **5.0.0 → 6.0.0** (major, appVersion unverändert bei 4.7.0). Erstes StatefulSet-Chart der Welle.

Drei Änderungen wie gehabt, getrennt ausgewiesen — **und der erste Fall mit einer nicht-leeren Liste abgewiesener Schlüssel.** Die steht unten und ist die eigentliche Nachricht dieses PRs.

---

# 1. Strict `values.schema.json` (#68)

`additionalProperties: false` auf allen chart-eigenen Objektebenen: oberste Ebene, `config`, `zipline`, `zipline.resources` mit `.requests`/`.limits`, `env[]` mit `valueFrom` und beiden KeyRefs, `securityContext`, `ingress`, `secrets`.

**Offen bleiben** die durchgereichten Objekte: die drei Probes, `securityContext.pod`/`.container`, `global`, `ingress.annotations`.

`config` ist bewusst **nicht** null-sicher: `config.storage` und `config.storageClass` stehen unter `required()`, ein geleerter Block scheitert also laut und gehört zur lauten Klasse, die #99 ausnimmt.

# 2. Ingress-Gate (#93)

Ingress-Template gegatet, `ingress.enabled` mit Default `true`.

### Prüfpunkt aus rallly angewandt — und er greift hier erneut

Vor dem Gate-Einbau geprüft, ob `ingress.domain` **außerhalb** des Ingress-Templates gelesen wird. Wird es: `zipline.sfs.yaml` speist daraus `CORE_DEFAULT_DOMAIN`, die Default-Domain für generierte Share-Links — und zwar bisher **ohne** `required()`. Die Garantie kam allein vom ungegateten Ingress-Template.

Ohne Absicherung hätte das Gate also Links auf eine leere Domain ausgegeben, lautlos. Der Lesezugriff steht deshalb jetzt ebenfalls unter `required()`:

```
$ helm template t zipline --set ingress.enabled=false …   # ohne domain
Error: execution error at (zipline/templates/zipline.sfs.yaml:34:25):
A Domain/Host must be provided (ingress.domain)
```

Damit zum dritten Mal dasselbe Muster aus unterschiedlichem Anlass — patchmon `CORS_ORIGIN`, rallly `NEXT_PUBLIC_BASE_URL`, zipline `CORE_DEFAULT_DOMAIN`: **Das Gate macht `clusterIssuer` entbehrlich, nicht `domain`.**

| Fall | Ergebnis |
|---|---|
| Gate an (Default) | 1 Ingress, `CORE_DEFAULT_DOMAIN` wie bisher |
| Gate aus, `domain` gesetzt, **kein** `clusterIssuer` | rendert, **0** Ingress, `value: "zipline.ci.local"` |
| Gate aus, **kein** `domain` | scheitert laut (siehe oben) |

Nebenbei: `config.maxUploadFileSize` wirkt nur über die ingress-nginx-Annotationen, ist mit abgeschaltetem Ingress also wirkungslos. Im Schema dokumentiert, damit es niemanden überrascht.

# 3. Null-Absicherung für Härtung, Probes und Ressourcen (#99)

`defaultedDict` und `subBlock` übernommen; abgesichert sind Pod- und Container-Context, die drei Probes und `resources`.

**Probe-Kontext geprüft:** Die Probes adressieren den Port über seinen Namen (`zipline-server`), kein Host-Header — kein zusätzlicher Kontext nötig. Wichtiger Detailpunkt: Die wiederhergestellte **Liveness**-Probe verwendet `/`, nicht `/api/healthcheck`. Diese Unterscheidung ist Absicht (der Healthcheck prüft die Datenbank mit; ein Datenbankausfall soll den Pod nicht neu starten), und die Helper-Defaults erhalten sie.

Der Pod-Context trägt `fsGroup: 1000`, was die Uploads-PVC für den Container schreibbar macht — ein geleerter Block hätte hier also nicht nur entschärft, sondern die Uploads unbeschreibbar gemacht.

---

## Nachweis 1: erased Block → vorher, nachher

```yaml
zipline:
  securityContext:
    container:
  livenessProbe:
```

**Vorher** (`5.0.0`): `securityContext: null` und `livenessProbe: null` — ungehärteter Container, Probe ersatzlos weg.

**Nachher**:

```yaml
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: true
            runAsNonRoot: true
          ...
          livenessProbe:
            failureThreshold: 3
            httpGet:
              path: /
              port: zipline-server
            periodSeconds: 10
            timeoutSeconds: 5
```

## Nachweis 2: ein bewusst gesetztes `false` / `0` gewinnt weiterhin

`--set zipline.securityContext.container.readOnlyRootFilesystem=false` → `false`, übrige Defaults intakt.
`--set zipline.startupProbe.failureThreshold=0` → `0`, restliche Probe-Defaults intakt (inkl. `/api/healthcheck`).

## Nachweis 3: das Rendering ändert sich nicht

`diff` gegen den `5.0.0`-Stand mit `ci/zipline/test-values.yaml`: einziger Unterschied ist der vierzeilige Kommentar über `CORE_DEFAULT_DOMAIN`. Sonst byte-identisch.

## Verifikation

```
$ helm lint --strict zipline
1 chart(s) linted, 0 chart(s) failed
```

**Helper-Audit:** 12 aufgerufene Namen, 12 definierte, Schnittmenge vollständig — nichts umbenannt.

**Negativprobe — vier Ebenen:**

```
--set bogusTopLevel=true                      -> at '': 'bogusTopLevel' not allowed
--set zipline.resources.requests.bogusCpu=1   -> at '/zipline/resources/requests': 'bogusCpu' not allowed
--set ingress.enable=false                    -> at '/ingress': 'enable' not allowed
--set config.storageClassName=longhorn        -> at '/config': 'storageClassName' not allowed
```

Die letzte ist ein realistischer Tippfehler: Der Schlüssel heißt `config.storageClass`, das Kubernetes-Feld dagegen `storageClassName`.

---

## Validierung gegen die real ausgerollten Werte — **hier gibt es etwas zu tun**

Bundle `fleet-cd/zipline/`, Release `zipline`, gepinnt auf **`4.1.1+up4.7.0`**. Bundle-Datei und `helm get values zipline -n zipline` sind deckungsgleich.

**Liste abgewiesener Schlüssel:**

```
$ helm template zipline zipline -f fleet-cd/zipline/zipline.values.yaml
Error: values don't meet the specifications of the schema(s) in the following chart(s):
zipline:
- at '/config': additional properties 'domain', 'secretRef' not allowed
```

| Abgewiesener Schlüssel | Heutiger Schlüssel |
|---|---|
| `config.secretRef.db` | `secrets.databaseSecretRef` |
| `config.secretRef.zipline` | `secrets.ziplineSecretRef` |
| `config.domain` | `ingress.domain` |
| *(fehlt ganz)* | `ingress.clusterIssuer` — war früher hart auf `letsencrypt-issuer` verdrahtet, ist seit `5.0.0` ein Pflichtwert |

### Wichtig zur Einordnung: das ist **kein** Schaden, den dieser PR anrichtet

Die Bundle-Werte passen schon **heute** nicht mehr zum Chart. Gegen den veröffentlichten `5.0.0` **ohne** Schema gerendert:

```
Error: execution error at (zipline/templates/zipline.secret.yaml:6:15):
You must provide a ziplineSecret Reference
```

Die Umstellung kam mit `48cb5c0` (Conventions-Batch 3, Chart `4.1.2 → 5.0.0`); das Bundle steht seither auf `4.1.1` und hat sie nie mitgemacht. Sichtbar wird es nur nicht, weil Fleet exakte Versionen pinnt und das Release nie neu gerendert wurde — **dieselbe Beobachtung wie bei urlaubsverwaltung: Eine gepflegte Datei sagt nichts über den ausgerollten Zustand.**

Neu ist allein, dass das Schema die toten Schlüssel jetzt **benennt**, statt sie stumm zu ignorieren und erst beim `required()` mit einer Fehlermeldung zu scheitern, die nicht sagt, woran es liegt.

### Arbeitsanweisung für die Cluster-Seite

Vor dem Hochziehen von `4.1.1` auf `6.0.0` in `fleet-cd/zipline/zipline.values.yaml`:

```yaml
secrets:
  databaseSecretRef: vaults/Kubernetes-Cluster/items/zipline-db
  ziplineSecretRef: vaults/Kubernetes-Cluster/items/zipline-server

config:
  storage: 50Gi          # bleibt

ingress:
  domain: zipline.jk-dev.de
  clusterIssuer: letsencrypt-issuer   # entspricht dem Live-Ingress
```

`clusterIssuer: letsencrypt-issuer` ist am laufenden Objekt abgelesen (`kubectl get ingress -n zipline`), nicht geraten. Damit rendert das Bundle gegen `6.0.0` sauber durch.

Refs #68, Refs #93, Refs #99.
