### PR TITLE
teamspeak-server: strict values.schema.json + Null-Absicherung (Welle 2, #68/#99)

### DIFF
--- a/teamspeak-server/Chart.yaml
+++ b/teamspeak-server/Chart.yaml
@@ -5,5 +5,5 @@ icon: https://avatars.githubusercontent.com/u/136759148
 
 type: application
 
-version: 4.0.0+up6.0.0.beta12.1
+version: 5.0.0+up6.0.0.beta12.1
 appVersion: "6.0.0-beta12.1"

--- a/teamspeak-server/templates/_helpers.tpl
+++ b/teamspeak-server/templates/_helpers.tpl
@@ -114,3 +114,162 @@ template-chart is the reference implementation.
 1
 {{- end -}}
 {{- end -}}
+
+{{/*
+Merge a user-supplied values sub-tree onto a dict of chart defaults so that a
+null / empty override falls back to the defaults instead of erasing them.
+
+Input: dict "defaults" <dict> "given" <dict|nil> "path" <string, optional
+values path used in error messages>. Output: YAML of the merged dict (consume
+it with fromYaml).
+
+Why this exists (issue #99): Helm merges values maps recursively, but an
+override key written without children — e.g. a leftover
+
+  securityContext:
+
+after deleting its last remaining sub-key — is YAML null. Where the chart
+defines a default, Helm treats that null as a deletion of the default; the
+template then renders "securityContext: null": no readOnlyRootFilesystem, no
+dropped capabilities, no allowPrivilegeEscalation: false. The workload starts
+and reports healthy while being unhardened, so nothing points at the mistake.
+The same shape erases a probe (it disappears) or the resources block (no
+requests, no computed limits). This helper defines the opposite semantics: an
+empty block means "chart defaults apply".
+
+Rules:
+  - a nil "given" is treated as an empty dict (all defaults apply).
+  - a key whose override value is null keeps the default (nulls never delete).
+  - a key present in both as a map is merged recursively, so a partially
+    filled block only overrides the keys it actually sets.
+  - a scalar override for a key the defaults define as a map is rejected with
+    a message naming the values path, instead of failing later with a template
+    field error.
+  - any other set value wins as given, including an explicit false or 0 —
+    Helm's "default" and sprig's "mergeOverwrite" would both swallow those
+    zero values, hence the explicit kindIs "invalid" nil check.
+  - keys only present in the override are passed through unchanged.
+
+NOTE: like the helpers above, this is duplicated into every chart's
+templates/_helpers.tpl with the chart's name as define prefix, because charts
+in this repo deliberately have no dependencies.
+*/}}
+{{- define "teamspeak-server.defaultedDict" -}}
+{{- $defaults := .defaults | default dict -}}
+{{- $given := .given -}}
+{{- $path := .path | default "value" -}}
+{{- if kindIs "invalid" $given -}}
+{{- $given = dict -}}
+{{- end -}}
+{{- if not (kindIs "map" $given) -}}
+{{- fail (printf "%s must be a mapping or null, got %s (%v)" $path (kindOf $given) $given) -}}
+{{- end -}}
+{{- $out := deepCopy $defaults -}}
+{{- range $key, $value := $given -}}
+{{- if not (kindIs "invalid" $value) -}}
+{{- $default := index $defaults $key -}}
+{{- if and (kindIs "map" $value) (kindIs "map" $default) -}}
+{{- $_ := set $out $key (fromYaml (include "teamspeak-server.defaultedDict" (dict "defaults" $default "given" $value "path" (printf "%s.%s" $path $key)))) -}}
+{{- else if kindIs "map" $default -}}
+{{- fail (printf "%s.%s must be a mapping or null, got %s (%v)" $path $key (kindOf $value) $value) -}}
+{{- else -}}
+{{- $_ := set $out $key $value -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- toYaml $out -}}
+{{- end -}}
+
+{{/*
+Pick one sub-block out of a values block that may itself be null.
+
+Input: dict "block" <dict|nil> "key" <string> "path" <string>.
+Returns YAML of dict "value" <the sub-block, may be nil>, after rejecting a
+non-mapping block with a message that names the values path. Needed because
+".Values.securityContext" can itself be erased.
+*/}}
+{{- define "teamspeak-server.subBlock" -}}
+{{- $block := .block -}}
+{{- if kindIs "invalid" $block -}}
+{{- $block = dict -}}
+{{- end -}}
+{{- if not (kindIs "map" $block) -}}
+{{- fail (printf "%s must be a mapping or null, got %s (%v)" .path (kindOf $block) $block) -}}
+{{- end -}}
+{{- toYaml (dict "value" (index $block .key)) -}}
+{{- end -}}
+
+{{/*
+The effective security contexts, probes and resources (issue #99).
+
+The defaults below MUST stay in sync with the corresponding blocks in
+values.yaml, which stays the documented, user-facing place for them; this copy
+is only the fallback for the case where an override has erased the block.
+
+Note that this chart keeps these blocks at the TOP level of values.yaml, not
+under a chart-named key, so the paths in the error messages have no prefix.
+
+The probes address the TCP file-transfer port by its name ("file-transfer"),
+because the voice service is UDP and cannot be probed. A rebuilt default probe
+must keep that port name, otherwise the workload has no working probe at all.
+*/}}
+{{- define "teamspeak-server.podSecurityContext" -}}
+{{- $given := (fromYaml (include "teamspeak-server.subBlock" (dict "block" . "key" "pod" "path" "securityContext"))).value -}}
+{{- $defaults := dict
+      "runAsNonRoot" true
+      "runAsUser" 9987
+      "runAsGroup" 9987
+      "fsGroup" 9987
+      "fsGroupChangePolicy" "Always" -}}
+{{- include "teamspeak-server.defaultedDict" (dict "defaults" $defaults "given" $given "path" "securityContext.pod") -}}
+{{- end -}}
+
+{{- define "teamspeak-server.containerSecurityContext" -}}
+{{- $given := (fromYaml (include "teamspeak-server.subBlock" (dict "block" . "key" "container" "path" "securityContext"))).value -}}
+{{- $defaults := dict
+      "allowPrivilegeEscalation" false
+      "readOnlyRootFilesystem" true
+      "runAsNonRoot" true
+      "capabilities" (dict "drop" (list "ALL") "add" (list)) -}}
+{{- include "teamspeak-server.defaultedDict" (dict "defaults" $defaults "given" $given "path" "securityContext.container") -}}
+{{- end -}}
+
+{{- define "teamspeak-server.livenessProbe" -}}
+{{- $defaults := dict
+      "tcpSocket" (dict "port" "file-transfer")
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 3 -}}
+{{- include "teamspeak-server.defaultedDict" (dict "defaults" $defaults "given" . "path" "livenessProbe") -}}
+{{- end -}}
+
+{{- define "teamspeak-server.readinessProbe" -}}
+{{- $defaults := dict
+      "tcpSocket" (dict "port" "file-transfer")
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 3 -}}
+{{- include "teamspeak-server.defaultedDict" (dict "defaults" $defaults "given" . "path" "readinessProbe") -}}
+{{- end -}}
+
+{{- define "teamspeak-server.startupProbe" -}}
+{{- $defaults := dict
+      "tcpSocket" (dict "port" "file-transfer")
+      "periodSeconds" 5
+      "timeoutSeconds" 5
+      "failureThreshold" 30 -}}
+{{- include "teamspeak-server.defaultedDict" (dict "defaults" $defaults "given" . "path" "startupProbe") -}}
+{{- end -}}
+
+{{/*
+The effective resources block, fed into the resources helper above so that an
+erased "resources:" still yields the chart's requests and computed limits
+instead of a container without any resource accounting.
+*/}}
+{{- define "teamspeak-server.effectiveResources" -}}
+{{- $defaults := dict
+      "limitFactor" 3
+      "requests" (dict "cpu" 0.2 "memory" "100Mi" "ephemeral-storage" "100Mi") -}}
+{{- $merged := fromYaml (include "teamspeak-server.defaultedDict" (dict "defaults" $defaults "given" . "path" "resources")) -}}
+{{- include "teamspeak-server.resources" $merged -}}
+{{- end -}}

--- a/teamspeak-server/templates/teamspeak-server.sfs.yaml
+++ b/teamspeak-server/templates/teamspeak-server.sfs.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       automountServiceAccountToken: false
       securityContext:
-        {{- toYaml .Values.securityContext.pod | nindent 8 }}
+        {{- include "teamspeak-server.podSecurityContext" .Values.securityContext | nindent 8 }}
       containers:
         - name: {{ .Release.Name }}-{{ .Chart.Name }}-sfs
           image: "teamspeaksystems/teamspeak6-server:{{ .Chart.AppVersion }}"
@@ -60,15 +60,15 @@ spec:
             {{- end }}
             {{- end }}
           livenessProbe:
-            {{- toYaml .Values.livenessProbe | nindent 12 }}
+            {{- include "teamspeak-server.livenessProbe" .Values.livenessProbe | nindent 12 }}
           readinessProbe:
-            {{- toYaml .Values.readinessProbe | nindent 12 }}
+            {{- include "teamspeak-server.readinessProbe" .Values.readinessProbe | nindent 12 }}
           startupProbe:
-            {{- toYaml .Values.startupProbe | nindent 12 }}
+            {{- include "teamspeak-server.startupProbe" .Values.startupProbe | nindent 12 }}
           resources:
-            {{- include "teamspeak-server.resources" .Values.resources | nindent 12 }}
+            {{- include "teamspeak-server.effectiveResources" .Values.resources | nindent 12 }}
           securityContext:
-            {{- toYaml .Values.securityContext.container | nindent 12 }}
+            {{- include "teamspeak-server.containerSecurityContext" .Values.securityContext | nindent 12 }}
           volumeMounts:
             - name: "teamspeak-volume"
               mountPath: /var/tsserver/

--- a/teamspeak-server/values.schema.json
+++ b/teamspeak-server/values.schema.json
@@ -1,0 +1,165 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "teamspeak-server values",
+  "description": "Strict values schema (issue #68). additionalProperties is false on every chart-owned object level, so a key that the chart does not read is rejected at render time instead of being silently ignored. The only objects that stay open are the ones passed verbatim into the Kubernetes pod spec (probes, security contexts, global) - the chart does not interpret their contents, so it cannot judge which keys are meaningful. The hardening, probe and resources blocks additionally accept null, because an erased block falls back to the chart defaults (issue #99). Note that this chart keeps replicas, resources, probes and securityContext at the TOP level rather than under a chart-named key.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "global": {
+      "description": "Helm's conventional cross-chart values. Unused by this chart, kept open so an umbrella install cannot break on it.",
+      "type": "object"
+    },
+    "scaleDown": {
+      "type": "boolean"
+    },
+    "replicas": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "server": {
+      "description": "Ports. Each value is used as container port, service port and NodePort, and is passed to the server so it listens on the exposed port - file transfer requires the in-container port to match the externally reachable one.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "voicePort": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "fileTransferPort": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        }
+      }
+    },
+    "resources": {
+      "$ref": "#/definitions/resources"
+    },
+    "env": {
+      "$ref": "#/definitions/env"
+    },
+    "livenessProbe": {
+      "$ref": "#/definitions/probe"
+    },
+    "readinessProbe": {
+      "$ref": "#/definitions/probe"
+    },
+    "startupProbe": {
+      "$ref": "#/definitions/probe"
+    },
+    "securityContext": {
+      "$ref": "#/definitions/securityContext"
+    },
+    "storage": {
+      "description": "The data PVC. Not null-safe on purpose: an erased block yields an invalid PVC rather than a silently degraded workload.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "size": {
+          "type": ["string", "null"]
+        },
+        "storageClass": {
+          "type": ["string", "null"]
+        }
+      }
+    }
+  },
+  "definitions": {
+    "resources": {
+      "description": "May be null / empty: the chart then falls back to its default requests and computed limits (issue #99) instead of rendering a container without resource accounting.",
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "limitFactor": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "requests": {
+          "$ref": "#/definitions/resourceList"
+        },
+        "limits": {
+          "$ref": "#/definitions/resourceList"
+        }
+      }
+    },
+    "resourceList": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "cpu": {
+          "type": ["string", "number", "null"]
+        },
+        "memory": {
+          "type": ["string", "number", "null"]
+        },
+        "ephemeral-storage": {
+          "type": ["string", "number", "null"]
+        },
+        "ephemeralStorage": {
+          "type": ["string", "number", "null"]
+        }
+      }
+    },
+    "env": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "valueFrom": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "secretKeyRef": {
+                "$ref": "#/definitions/keyRef"
+              },
+              "configMapKeyRef": {
+                "$ref": "#/definitions/keyRef"
+              }
+            }
+          }
+        }
+      }
+    },
+    "keyRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "key"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        }
+      }
+    },
+    "securityContext": {
+      "description": "May be null / empty at any level: the chart then falls back to its hardening defaults (issue #99) instead of rendering an unhardened workload.",
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "pod": {
+          "description": "Merged onto the chart's pod hardening defaults and rendered as the pod's securityContext; kept open because the chart does not interpret the individual fields.",
+          "type": ["object", "null"]
+        },
+        "container": {
+          "description": "Merged onto the chart's container hardening defaults and rendered as the container's securityContext; kept open because the chart does not interpret the individual fields.",
+          "type": ["object", "null"]
+        }
+      }
+    },
+    "probe": {
+      "description": "Merged onto the chart's probe defaults and rendered as a container probe; kept open because the chart does not interpret the individual fields. May be null / empty, which means the defaults apply (issue #99) rather than the probe disappearing.",
+      "type": ["object", "null"]
+    }
+  }
+}


### PR DESCRIPTION
Fünftes Chart der **Welle 2** aus #68. **4.0.0 → 5.0.0** (major, appVersion unverändert bei `6.0.0-beta12.1`).

**Kein Ingress-Gate** — dieses Chart hat **überhaupt keinen Ingress**. Voice (UDP) und File-Transfer (TCP) werden per NodePort exponiert. Der Prüfpunkt aus rallly/voucher-vault ist trotzdem gelaufen, über **beide** Quellen:

```
$ grep -rn "ingress.domain" teamspeak-server/templates/   -> (none)
$ grep -n  "ingress.domain" teamspeak-server/values.yaml  -> (none)
```

Also zwei Änderungen, kein dritter Punkt.

---

# 1. Strict `values.schema.json` (#68)

**Besonderheit der Werte-Oberfläche:** Dieses Chart hält `replicas`, `resources`, `env`, die drei Probes und `securityContext` auf der **obersten Ebene**, nicht unter einem chart-benannten Block. Das Schema bildet diese Form ab, statt eine Verschachtelung zu erfinden, die es nicht gibt — die Fehlermeldungen lauten deshalb `at '/resources/requests'` und nicht `at '/teamspeak-server/...'`.

`additionalProperties: false` auf allen chart-eigenen Objektebenen: oberste Ebene, `server`, `resources` mit `.requests`/`.limits`, `env[]` mit `valueFrom` und beiden KeyRefs, `securityContext`, `storage`.

`storage` bleibt **nicht** null-sicher: Ein geleerter Block ergibt eine ungültige PVC — laute Klasse, die #99 ausnimmt.

# 2. Null-Absicherung für Härtung, Probes und Ressourcen (#99)

**Die drei Prüfpunkte, alle nachgemessen statt angenommen:**

- **Wächter?** Keine. Die Blöcke stehen ohne `{{- if }}` im Template; ein geleerter Block rendert sichtbar `null`.
- **Probe-Kontext?** Ja, und er ist hier essenziell: Die Probes zielen per **Portnamen** auf `file-transfer`. Das Voice-Interface ist UDP und lässt sich nicht proben, der TCP-File-Transfer-Port ist also das Einzige, worauf eine Probe überhaupt zielen kann. Eine rekonstruierte Default-Probe ohne diesen Portnamen ließe das Workload ganz ohne funktionierende Probe zurück. Die Helper-Defaults tragen ihn mit.
- **`ingress.domain`?** Kommt nicht vor (siehe oben).

**Ein Detail zur Treue der Defaults:** Der Container-Context in `values.yaml` enthält `capabilities.add: []`. Ich habe die leere Liste in die Helper-Defaults übernommen, damit ein geleerter Block das heutige Rendering **exakt** wiederherstellt statt einer aufgeräumten Variante.

Der Vollständigkeit halber geprüft, weil rallly an dieser Stelle einen Warnkommentar trägt (#84, Trivy `AVD-KSV-0022`): Das ist hier die **leere-Liste**-Form (`add: []`), nicht die Null-Eintrag-Form (`add:` mit leerem Listenpunkt), die den Befund ausgelöst hatte. Sie rendert als `add: []` und ist unbedenklich — redundant, aber harmlos. Ich fasse sie in diesem PR bewusst nicht an, weil das eine inhaltliche Änderung am Rendering wäre und dieser PR verhaltensneutral bleiben soll.

---

## Nachweis 1: erased Block → vorher, nachher

```yaml
securityContext:
  container:
livenessProbe:
resources:
  limits:
```

**Vorher** (`4.0.0`): `securityContext: null`, `livenessProbe: null`.

**Nachher**:

```yaml
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              add: []
              drop:
              - ALL
            readOnlyRootFilesystem: true
            runAsNonRoot: true
          ...
          livenessProbe:
            failureThreshold: 3
            periodSeconds: 10
            tcpSocket:
              port: file-transfer      # <- Portname erhalten
            timeoutSeconds: 5
          ...
          resources:
            limits:
              ephemeral-storage: 300Mi
              memory: 300Mi
            requests:
              cpu: 0.2
              ephemeral-storage: 100Mi
              memory: 100Mi
```

Der `limits:`-Fall belegt wieder die Schema-Typen: Ohne `["object", "null"]` wäre hier hart abgebrochen worden, weil `limits` keinen Chart-Default hat und das `null` bis in die Validierung überlebt.

## Nachweis 2: ein bewusst gesetztes `false` / `0` gewinnt weiterhin

`--set securityContext.container.readOnlyRootFilesystem=false` → `false`, während `allowPrivilegeEscalation: false`, `drop: ALL` **und** `add: []` erhalten bleiben.

`--set startupProbe.failureThreshold=0` → `0`, restliche Probe-Defaults inklusive Portname intakt.

## Nachweis 3: das Rendering ändert sich nicht

```
$ diff <(helm template t <4.0.0> -f ci/teamspeak-server/test-values.yaml) \
       <(helm template t teamspeak-server -f ci/teamspeak-server/test-values.yaml)
(keine Ausgabe — byte-identisch)
```

Hier sogar ohne jede Ausnahme: Dieser PR fügt keinen Kommentar ins Template ein, also ist das Manifest wirklich Byte für Byte gleich.

## Verifikation

```
$ helm lint --strict teamspeak-server
1 chart(s) linted, 0 chart(s) failed
```

**Helper-Audit:** 12 aufgerufene Namen, 12 definierte.

**Negativprobe:**

```
--set bogusTopLevel=true              -> at '': 'bogusTopLevel' not allowed
--set resources.requests.bogusCpu=1   -> at '/resources/requests': 'bogusCpu' not allowed
--set server.queryPort=10011          -> at '/server': 'queryPort' not allowed
```

Die letzte ist ein realistischer Fall: TeamSpeak hat einen ServerQuery-Port, den dieses Chart aber nicht exponiert — ein Schlüssel, den man plausibel setzen würde und der heute wirkungslos verschwände.

## Validierung gegen die real ausgerollten Werte

Bundle `fleet-cd/ts-server/`, Release `ts-server`, gepinnt auf `4.0.0+up6.0.0.beta12.1`. Bundle-Datei und `helm get values ts-server -n ts-server` deckungsgleich.

Die Werte-Datei setzt **nur** `scaleDown: true` — der Server ist heruntergefahren, PVC, Secrets und Services bleiben stehen.

> **Korrektur (nachträglich eingetragen).** In der ersten Fassung dieses PR-Textes stand, der Server sei stillgelegt, „weil die TeamSpeak-Lizenz abgelaufen ist". **Das ist falsch.** Ich hatte den Kommentar aus der Bundle-Datei übernommen, statt ihn zu prüfen. Laut #40 ist die im Image mitgelieferte Lizenz **bis 2026-10-01 gültig** — heute ist der 23.08.2026. Der Beleg steckt sogar in diesem PR: Der Install-Test verifiziert laut #40 die Lizenzgültigkeit mit, und er ist mit echtem Install grün durchgelaufen; bei abgelaufener Lizenz wäre er gescheitert.
>
> Warum das Release auf `scaleDown: true` steht, ist eine Entscheidung der Cluster-Seite und hat mit der Lizenz nichts zu tun. Der Kommentar in `fleet-cd/ts-server/teamspeak-server.values.yaml` behauptet dort weiterhin das Gegenteil und sollte richtiggestellt werden — sonst wird aus „Lizenz abgelaufen" irgendwann „Chart kann weg", und die echte Frist aus #40 bleibt unbemerkt liegen.

**Liste abgewiesener Schlüssel: leer.** Gegengeprüft, dass die Stilllegung erhalten bleibt: Das Rendering mit den Bundle-Werten ergibt weiterhin `replicas: 0`. Vor dem Hochziehen auf `5.0.0` ist **nichts zu bereinigen**.

Refs #68, Refs #99.
