### PR TITLE
outline: strict values.schema.json + Null-Absicherung (Welle 2, #68/#99)

### DIFF
--- a/outline/Chart.yaml
+++ b/outline/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://raw.githubusercontent.com/outline/outline/main/public/images/icon-
 
 type: application
 
-version: 5.0.0+up1.9.2
+version: 6.0.0+up1.9.2
 appVersion: 1.9.2
 
 maintainers:

--- a/outline/templates/_helpers.tpl
+++ b/outline/templates/_helpers.tpl
@@ -114,3 +114,159 @@ template-chart is the reference implementation.
 1
 {{- end -}}
 {{- end -}}
+
+{{/*
+Merge a user-supplied values sub-tree onto a dict of chart defaults so that a
+null / empty override falls back to the defaults instead of erasing them.
+
+Input: dict "defaults" <dict> "given" <dict|nil> "path" <string, optional
+values path used in error messages>. Output: YAML of the merged dict (consume
+it with fromYaml).
+
+Why this exists (issue #99): Helm merges values maps recursively, but an
+override key written without children — e.g. a leftover
+
+  securityContext:
+
+after deleting its last remaining sub-key — is YAML null. Where the chart
+defines a default, Helm treats that null as a deletion of the default; the
+template then renders "securityContext: null": no readOnlyRootFilesystem, no
+dropped capabilities, no allowPrivilegeEscalation: false. The workload starts
+and reports healthy while being unhardened, so nothing points at the mistake.
+The same shape erases a probe (it disappears) or the resources block (no
+requests, no computed limits). This helper defines the opposite semantics: an
+empty block means "chart defaults apply".
+
+Rules:
+  - a nil "given" is treated as an empty dict (all defaults apply).
+  - a key whose override value is null keeps the default (nulls never delete).
+  - a key present in both as a map is merged recursively, so a partially
+    filled block only overrides the keys it actually sets.
+  - a scalar override for a key the defaults define as a map is rejected with
+    a message naming the values path, instead of failing later with a template
+    field error.
+  - any other set value wins as given, including an explicit false or 0 —
+    Helm's "default" and sprig's "mergeOverwrite" would both swallow those
+    zero values, hence the explicit kindIs "invalid" nil check.
+  - keys only present in the override are passed through unchanged.
+
+NOTE: like the helpers above, this is duplicated into every chart's
+templates/_helpers.tpl with the chart's name as define prefix, because charts
+in this repo deliberately have no dependencies.
+*/}}
+{{- define "outline.defaultedDict" -}}
+{{- $defaults := .defaults | default dict -}}
+{{- $given := .given -}}
+{{- $path := .path | default "value" -}}
+{{- if kindIs "invalid" $given -}}
+{{- $given = dict -}}
+{{- end -}}
+{{- if not (kindIs "map" $given) -}}
+{{- fail (printf "%s must be a mapping or null, got %s (%v)" $path (kindOf $given) $given) -}}
+{{- end -}}
+{{- $out := deepCopy $defaults -}}
+{{- range $key, $value := $given -}}
+{{- if not (kindIs "invalid" $value) -}}
+{{- $default := index $defaults $key -}}
+{{- if and (kindIs "map" $value) (kindIs "map" $default) -}}
+{{- $_ := set $out $key (fromYaml (include "outline.defaultedDict" (dict "defaults" $default "given" $value "path" (printf "%s.%s" $path $key)))) -}}
+{{- else if kindIs "map" $default -}}
+{{- fail (printf "%s.%s must be a mapping or null, got %s (%v)" $path $key (kindOf $value) $value) -}}
+{{- else -}}
+{{- $_ := set $out $key $value -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- toYaml $out -}}
+{{- end -}}
+
+{{/*
+Pick one sub-block out of a values block that may itself be null.
+
+Input: dict "block" <dict|nil> "key" <string> "path" <string>.
+Returns YAML of dict "value" <the sub-block, may be nil>, after rejecting a
+non-mapping block with a message that names the values path. Needed because
+".Values.outline.securityContext" can itself be erased.
+*/}}
+{{- define "outline.subBlock" -}}
+{{- $block := .block -}}
+{{- if kindIs "invalid" $block -}}
+{{- $block = dict -}}
+{{- end -}}
+{{- if not (kindIs "map" $block) -}}
+{{- fail (printf "%s must be a mapping or null, got %s (%v)" .path (kindOf $block) $block) -}}
+{{- end -}}
+{{- toYaml (dict "value" (index $block .key)) -}}
+{{- end -}}
+
+{{/*
+The effective security contexts, probes and resources (issue #99).
+
+The defaults below MUST stay in sync with the corresponding blocks in
+values.yaml, which stays the documented, user-facing place for them; this copy
+is only the fallback for the case where an override has erased the block.
+
+All three probes use /_health on purpose: it is the only health endpoint
+Outline offers, and "/" returns 500 as well when the database is down, so
+there is no dependency-free alternative to fall back to.
+*/}}
+{{- define "outline.podSecurityContext" -}}
+{{- $given := (fromYaml (include "outline.subBlock" (dict "block" . "key" "pod" "path" "outline.securityContext"))).value -}}
+{{- $defaults := dict
+      "runAsNonRoot" true
+      "runAsUser" 1001
+      "runAsGroup" 1001
+      "fsGroup" 1001
+      "fsGroupChangePolicy" "Always" -}}
+{{- include "outline.defaultedDict" (dict "defaults" $defaults "given" $given "path" "outline.securityContext.pod") -}}
+{{- end -}}
+
+{{- define "outline.containerSecurityContext" -}}
+{{- $given := (fromYaml (include "outline.subBlock" (dict "block" . "key" "container" "path" "outline.securityContext"))).value -}}
+{{- $defaults := dict
+      "allowPrivilegeEscalation" false
+      "readOnlyRootFilesystem" true
+      "runAsNonRoot" true
+      "capabilities" (dict "drop" (list "ALL")) -}}
+{{- include "outline.defaultedDict" (dict "defaults" $defaults "given" $given "path" "outline.securityContext.container") -}}
+{{- end -}}
+
+{{- define "outline.livenessProbe" -}}
+{{- $defaults := dict
+      "httpGet" (dict "path" "/_health" "port" 3000)
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 3 -}}
+{{- include "outline.defaultedDict" (dict "defaults" $defaults "given" . "path" "outline.livenessProbe") -}}
+{{- end -}}
+
+{{- define "outline.readinessProbe" -}}
+{{- $defaults := dict
+      "httpGet" (dict "path" "/_health" "port" 3000)
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 3 -}}
+{{- include "outline.defaultedDict" (dict "defaults" $defaults "given" . "path" "outline.readinessProbe") -}}
+{{- end -}}
+
+{{- define "outline.startupProbe" -}}
+{{- $defaults := dict
+      "httpGet" (dict "path" "/_health" "port" 3000)
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 30 -}}
+{{- include "outline.defaultedDict" (dict "defaults" $defaults "given" . "path" "outline.startupProbe") -}}
+{{- end -}}
+
+{{/*
+The effective resources block, fed into the resources helper above so that an
+erased "resources:" still yields the chart's requests and computed limits
+instead of a container without any resource accounting.
+*/}}
+{{- define "outline.effectiveResources" -}}
+{{- $defaults := dict
+      "limitFactor" 3
+      "requests" (dict "cpu" 0.1 "memory" "512Mi" "ephemeralStorage" "10Mi") -}}
+{{- $merged := fromYaml (include "outline.defaultedDict" (dict "defaults" $defaults "given" . "path" "outline.resources")) -}}
+{{- include "outline.resources" $merged -}}
+{{- end -}}

--- a/outline/templates/outline.sfs.yaml
+++ b/outline/templates/outline.sfs.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       automountServiceAccountToken: false
       securityContext:
-        {{- toYaml .Values.outline.securityContext.pod | nindent 8 }}
+        {{- include "outline.podSecurityContext" .Values.outline.securityContext | nindent 8 }}
       containers:
         - name: {{ .Release.Name }}-{{ .Chart.Name }}-sfs
           image: "outlinewiki/outline:{{ .Chart.AppVersion }}"
@@ -26,8 +26,12 @@ spec:
           env:
             - name: PORT
               value: "3000"
+            # ingress.domain is not a pure Ingress value: it is also Outline's
+            # public URL, used for generated links and the OIDC redirect URI,
+            # so it stays required even when the Ingress is switched off (an
+            # empty value would render "https://" and break logins silently).
             - name: URL
-              value: "https://{{ .Values.ingress.domain }}"
+              value: "https://{{ required "A Domain/Host must be provided (ingress.domain)" .Values.ingress.domain }}"
             - name: SECRET_KEY
               valueFrom:
                 secretKeyRef:
@@ -100,15 +104,15 @@ spec:
               protocol: TCP
               name: http
           livenessProbe:
-            {{- toYaml .Values.outline.livenessProbe | nindent 12 }}
+            {{- include "outline.livenessProbe" .Values.outline.livenessProbe | nindent 12 }}
           readinessProbe:
-            {{- toYaml .Values.outline.readinessProbe | nindent 12 }}
+            {{- include "outline.readinessProbe" .Values.outline.readinessProbe | nindent 12 }}
           startupProbe:
-            {{- toYaml .Values.outline.startupProbe | nindent 12 }}
+            {{- include "outline.startupProbe" .Values.outline.startupProbe | nindent 12 }}
           resources:
-            {{- include "outline.resources" .Values.outline.resources | nindent 12 }}
+            {{- include "outline.effectiveResources" .Values.outline.resources | nindent 12 }}
           securityContext:
-            {{- toYaml .Values.outline.securityContext.container | nindent 12 }}
+            {{- include "outline.containerSecurityContext" .Values.outline.securityContext | nindent 12 }}
           volumeMounts:
             - mountPath: "/outline-data/data"
               name: outline-data

--- a/outline/values.schema.json
+++ b/outline/values.schema.json
@@ -1,0 +1,213 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "outline values",
+  "description": "Strict values schema (issue #68). additionalProperties is false on every chart-owned object level, so a key that the chart does not read is rejected at render time instead of being silently ignored. The only objects that stay open are the ones passed verbatim into the Kubernetes pod spec (probes, security contexts, global) - the chart does not interpret their contents, so it cannot judge which keys are meaningful. The hardening, probe and resources blocks additionally accept null, because an erased block falls back to the chart defaults (issue #99).",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "global": {
+      "description": "Helm's conventional cross-chart values. Unused by this chart, kept open so an umbrella install cannot break on it.",
+      "type": "object"
+    },
+    "scaleDown": {
+      "type": "boolean"
+    },
+    "secrets": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "configSecretRef": {
+          "type": ["string", "null"]
+        },
+        "redisSecretRef": {
+          "type": ["string", "null"]
+        },
+        "dbSecretRef": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "outline": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "replicas": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "maxUploadSize": {
+          "description": "Passed to the app as a byte count; the chart's values keep it a string on purpose.",
+          "type": ["string", "number", "null"]
+        },
+        "forceHttps": {
+          "description": "Passed through as a string ('true' / 'false'), matching the app's env parsing.",
+          "type": ["string", "boolean", "null"]
+        },
+        "oidc": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "displayName": {
+              "type": ["string", "null"]
+            }
+          }
+        },
+        "storage": {
+          "description": "The uploads PVC. Not null-safe on purpose: an erased block yields an invalid PVC rather than a silently degraded workload.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "size": {
+              "type": ["string", "null"]
+            },
+            "storageClass": {
+              "type": ["string", "null"]
+            }
+          }
+        },
+        "securityContext": {
+          "$ref": "#/definitions/securityContext"
+        },
+        "livenessProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "readinessProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "startupProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "env": {
+          "$ref": "#/definitions/env"
+        },
+        "resources": {
+          "$ref": "#/definitions/resources"
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "description": "Gates the whole Ingress template. false omits the Ingress and makes clusterIssuer unnecessary - but NOT domain, which is also Outline's public URL.",
+          "type": "boolean"
+        },
+        "maxUploadFileSize": {
+          "description": "Rendered into the ingress-nginx proxy-body-size annotation, so it only takes effect while the Ingress is enabled.",
+          "type": ["string", "null"]
+        },
+        "clusterIssuer": {
+          "type": ["string", "null"]
+        },
+        "domain": {
+          "type": ["string", "null"]
+        },
+        "className": {
+          "type": ["string", "null"]
+        },
+        "annotations": {
+          "description": "Extra Ingress annotations, merged with the cert-manager and proxy-body-size annotations the chart always sets. Free-form keys by nature.",
+          "type": "object"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "resources": {
+      "description": "May be null / empty: the chart then falls back to its default requests and computed limits (issue #99) instead of rendering a container without resource accounting.",
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "limitFactor": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "requests": {
+          "$ref": "#/definitions/resourceList"
+        },
+        "limits": {
+          "$ref": "#/definitions/resourceList"
+        }
+      }
+    },
+    "resourceList": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "cpu": {
+          "type": ["string", "number", "null"]
+        },
+        "memory": {
+          "type": ["string", "number", "null"]
+        },
+        "ephemeral-storage": {
+          "type": ["string", "number", "null"]
+        },
+        "ephemeralStorage": {
+          "type": ["string", "number", "null"]
+        }
+      }
+    },
+    "env": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "valueFrom": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "secretKeyRef": {
+                "$ref": "#/definitions/keyRef"
+              },
+              "configMapKeyRef": {
+                "$ref": "#/definitions/keyRef"
+              }
+            }
+          }
+        }
+      }
+    },
+    "keyRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "key"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        }
+      }
+    },
+    "securityContext": {
+      "description": "May be null / empty at any level: the chart then falls back to its hardening defaults (issue #99) instead of rendering an unhardened workload.",
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "pod": {
+          "description": "Merged onto the chart's pod hardening defaults and rendered as the pod's securityContext; kept open because the chart does not interpret the individual fields.",
+          "type": ["object", "null"]
+        },
+        "container": {
+          "description": "Merged onto the chart's container hardening defaults and rendered as the container's securityContext; kept open because the chart does not interpret the individual fields.",
+          "type": ["object", "null"]
+        }
+      }
+    },
+    "probe": {
+      "description": "Merged onto the chart's probe defaults and rendered as a container probe; kept open because the chart does not interpret the individual fields. May be null / empty, which means the defaults apply (issue #99) rather than the probe disappearing.",
+      "type": ["object", "null"]
+    }
+  }
+}


### PR DESCRIPTION
Viertes Chart der **Welle 2** aus #68. **5.0.0 → 6.0.0** (major, appVersion unverändert bei 1.9.2).

**Kein Ingress-Gate** — outline gatet bereits korrekt (#93: „bereits korrekt"). Zwei Änderungen, plus eine Absicherung, die das **vorhandene** Gate gebraucht hätte.

---

# 1. Strict `values.schema.json` (#68)

`additionalProperties: false` auf allen chart-eigenen Objektebenen: oberste Ebene, `outline`, `outline.oidc`, `outline.storage`, `outline.resources` mit `.requests`/`.limits`, `env[]` mit `valueFrom` und beiden KeyRefs, `securityContext`, `ingress`, `secrets`.

**Offen bleiben** die durchgereichten Objekte: die drei Probes, `securityContext.pod`/`.container`, `global`, `ingress.annotations`.

`maxUploadSize` und `forceHttps` sind als String **und** als Zahl/Boolean erlaubt: Die Chart-Defaults halten sie bewusst als String (`'262144000'`, `'false'`), aber ein unquotierter Wert in einer Werte-Datei ist eine naheliegende Schreibweise und funktioniert.

`outline.storage` bleibt **nicht** null-sicher: Ein geleerter Block ergibt eine ungültige PVC, kein still degradiertes Workload — laute Klasse, die #99 ausnimmt.

# 2. Null-Absicherung für Härtung, Probes und Ressourcen (#99)

`defaultedDict` und `subBlock` übernommen; abgesichert sind Pod-Context, Container-Context, die drei Probes und `resources`.

**Die beiden neuen Prüfpunkte aus voucher-vault angewandt:**

- **Wächter?** Keine. Die Probe- und Context-Blöcke stehen bei outline ohne `{{- if }}` im Template, ein geleerter Block rendert also `null` (sichtbar) statt zu verschwinden. Nachgeprüft, nicht angenommen.
- **Probe-Kontext?** Keiner. Die Probes adressieren Port `3000` numerisch und tragen keinen Host-Header — es geht beim Rekonstruieren also nichts verloren.

Ein inhaltlicher Punkt, den die Defaults erhalten müssen: **Alle drei Probes verwenden `/_health`**, auch die Liveness. Das ist Absicht — `/_health` ist Outlines einziger Health-Endpunkt, und `/` liefert bei Datenbankausfall ebenfalls 500, es gibt also keinen abhängigkeitsfreien Pfad, auf den man ausweichen könnte. Die Helper-Defaults bilden das genauso ab.

# 3. `ingress.domain` ist dort abgesichert, wo es gelesen wird

Prüfpunkt über **`values.yaml` und `templates/`** (die erweiterte Fassung): Der Zugriff liegt hier im Template — `outline.sfs.yaml` speist daraus `URL`, Outlines öffentliche URL für generierte Links und die OIDC-Redirect-URI —, und zwar **ohne** `required()`.

Wie bei voucher-vault existiert das Gate schon, **das Loch besteht also bereits heute**. Am veröffentlichten `5.0.0`, Ingress aus, kein `domain`:

```yaml
            - name: URL
              value: "https://"
```

Damit sind alle generierten Links kaputt und der OIDC-Login schlägt fehl — bei fehlerfreiem Rendering. Jetzt:

```
$ helm template t outline … --set ingress.enabled=false --set ingress.domain=null
Error: execution error at (outline/templates/outline.sfs.yaml:34:33):
A Domain/Host must be provided (ingress.domain)
```

Fünftes Chart mit demselben Muster: patchmon `CORS_ORIGIN`, rallly `NEXT_PUBLIC_BASE_URL`, zipline `CORE_DEFAULT_DOMAIN`, voucher-vault `DOMAIN`, outline `URL`. **Das Gate macht `clusterIssuer` entbehrlich, nie `domain`.**

---

## Nachweis 1: erased Block → vorher, nachher

```yaml
outline:
  securityContext:
    container:
  livenessProbe:
  resources:
    limits:
```

**Vorher** (`5.0.0`): `securityContext: null`, `livenessProbe: null`.

**Nachher**: volle Härtungs-Defaults, vollständige Default-Probe auf `/_health`, und für die Ressourcen:

```yaml
          resources:
            limits:
              ephemeral-storage: 30Mi
              memory: 1536Mi
            requests:
              cpu: 0.1
              ephemeral-storage: 10Mi
              memory: 512Mi
```

Der `limits:`-Fall ist zugleich der Beleg für die Schema-Typen: Ohne die Erweiterung auf `["object", "null"]` hätte das Schema hier hart abgebrochen (`got null, want object`), weil `limits` keinen Chart-Default hat und das `null` deshalb bis in die Validierung überlebt.

## Nachweis 2: ein bewusst gesetztes `false` / `0` gewinnt weiterhin

`--set outline.securityContext.container.readOnlyRootFilesystem=false` → `false`, übrige Härtung intakt.
`--set outline.startupProbe.failureThreshold=0` → `0`, restliche Probe-Defaults inklusive `/_health` intakt.

## Nachweis 3: das Rendering ändert sich nicht

`diff` gegen den `5.0.0`-Stand mit `ci/outline/test-values.yaml`: einziger Unterschied ist der vierzeilige Kommentar über `URL`. Sonst byte-identisch.

## Verifikation

```
$ helm lint --strict outline
1 chart(s) linted, 0 chart(s) failed
```

**Helper-Audit:** 12 aufgerufene Namen, 12 definierte.

| Gate-Fall | Ergebnis |
|---|---|
| Gate an (Default) | 1 Ingress, `URL` wie bisher |
| Gate aus, `domain` gesetzt, **kein** `clusterIssuer` | rendert, **0** Ingress, `value: "https://outline.ci.local"` |
| Gate aus, **kein** `domain` | scheitert laut |

**Negativprobe:**

```
--set bogusTopLevel=true                        -> at '': 'bogusTopLevel' not allowed
--set outline.resources.requests.bogusCpu=1     -> at '/outline/resources/requests': 'bogusCpu' not allowed
--set outline.storage.amount=10Gi               -> at '/outline/storage': 'amount' not allowed
```

Die letzte ist ein realistischer Tippfehler: Der Schlüssel heißt `outline.storage.size`, während das Schwester-Chart voucher-vault `storage.amount` verwendet.

## Validierung gegen die real ausgerollten Werte

Bundle `fleet-cd/outline-jk/outline/`, Release `outline-jk`, gepinnt auf `5.0.0+up1.9.2`. Bundle-Datei und `helm get values outline-jk -n outline-jk` deckungsgleich.

**Liste abgewiesener Schlüssel: leer.** Gesetzt werden nur `secrets.*`, `outline.oidc.displayName`, `outline.storage.{size,storageClass}` und `ingress.{clusterIssuer,domain}` — alle bekannt und gefüllt, kein geleerter Block, `ingress.domain` vorhanden. Vor dem Hochziehen auf `6.0.0` ist **nichts zu bereinigen**.

Refs #68, Refs #99 (#93 listet outline unter „bereits korrekt").
