### PR TITLE
voucher-vault: strict values.schema.json + Null-Absicherung (Welle 2, #68/#99)

### DIFF
--- a/voucher-vault/Chart.yaml
+++ b/voucher-vault/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://raw.githubusercontent.com/l4rm4nd/VoucherVault/main/myapp/static/a
 
 type: application
 
-version: 4.0.0+up1.30.1
+version: 5.0.0+up1.30.1
 appVersion: "1.30.1"
 
 maintainers:

--- a/voucher-vault/templates/_helpers.tpl
+++ b/voucher-vault/templates/_helpers.tpl
@@ -114,3 +114,164 @@ template-chart is the reference implementation.
 1
 {{- end -}}
 {{- end -}}
+
+{{/*
+Merge a user-supplied values sub-tree onto a dict of chart defaults so that a
+null / empty override falls back to the defaults instead of erasing them.
+
+Input: dict "defaults" <dict> "given" <dict|nil> "path" <string, optional
+values path used in error messages>. Output: YAML of the merged dict (consume
+it with fromYaml).
+
+Why this exists (issue #99): Helm merges values maps recursively, but an
+override key written without children — e.g. a leftover
+
+  securityContext:
+
+after deleting its last remaining sub-key — is YAML null. Where the chart
+defines a default, Helm treats that null as a deletion of the default; the
+template then renders "securityContext: null": no readOnlyRootFilesystem, no
+dropped capabilities, no allowPrivilegeEscalation: false. The workload starts
+and reports healthy while being unhardened, so nothing points at the mistake.
+The same shape erases a probe or the resources block. This helper defines the
+opposite semantics: an empty block means "chart defaults apply".
+
+Rules:
+  - a nil "given" is treated as an empty dict (all defaults apply).
+  - a key whose override value is null keeps the default (nulls never delete).
+  - a key present in both as a map is merged recursively, so a partially
+    filled block only overrides the keys it actually sets.
+  - a scalar override for a key the defaults define as a map is rejected with
+    a message naming the values path, instead of failing later with a template
+    field error.
+  - any other set value wins as given, including an explicit false or 0 —
+    Helm's "default" and sprig's "mergeOverwrite" would both swallow those
+    zero values, hence the explicit kindIs "invalid" nil check.
+  - keys only present in the override are passed through unchanged.
+
+NOTE: like the helpers above, this is duplicated into every chart's
+templates/_helpers.tpl with the chart's name as define prefix, because charts
+in this repo deliberately have no dependencies.
+*/}}
+{{- define "voucher-vault.defaultedDict" -}}
+{{- $defaults := .defaults | default dict -}}
+{{- $given := .given -}}
+{{- $path := .path | default "value" -}}
+{{- if kindIs "invalid" $given -}}
+{{- $given = dict -}}
+{{- end -}}
+{{- if not (kindIs "map" $given) -}}
+{{- fail (printf "%s must be a mapping or null, got %s (%v)" $path (kindOf $given) $given) -}}
+{{- end -}}
+{{- $out := deepCopy $defaults -}}
+{{- range $key, $value := $given -}}
+{{- if not (kindIs "invalid" $value) -}}
+{{- $default := index $defaults $key -}}
+{{- if and (kindIs "map" $value) (kindIs "map" $default) -}}
+{{- $_ := set $out $key (fromYaml (include "voucher-vault.defaultedDict" (dict "defaults" $default "given" $value "path" (printf "%s.%s" $path $key)))) -}}
+{{- else if kindIs "map" $default -}}
+{{- fail (printf "%s.%s must be a mapping or null, got %s (%v)" $path $key (kindOf $value) $value) -}}
+{{- else -}}
+{{- $_ := set $out $key $value -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- toYaml $out -}}
+{{- end -}}
+
+{{/*
+Pick one sub-block out of a values block that may itself be null.
+
+Input: dict "block" <dict|nil> "key" <string> "path" <string>.
+Returns YAML of dict "value" <the sub-block, may be nil>, after rejecting a
+non-mapping block with a message that names the values path. Needed because
+".Values.voucherVault.securityContext" can itself be erased.
+*/}}
+{{- define "voucher-vault.subBlock" -}}
+{{- $block := .block -}}
+{{- if kindIs "invalid" $block -}}
+{{- $block = dict -}}
+{{- end -}}
+{{- if not (kindIs "map" $block) -}}
+{{- fail (printf "%s must be a mapping or null, got %s (%v)" .path (kindOf $block) $block) -}}
+{{- end -}}
+{{- toYaml (dict "value" (index $block .key)) -}}
+{{- end -}}
+
+{{/*
+The effective security contexts, probes and resources (issue #99).
+
+The defaults below MUST stay in sync with the corresponding blocks in
+values.yaml, which stays the documented, user-facing place for them; this copy
+is only the fallback for the case where an override has erased the block.
+
+The probes carry a Host header of 127.0.0.1: Django's ALLOWED_HOSTS only
+accepts 127.0.0.1 and the configured DOMAIN, so probing with the default Host
+(the pod IP) would always return 400. A rebuilt default probe must keep that
+header, otherwise the pod never becomes ready.
+*/}}
+{{- define "voucher-vault.podSecurityContext" -}}
+{{- $given := (fromYaml (include "voucher-vault.subBlock" (dict "block" . "key" "pod" "path" "voucherVault.securityContext"))).value -}}
+{{- $defaults := dict
+      "runAsNonRoot" true
+      "runAsUser" 33
+      "runAsGroup" 33
+      "fsGroup" 33
+      "fsGroupChangePolicy" "Always" -}}
+{{- include "voucher-vault.defaultedDict" (dict "defaults" $defaults "given" $given "path" "voucherVault.securityContext.pod") -}}
+{{- end -}}
+
+{{- define "voucher-vault.containerSecurityContext" -}}
+{{- $given := (fromYaml (include "voucher-vault.subBlock" (dict "block" . "key" "container" "path" "voucherVault.securityContext"))).value -}}
+{{- $defaults := dict
+      "allowPrivilegeEscalation" false
+      "readOnlyRootFilesystem" true
+      "runAsNonRoot" true
+      "capabilities" (dict "drop" (list "ALL")) -}}
+{{- include "voucher-vault.defaultedDict" (dict "defaults" $defaults "given" $given "path" "voucherVault.securityContext.container") -}}
+{{- end -}}
+
+{{- define "voucher-vault.probeHttpGet" -}}
+{{- dict "path" "/" "port" "http" "httpHeaders" (list (dict "name" "Host" "value" "127.0.0.1")) | toYaml -}}
+{{- end -}}
+
+{{- define "voucher-vault.livenessProbe" -}}
+{{- $defaults := dict
+      "httpGet" (fromYaml (include "voucher-vault.probeHttpGet" .))
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 3 -}}
+{{- include "voucher-vault.defaultedDict" (dict "defaults" $defaults "given" . "path" "voucherVault.livenessProbe") -}}
+{{- end -}}
+
+{{- define "voucher-vault.readinessProbe" -}}
+{{- $defaults := dict
+      "httpGet" (fromYaml (include "voucher-vault.probeHttpGet" .))
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 3 -}}
+{{- include "voucher-vault.defaultedDict" (dict "defaults" $defaults "given" . "path" "voucherVault.readinessProbe") -}}
+{{- end -}}
+
+{{- define "voucher-vault.startupProbe" -}}
+{{- $defaults := dict
+      "httpGet" (fromYaml (include "voucher-vault.probeHttpGet" .))
+      "periodSeconds" 5
+      "timeoutSeconds" 5
+      "failureThreshold" 30 -}}
+{{- include "voucher-vault.defaultedDict" (dict "defaults" $defaults "given" . "path" "voucherVault.startupProbe") -}}
+{{- end -}}
+
+{{/*
+The effective resources block, fed into the resources helper above so that an
+erased "resources:" still yields the chart's requests and computed limits.
+The ephemeral-storage request matters here beyond the usual reason: the
+static-files emptyDir holds ~90Mi of assets and counts toward it.
+*/}}
+{{- define "voucher-vault.effectiveResources" -}}
+{{- $defaults := dict
+      "limitFactor" 3
+      "requests" (dict "cpu" 0.1 "memory" "256Mi" "ephemeral-storage" "128Mi") -}}
+{{- $merged := fromYaml (include "voucher-vault.defaultedDict" (dict "defaults" $defaults "given" . "path" "voucherVault.resources")) -}}
+{{- include "voucher-vault.resources" $merged -}}
+{{- end -}}

--- a/voucher-vault/templates/voucher-vault.sfs.yaml
+++ b/voucher-vault/templates/voucher-vault.sfs.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       automountServiceAccountToken: false
       securityContext:
-        {{- toYaml .Values.voucherVault.securityContext.pod | nindent 8 }}
+        {{- include "voucher-vault.podSecurityContext" .Values.voucherVault.securityContext | nindent 8 }}
       initContainers:
         # STATIC_ROOT (/opt/app/myapp/static) doubles as the app's own static
         # source directory, so it cannot simply be shadowed by an empty
@@ -33,7 +33,7 @@ spec:
           # on the mountpoint itself, which the non-root uid may not own.
           command: ["sh", "-c", "cp -a /opt/app/myapp/static/* /static-seed/"]
           securityContext:
-            {{- toYaml .Values.voucherVault.securityContext.container | nindent 12 }}
+            {{- include "voucher-vault.containerSecurityContext" .Values.voucherVault.securityContext | nindent 12 }}
           volumeMounts:
             - name: static-files
               mountPath: /static-seed
@@ -73,22 +73,19 @@ spec:
             {{- end }}
           ports:
             {{- toYaml .Values.voucherVault.ports | nindent 12 }}
-          {{- if .Values.voucherVault.livenessProbe }}
+          # No "if" guards here any more: an erased probe block used to omit the
+          # probe entirely and silently. It now falls back to the chart
+          # defaults (#99), so the workload keeps its probes.
           livenessProbe:
-            {{- toYaml .Values.voucherVault.livenessProbe | nindent 12 }}
-          {{- end }}
-          {{- if .Values.voucherVault.readinessProbe }}
+            {{- include "voucher-vault.livenessProbe" .Values.voucherVault.livenessProbe | nindent 12 }}
           readinessProbe:
-            {{- toYaml .Values.voucherVault.readinessProbe | nindent 12 }}
-          {{- end }}
-          {{- if .Values.voucherVault.startupProbe }}
+            {{- include "voucher-vault.readinessProbe" .Values.voucherVault.readinessProbe | nindent 12 }}
           startupProbe:
-            {{- toYaml .Values.voucherVault.startupProbe | nindent 12 }}
-          {{- end }}
+            {{- include "voucher-vault.startupProbe" .Values.voucherVault.startupProbe | nindent 12 }}
           resources:
-            {{- include "voucher-vault.resources" .Values.voucherVault.resources | nindent 12 }}
+            {{- include "voucher-vault.effectiveResources" .Values.voucherVault.resources | nindent 12 }}
           securityContext:
-            {{- toYaml .Values.voucherVault.securityContext.container | nindent 12 }}
+            {{- include "voucher-vault.containerSecurityContext" .Values.voucherVault.securityContext | nindent 12 }}
           volumeMounts:
             # Writable emptyDirs over the paths the image writes at runtime,
             # so the root filesystem can stay read-only (see securityContext

--- a/voucher-vault/values.schema.json
+++ b/voucher-vault/values.schema.json
@@ -1,0 +1,210 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "voucher-vault values",
+  "description": "Strict values schema (issue #68). additionalProperties is false on every chart-owned object level, so a key that the chart does not read is rejected at render time instead of being silently ignored. The only objects that stay open are the ones passed verbatim into the Kubernetes pod spec (probes, security contexts, ports, volumes, global) - the chart does not interpret their contents, so it cannot judge which keys are meaningful. The hardening, probe and resources blocks additionally accept null, because an erased block falls back to the chart defaults (issue #99).",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "global": {
+      "description": "Helm's conventional cross-chart values. Unused by this chart, kept open so an umbrella install cannot break on it.",
+      "type": "object"
+    },
+    "scaleDown": {
+      "type": "boolean"
+    },
+    "secrets": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "voucherVaultSecretRef": {
+          "type": ["string", "null"]
+        },
+        "oidcSecretRef": {
+          "type": ["string", "null"]
+        },
+        "databaseSecretRef": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "voucherVault": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "replicas": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "resources": {
+          "$ref": "#/definitions/resources"
+        },
+        "livenessProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "readinessProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "startupProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "securityContext": {
+          "$ref": "#/definitions/securityContext"
+        },
+        "ports": {
+          "description": "Rendered verbatim as the container's ports list; kept open because the chart does not interpret the entries.",
+          "type": ["array", "null"]
+        },
+        "env": {
+          "description": "The container's full env list (not merely additive here). Entries are rendered through tpl, so values may contain Helm templating.",
+          "$ref": "#/definitions/env"
+        },
+        "storage": {
+          "description": "Volumes and volumeMounts of the workload, rendered verbatim into the pod spec; kept open because the chart does not interpret the entries.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "volumes": {
+              "type": ["array", "null"]
+            },
+            "volumeMounts": {
+              "type": ["array", "null"]
+            }
+          }
+        }
+      }
+    },
+    "storage": {
+      "description": "The data PVC. Not null-safe on purpose: an erased block yields an invalid PVC rather than a silently degraded workload.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "amount": {
+          "type": ["string", "null"]
+        },
+        "storageClass": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "description": "Gates the whole Ingress template. false omits the Ingress and makes clusterIssuer unnecessary - but NOT domain, which is also Django's ALLOWED_HOSTS entry.",
+          "type": "boolean"
+        },
+        "clusterIssuer": {
+          "type": ["string", "null"]
+        },
+        "domain": {
+          "type": ["string", "null"]
+        },
+        "className": {
+          "type": ["string", "null"]
+        },
+        "annotations": {
+          "description": "Extra Ingress annotations, merged with the cert-manager annotation the chart always sets. Free-form keys by nature.",
+          "type": "object"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "resources": {
+      "description": "May be null / empty: the chart then falls back to its default requests and computed limits (issue #99) instead of rendering a container without resource accounting.",
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "limitFactor": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "requests": {
+          "$ref": "#/definitions/resourceList"
+        },
+        "limits": {
+          "$ref": "#/definitions/resourceList"
+        }
+      }
+    },
+    "resourceList": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "cpu": {
+          "type": ["string", "number", "null"]
+        },
+        "memory": {
+          "type": ["string", "number", "null"]
+        },
+        "ephemeral-storage": {
+          "type": ["string", "number", "null"]
+        },
+        "ephemeralStorage": {
+          "type": ["string", "number", "null"]
+        }
+      }
+    },
+    "env": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": ["string", "number", "boolean"]
+          },
+          "valueFrom": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "secretKeyRef": {
+                "$ref": "#/definitions/keyRef"
+              },
+              "configMapKeyRef": {
+                "$ref": "#/definitions/keyRef"
+              }
+            }
+          }
+        }
+      }
+    },
+    "keyRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "key"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        }
+      }
+    },
+    "securityContext": {
+      "description": "May be null / empty at any level: the chart then falls back to its hardening defaults (issue #99) instead of rendering an unhardened workload.",
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "pod": {
+          "description": "Merged onto the chart's pod hardening defaults and rendered as the pod's securityContext; kept open because the chart does not interpret the individual fields.",
+          "type": ["object", "null"]
+        },
+        "container": {
+          "description": "Merged onto the chart's container hardening defaults and rendered as the securityContext of both the init container and the app container; kept open because the chart does not interpret the individual fields.",
+          "type": ["object", "null"]
+        }
+      }
+    },
+    "probe": {
+      "description": "Merged onto the chart's probe defaults and rendered as a container probe; kept open because the chart does not interpret the individual fields. May be null / empty, which means the defaults apply (issue #99) rather than the probe disappearing.",
+      "type": ["object", "null"]
+    }
+  }
+}

--- a/voucher-vault/values.yaml
+++ b/voucher-vault/values.yaml
@@ -86,8 +86,12 @@ voucherVault:
       protocol: TCP
       name: http
   env:
+    # ingress.domain is not a pure Ingress value: Django's ALLOWED_HOSTS only
+    # accepts 127.0.0.1 and this DOMAIN, so an empty value makes the app answer
+    # 400 to every real request. It therefore stays required even when the
+    # Ingress is switched off via ingress.enabled.
     - name: DOMAIN
-      value: "{{ .Values.ingress.domain }}"
+      value: '{{ required "A Domain/Host must be provided (ingress.domain)" .Values.ingress.domain }}'
     - name: SECURE_COOKIES
       value: "True"
     - name: SESSION_COOKIE_AGE
@@ -196,6 +200,9 @@ storage:
   storageClass: null
 
 ingress:
+  # Set to false to omit the Ingress entirely. Note that ingress.domain stays
+  # required even then: it is also Django's ALLOWED_HOSTS entry (the DOMAIN env
+  # above), not just the Ingress host. Only clusterIssuer becomes unnecessary.
   enabled: true
   clusterIssuer: null
   domain: null


### PR DESCRIPTION
Drittes Chart der **Welle 2** aus #68. **4.0.0 → 5.0.0** (major, appVersion unverändert bei 1.30.1).

**Kein Ingress-Gate** — voucher-vault gatet bereits korrekt und steht in #93 unter „bereits korrekt". Zwei Änderungen also, plus eine Absicherung, die das **vorhandene** Gate benötigt und bisher nicht hatte.

---

# 1. Strict `values.schema.json` (#68)

`additionalProperties: false` auf allen chart-eigenen Objektebenen: oberste Ebene, `voucherVault`, `voucherVault.resources` mit `.requests`/`.limits`, `voucherVault.storage`, `env[]` mit `valueFrom` und beiden KeyRefs, `securityContext`, `storage`, `ingress`, `secrets`.

**Offen bleiben** die Objekte und Listen, die wörtlich in die Pod-Spec gehen: die drei Probes, `securityContext.pod`/`.container`, `voucherVault.ports`, `voucherVault.storage.volumes` und `.volumeMounts`, `global`, `ingress.annotations`.

`voucherVault.env` ist hier bewusst als vollständige Env-Liste modelliert (nicht nur additiv wie in anderen Charts) — das Chart rendert genau diese Liste, inklusive tpl-Auswertung.

# 2. Null-Absicherung für Härtung, Probes und Ressourcen (#99)

Zwei Besonderheiten dieses Charts, die über das übliche Muster hinausgehen:

### Die Probes verschwanden vorher **ersatzlos**, nicht als `null`

Sie standen in `{{- if .Values.voucherVault.livenessProbe }}`-Wächtern. Ein geleerter Probe-Block hat die Probe deshalb nicht als `livenessProbe: null` gerendert, sondern **gar nicht** — dieselbe Klasse, aber noch schwerer zu bemerken, weil im Manifest schlicht nichts steht, worüber man stolpern könnte.

Am `4.0.0`-Stand mit geleertem `livenessProbe:` gezählt:

```
$ helm template … | grep -c livenessProbe
0
```

Die Wächter sind entfallen; ein leerer Block bedeutet jetzt „Chart-Defaults".

### Die rekonstruierte Probe muss den `Host`-Header behalten

Djangos `ALLOWED_HOSTS` akzeptiert nur `127.0.0.1` und die konfigurierte `DOMAIN`. Eine Probe ohne `Host: 127.0.0.1` bekäme vom Pod-IP-Request immer 400 — der Pod würde nie ready. Die Helper-Defaults tragen den Header deshalb mit:

```yaml
          livenessProbe:
            failureThreshold: 3
            httpGet:
              httpHeaders:
              - name: Host
                value: 127.0.0.1
              path: /
              port: http
            periodSeconds: 10
            timeoutSeconds: 5
```

Abgesichert sind außerdem Pod-Context, Container-Context (an **beiden** Stellen — Init-Container und App-Container) und `resources`. Der Pod-Context trägt `fsGroup: 33`, was die Daten-PVC schreibbar macht.

`storage` (die PVC) bleibt ohne Absicherung: Ein geleerter Block ergibt eine ungültige PVC, kein still degradiertes Workload — laute Klasse.

# 3. `ingress.domain` ist dort abgesichert, wo es gelesen wird

**Hier hat der Prüfpunkt aus rallly/zipline eine Verfeinerung gebraucht.** Bei den beiden lag der Zugriff im Template und ein Grep über `templates/` fand ihn. Bei voucher-vault liegt er in **`values.yaml`** — als tpl-String im `DOMAIN`-Env-Eintrag:

```yaml
    - name: DOMAIN
      value: "{{ .Values.ingress.domain }}"
```

Ein Grep nur über `templates/` hätte das übersehen. Ich prüfe den Punkt ab jetzt über `values.yaml` **und** `templates/`.

Die Folge ist dieselbe wie bei den anderen, mit einem Unterschied: **Das Loch besteht hier schon heute**, weil das Gate bereits existiert. Am `4.0.0`-Stand, Ingress aus, kein `domain`:

```yaml
            - name: "DOMAIN"
              value: ""
```

Django antwortet damit auf jeden echten Request mit 400 — lautlos, denn gerendert und gestartet wird alles. Der Lesezugriff steht deshalb jetzt unter `required()`:

```
$ helm template t voucher-vault … --set ingress.enabled=false --set ingress.domain=null
Error: execution error at (voucher-vault/templates/voucher-vault.sfs.yaml:57:24):
A Domain/Host must be provided (ingress.domain)
```

Damit zum vierten Mal dasselbe Muster: patchmon `CORS_ORIGIN`, rallly `NEXT_PUBLIC_BASE_URL`, zipline `CORE_DEFAULT_DOMAIN`, voucher-vault `DOMAIN`. **Das Gate macht `clusterIssuer` entbehrlich, nie `domain`.**

---

## Nachweis 1: erased Block → vorher, nachher

```yaml
voucherVault:
  securityContext:
    container:
  livenessProbe:
```

| | vorher (`4.0.0`) | nachher |
|---|---|---|
| Container-Context | `securityContext: null` — ungehärtet | volle Härtungs-Defaults |
| Liveness-Probe | **fehlt komplett** (0 Treffer) | vollständige Default-Probe inkl. Host-Header |

## Nachweis 2: ein bewusst gesetztes `false` / `0` gewinnt weiterhin

`--set voucherVault.securityContext.container.readOnlyRootFilesystem=false` → `false`, während `allowPrivilegeEscalation: false`, `drop: ALL` und `runAsNonRoot: true` erhalten bleiben.

`--set voucherVault.startupProbe.failureThreshold=0` → `0`, restliche Probe-Defaults inklusive Host-Header intakt.

## Nachweis 3: das Rendering ändert sich nicht

`diff` gegen den `4.0.0`-Stand mit `ci/voucher-vault/test-values.yaml`: einziger Unterschied ist der dreizeilige Kommentar, der erklärt, warum die `if`-Wächter weg sind. Sonst byte-identisch.

## Verifikation

```
$ helm lint --strict voucher-vault
1 chart(s) linted, 0 chart(s) failed
```

**Helper-Audit:** 13 aufgerufene Namen, 13 definierte, Schnittmenge vollständig.

**Negativprobe:**

```
--set bogusTopLevel=true                            -> at '': 'bogusTopLevel' not allowed
--set voucherVault.resources.requests.bogusCpu=1    -> at '/voucherVault/resources/requests': 'bogusCpu' not allowed
--set storage.size=10Gi                             -> at '/storage': 'size' not allowed
```

Die letzte ist ein realistischer Tippfehler: Der Schlüssel heißt `storage.amount`.

## Validierung gegen die real ausgerollten Werte

Bundle `fleet-cd/voucher-vault/voucher-vault/`, Release `voucher-vault`, gepinnt auf `4.0.0+up1.30.1`. Bundle-Datei und `helm get values voucher-vault -n voucher-vault` deckungsgleich.

**Liste abgewiesener Schlüssel: leer.** Gesetzt werden nur `secrets.*`, `storage.amount` und `ingress.{enabled,clusterIssuer,domain}` — alle bekannt und gefüllt, kein geleerter Block, `ingress.domain` vorhanden. Vor dem Hochziehen auf `5.0.0` ist **nichts zu bereinigen**.

Refs #68, Refs #99 (das Gate stand hier schon; #93 listet voucher-vault unter „bereits korrekt").
