### PR TITLE
satisfactory: strict values.schema.json + Null-Absicherung (Welle 2, #68/#99)

### DIFF
--- a/satisfactory/Chart.yaml
+++ b/satisfactory/Chart.yaml
@@ -3,7 +3,7 @@ name: satisfactory
 description: A Helm chart to deploy a Satisfactory Gameserver on Kubernetes
 icon: https://raw.githubusercontent.com/wolveix/satisfactory-server/main/.github/logo.png
 type: application
-version: 4.0.0+upv1.9.10
+version: 5.0.0+upv1.9.10
 appVersion: "v1.9.10"
 maintainers:
   - name: jklein

--- a/satisfactory/templates/_helpers.tpl
+++ b/satisfactory/templates/_helpers.tpl
@@ -114,3 +114,173 @@ template-chart is the reference implementation.
 1
 {{- end -}}
 {{- end -}}
+
+{{/*
+Merge a user-supplied values sub-tree onto a dict of chart defaults so that a
+null / empty override falls back to the defaults instead of erasing them.
+
+Input: dict "defaults" <dict> "given" <dict|nil> "path" <string, optional
+values path used in error messages>. Output: YAML of the merged dict (consume
+it with fromYaml).
+
+Why this exists (issue #99): Helm merges values maps recursively, but an
+override key written without children — e.g. a leftover
+
+  securityContext:
+
+after deleting its last remaining sub-key — is YAML null. Where the chart
+defines a default, Helm treats that null as a deletion of the default; the
+template then renders "securityContext: null": no readOnlyRootFilesystem, no
+dropped capabilities, no allowPrivilegeEscalation: false. The workload starts
+and reports healthy while being unhardened, so nothing points at the mistake.
+The same shape erases a probe (it disappears) or the resources block (no
+requests, no computed limits). This helper defines the opposite semantics: an
+empty block means "chart defaults apply".
+
+Rules:
+  - a nil "given" is treated as an empty dict (all defaults apply).
+  - a key whose override value is null keeps the default (nulls never delete).
+  - a key present in both as a map is merged recursively, so a partially
+    filled block only overrides the keys it actually sets.
+  - a scalar override for a key the defaults define as a map is rejected with
+    a message naming the values path, instead of failing later with a template
+    field error.
+  - any other set value wins as given, including an explicit false or 0 —
+    Helm's "default" and sprig's "mergeOverwrite" would both swallow those
+    zero values, hence the explicit kindIs "invalid" nil check.
+  - keys only present in the override are passed through unchanged.
+
+NOTE: like the helpers above, this is duplicated into every chart's
+templates/_helpers.tpl with the chart's name as define prefix, because charts
+in this repo deliberately have no dependencies.
+*/}}
+{{- define "satisfactory.defaultedDict" -}}
+{{- $defaults := .defaults | default dict -}}
+{{- $given := .given -}}
+{{- $path := .path | default "value" -}}
+{{- if kindIs "invalid" $given -}}
+{{- $given = dict -}}
+{{- end -}}
+{{- if not (kindIs "map" $given) -}}
+{{- fail (printf "%s must be a mapping or null, got %s (%v)" $path (kindOf $given) $given) -}}
+{{- end -}}
+{{- $out := deepCopy $defaults -}}
+{{- range $key, $value := $given -}}
+{{- if not (kindIs "invalid" $value) -}}
+{{- $default := index $defaults $key -}}
+{{- if and (kindIs "map" $value) (kindIs "map" $default) -}}
+{{- $_ := set $out $key (fromYaml (include "satisfactory.defaultedDict" (dict "defaults" $default "given" $value "path" (printf "%s.%s" $path $key)))) -}}
+{{- else if kindIs "map" $default -}}
+{{- fail (printf "%s.%s must be a mapping or null, got %s (%v)" $path $key (kindOf $value) $value) -}}
+{{- else -}}
+{{- $_ := set $out $key $value -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- toYaml $out -}}
+{{- end -}}
+
+{{/*
+Pick one sub-block out of a values block that may itself be null.
+
+Input: dict "block" <dict|nil> "key" <string> "path" <string>.
+Returns YAML of dict "value" <the sub-block, may be nil>, after rejecting a
+non-mapping block with a message that names the values path. Needed because
+".Values.securityContext" can itself be erased.
+*/}}
+{{- define "satisfactory.subBlock" -}}
+{{- $block := .block -}}
+{{- if kindIs "invalid" $block -}}
+{{- $block = dict -}}
+{{- end -}}
+{{- if not (kindIs "map" $block) -}}
+{{- fail (printf "%s must be a mapping or null, got %s (%v)" .path (kindOf $block) $block) -}}
+{{- end -}}
+{{- toYaml (dict "value" (index $block .key)) -}}
+{{- end -}}
+
+{{/*
+The effective security contexts, probes and resources (issue #99).
+
+The defaults below MUST stay in sync with the corresponding blocks in
+values.yaml, which stays the documented, user-facing place for them; this copy
+is only the fallback for the case where an override has erased the block.
+
+Like teamspeak-server, this chart keeps these blocks at the TOP level of
+values.yaml, so the paths in the error messages have no chart-name prefix.
+
+Probe specifics that a rebuilt default must not lose:
+  - liveness and startup run the image's own healthcheck script via exec. It
+    queries the server's HTTPS API on SERVERGAMEPORT, so it keeps working when
+    the port is overridden - which a tcpSocket default could not do.
+  - readiness uses the named "api" port.
+  - the startup budget is deliberately huge (30s x 40 = 20 minutes): the
+    server downloads and updates the game files via Steam on first start.
+*/}}
+{{- define "satisfactory.podSecurityContext" -}}
+{{- $given := (fromYaml (include "satisfactory.subBlock" (dict "block" . "key" "pod" "path" "securityContext"))).value -}}
+{{- $defaults := dict
+      "runAsNonRoot" true
+      "runAsUser" 1000
+      "runAsGroup" 1000
+      "fsGroup" 1000
+      "fsGroupChangePolicy" "OnRootMismatch" -}}
+{{- include "satisfactory.defaultedDict" (dict "defaults" $defaults "given" $given "path" "securityContext.pod") -}}
+{{- end -}}
+
+{{- define "satisfactory.containerSecurityContext" -}}
+{{- $given := (fromYaml (include "satisfactory.subBlock" (dict "block" . "key" "container" "path" "securityContext"))).value -}}
+{{- $defaults := dict
+      "allowPrivilegeEscalation" false
+      "readOnlyRootFilesystem" true
+      "runAsNonRoot" true
+      "capabilities" (dict "drop" (list "ALL") "add" (list)) -}}
+{{- include "satisfactory.defaultedDict" (dict "defaults" $defaults "given" $given "path" "securityContext.container") -}}
+{{- end -}}
+
+{{- define "satisfactory.healthcheckExec" -}}
+{{- dict "command" (list "/bin/sh" "-c" "/home/steam/healthcheck.sh") | toYaml -}}
+{{- end -}}
+
+{{- define "satisfactory.livenessProbe" -}}
+{{- $defaults := dict
+      "exec" (fromYaml (include "satisfactory.healthcheckExec" .))
+      "failureThreshold" 4
+      "successThreshold" 1
+      "periodSeconds" 30
+      "timeoutSeconds" 10 -}}
+{{- include "satisfactory.defaultedDict" (dict "defaults" $defaults "given" . "path" "livenessProbe") -}}
+{{- end -}}
+
+{{- define "satisfactory.readinessProbe" -}}
+{{- $defaults := dict
+      "tcpSocket" (dict "port" "api")
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 3 -}}
+{{- include "satisfactory.defaultedDict" (dict "defaults" $defaults "given" . "path" "readinessProbe") -}}
+{{- end -}}
+
+{{- define "satisfactory.startupProbe" -}}
+{{- $defaults := dict
+      "exec" (fromYaml (include "satisfactory.healthcheckExec" .))
+      "periodSeconds" 30
+      "timeoutSeconds" 10
+      "failureThreshold" 40 -}}
+{{- include "satisfactory.defaultedDict" (dict "defaults" $defaults "given" . "path" "startupProbe") -}}
+{{- end -}}
+
+{{/*
+The effective resources block, fed into the resources helper above so that an
+erased "resources:" still yields the chart's requests and computed limits.
+The limitFactor default stays 2 here (not the repo-wide 3): the game server
+holds a large world in memory and the factor keeps the memory limit at the
+previously published 8Gi.
+*/}}
+{{- define "satisfactory.effectiveResources" -}}
+{{- $defaults := dict
+      "limitFactor" 2
+      "requests" (dict "memory" "4Gi" "cpu" "1" "ephemeral-storage" "5Gi") -}}
+{{- $merged := fromYaml (include "satisfactory.defaultedDict" (dict "defaults" $defaults "given" . "path" "server.resources")) -}}
+{{- include "satisfactory.resources" $merged -}}
+{{- end -}}

--- a/satisfactory/templates/satisfactory.sfs.yaml
+++ b/satisfactory/templates/satisfactory.sfs.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       automountServiceAccountToken: false
       securityContext:
-        {{- toYaml .Values.securityContext.pod | nindent 8 }}
+        {{- include "satisfactory.podSecurityContext" .Values.securityContext | nindent 8 }}
       containers:
         - name: {{ .Release.Name }}-{{ .Chart.Name }}-sfs
           image: "ghcr.io/wolveix/satisfactory-server:{{ .Chart.AppVersion }}"
@@ -73,13 +73,13 @@ spec:
               containerPort: {{ .Values.server.messagingPort }}
               protocol: TCP
           livenessProbe:
-            {{- toYaml .Values.livenessProbe | nindent 12 }}
+            {{- include "satisfactory.livenessProbe" .Values.livenessProbe | nindent 12 }}
           readinessProbe:
-            {{- toYaml .Values.readinessProbe | nindent 12 }}
+            {{- include "satisfactory.readinessProbe" .Values.readinessProbe | nindent 12 }}
           startupProbe:
-            {{- toYaml .Values.startupProbe | nindent 12 }}
+            {{- include "satisfactory.startupProbe" .Values.startupProbe | nindent 12 }}
           resources:
-            {{- include "satisfactory.resources" .Values.server.resources | nindent 12 }}
+            {{- include "satisfactory.effectiveResources" .Values.server.resources | nindent 12 }}
           volumeMounts:
             - name: satisfactory-volume
               mountPath: /config
@@ -104,7 +104,7 @@ spec:
             - name: tmp
               mountPath: /tmp
           securityContext:
-            {{- toYaml .Values.securityContext.container | nindent 12 }}
+            {{- include "satisfactory.containerSecurityContext" .Values.securityContext | nindent 12 }}
       volumes:
         - name: satisfactory-volume
           persistentVolumeClaim:

--- a/satisfactory/values.schema.json
+++ b/satisfactory/values.schema.json
@@ -1,0 +1,182 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "satisfactory values",
+  "description": "Strict values schema (issue #68). additionalProperties is false on every chart-owned object level, so a key that the chart does not read is rejected at render time instead of being silently ignored. The only objects that stay open are the ones passed verbatim into the Kubernetes pod spec (probes, security contexts, global) - the chart does not interpret their contents, so it cannot judge which keys are meaningful. The hardening, probe and resources blocks additionally accept null, because an erased block falls back to the chart defaults (issue #99). Note that this chart keeps env, probes and securityContext at the TOP level rather than under a chart-named key.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "global": {
+      "description": "Helm's conventional cross-chart values. Unused by this chart, kept open so an umbrella install cannot break on it.",
+      "type": "object"
+    },
+    "scaleDown": {
+      "type": "boolean"
+    },
+    "dev": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "debug": {
+          "description": "Passed to the image as DEBUG.",
+          "type": ["boolean", "string", "null"]
+        }
+      }
+    },
+    "game": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "experimental": {
+          "description": "Passed to the image as STEAMBETA - switches to the experimental game branch.",
+          "type": ["boolean", "string", "null"]
+        },
+        "maxPlayers": {
+          "type": ["integer", "string", "null"]
+        },
+        "seasonalEvents": {
+          "description": "Inverted by the chart into DISABLESEASONALEVENTS, so true means events are enabled.",
+          "type": ["boolean", "string", "null"]
+        }
+      }
+    },
+    "server": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "replicas": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "gamePort": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "messagingPort": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "storage": {
+          "description": "Size of the data PVC. Not null-safe on purpose: an erased value yields an invalid PVC rather than a silently degraded workload.",
+          "type": ["string", "null"]
+        },
+        "resources": {
+          "$ref": "#/definitions/resources"
+        }
+      }
+    },
+    "env": {
+      "$ref": "#/definitions/env"
+    },
+    "livenessProbe": {
+      "$ref": "#/definitions/probe"
+    },
+    "readinessProbe": {
+      "$ref": "#/definitions/probe"
+    },
+    "startupProbe": {
+      "$ref": "#/definitions/probe"
+    },
+    "securityContext": {
+      "$ref": "#/definitions/securityContext"
+    }
+  },
+  "definitions": {
+    "resources": {
+      "description": "May be null / empty: the chart then falls back to its default requests and computed limits (issue #99) instead of rendering a container without resource accounting. The default limitFactor is 2 here, not the repo-wide 3, to keep the memory limit at the previously published 8Gi.",
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "limitFactor": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "requests": {
+          "$ref": "#/definitions/resourceList"
+        },
+        "limits": {
+          "$ref": "#/definitions/resourceList"
+        }
+      }
+    },
+    "resourceList": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "cpu": {
+          "type": ["string", "number", "null"]
+        },
+        "memory": {
+          "type": ["string", "number", "null"]
+        },
+        "ephemeral-storage": {
+          "type": ["string", "number", "null"]
+        },
+        "ephemeralStorage": {
+          "type": ["string", "number", "null"]
+        }
+      }
+    },
+    "env": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "valueFrom": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "secretKeyRef": {
+                "$ref": "#/definitions/keyRef"
+              },
+              "configMapKeyRef": {
+                "$ref": "#/definitions/keyRef"
+              }
+            }
+          }
+        }
+      }
+    },
+    "keyRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "key"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        }
+      }
+    },
+    "securityContext": {
+      "description": "May be null / empty at any level: the chart then falls back to its hardening defaults (issue #99) instead of rendering an unhardened workload.",
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "pod": {
+          "description": "Merged onto the chart's pod hardening defaults and rendered as the pod's securityContext; kept open because the chart does not interpret the individual fields.",
+          "type": ["object", "null"]
+        },
+        "container": {
+          "description": "Merged onto the chart's container hardening defaults and rendered as the container's securityContext; kept open because the chart does not interpret the individual fields.",
+          "type": ["object", "null"]
+        }
+      }
+    },
+    "probe": {
+      "description": "Merged onto the chart's probe defaults and rendered as a container probe; kept open because the chart does not interpret the individual fields. May be null / empty, which means the defaults apply (issue #99) rather than the probe disappearing.",
+      "type": ["object", "null"]
+    }
+  }
+}


### PR DESCRIPTION
Sechstes Chart der **Welle 2** aus #68. **4.0.0 → 5.0.0** (major, appVersion unverändert bei `v1.9.10`).

**Kein Ingress-Gate** — dieses Chart hat keinen Ingress (Game- und Messaging-Port per NodePort). Prüfpunkt trotzdem über **beide** Quellen gelaufen, mit leerem Ergebnis:

```
$ grep -rn "ingress.domain" satisfactory/templates/   -> (none)
$ grep -n  "ingress.domain" satisfactory/values.yaml  -> (none)
```

**Dieses Chart steht in `ci/excluded-charts.txt`**, im Wortlaut:

```
satisfactory the game-server image is multiple GB and Steam downloads 10GB+ game files on first start - impractical on a CI runner
```

Der Install-Test greift hier also **nicht**. Der lokale Nachweis ist der einzige, deshalb ist er unten breiter angelegt als sonst — inklusive einer Validierung durch den **API-Server des echten Clusters**.

---

# 1. Strict `values.schema.json` (#68)

`additionalProperties: false` auf allen chart-eigenen Objektebenen: oberste Ebene, `dev`, `game`, `server`, `server.resources` mit `.requests`/`.limits`, `env[]` mit `valueFrom` und beiden KeyRefs, `securityContext`.

Wie teamspeak-server hält dieses Chart `env`, die Probes und `securityContext` auf der **obersten Ebene**; das Schema bildet die vorhandene Form ab.

Die Booleans (`dev.debug`, `game.experimental`, `game.seasonalEvents`) sind als Boolean **und** String erlaubt — sie landen als Env-Variablen im Container, und beide Schreibweisen sind in Werte-Dateien üblich.

`server.storage` bleibt **nicht** null-sicher: ein geleerter Wert ergibt eine ungültige PVC — laute Klasse.

# 2. Null-Absicherung für Härtung, Probes und Ressourcen (#99)

**Vier Dinge, die ein rekonstruierter Default hier nicht verlieren darf** — jedes einzeln nachgemessen:

1. **Liveness und Startup laufen per `exec` über das mitgelieferte Healthcheck-Skript.** Es fragt die HTTPS-API des Servers auf `SERVERGAMEPORT` ab und funktioniert deshalb auch bei überschriebenem Port — was ein `tcpSocket`-Default **nicht** leisten könnte. Die Defaults tragen das exec-Kommando mit.
2. **Readiness zielt auf den benannten Port `api`.**
3. **`limitFactor` bleibt 2**, nicht die repo-weite 3. Genau das hält das Memory-Limit bei den veröffentlichten 8Gi.
4. **Der Pod-Context behält `fsGroupChangePolicy: OnRootMismatch`** (statt `Always`). Das ist der Unterschied zwischen „Pod startet" und „Kubernetes chownt bei jedem Start mehrere GB Spieldaten rekursiv durch".

Punkt 3 und 4 sind der Grund, warum ich die Defaults nicht generisch aus dem Template-Chart übernommen habe: Beide weichen bewusst vom Repo-Standard ab, und ein „aufgeräumter" Default hätte hier real geschadet.

---

## Nachweis 1: erased Block → vorher, nachher

```yaml
securityContext:
  container:
livenessProbe:
server:
  resources:
    limits:
```

**Vorher** (`4.0.0`): `securityContext: null`, `livenessProbe: null`.

**Nachher**:

```yaml
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              add: []
              drop:
              - ALL
            readOnlyRootFilesystem: true
            runAsNonRoot: true
          ...
          livenessProbe:
            exec:
              command:
              - /bin/sh
              - -c
              - /home/steam/healthcheck.sh      # <- exec-Healthcheck erhalten
            failureThreshold: 4
            periodSeconds: 30
            successThreshold: 1
            timeoutSeconds: 10
          ...
          resources:
            limits:
              ephemeral-storage: 10Gi
              memory: 8Gi                        # <- Faktor 2, nicht 3
            requests:
              cpu: "1"
              ephemeral-storage: 5Gi
              memory: 4Gi
```

## Nachweis 2: ein bewusst gesetztes `false` / `0` gewinnt weiterhin

`--set securityContext.container.readOnlyRootFilesystem=false` → `false`, während `allowPrivilegeEscalation: false`, `drop: ALL` und `add: []` erhalten bleiben.

`--set livenessProbe.failureThreshold=0` → `0`, während das exec-Kommando und die übrigen Werte intakt bleiben.

## Nachweis 3: das Rendering ändert sich nicht — zweifach geprüft

Weil hier kein Install-Test greift, habe ich den Vergleich gegen **beide** relevanten Werte-Sätze gefahren:

```
$ diff <(helm template t <4.0.0>)              <(helm template t satisfactory)
(keine Ausgabe — byte-identisch)

$ diff <(helm template … <4.0.0> -f <Bundle-Werte>) <(helm template … satisfactory -f <Bundle-Werte>)
(keine Ausgabe — byte-identisch)
```

Also identisch sowohl mit Chart-Defaults als auch mit den produktiv ausgerollten Werten.

## Nachweis 4: der API-Server des echten Clusters akzeptiert die Manifeste

Ersatz für den fehlenden Install-Test — die gerenderten Manifeste gegen den laufenden Cluster, server-seitig validiert:

```
$ kubectl apply --dry-run=server -f <gerendert mit Bundle-Werten> -n satisfactory
persistentvolumeclaim/satisfactory-satisfactory-vc configured (server dry run)
service/satisfactory-satisfactory-service configured (server dry run)
statefulset.apps/satisfactory-satisfactory-sfs configured (server dry run)
```

Alle drei Objekte werden vom API-Server angenommen (Schema-, Feld- und Typprüfung inklusive). Das ersetzt keinen echten Start des Spielservers, deckt aber genau den Teil ab, den der Install-Test sonst prüfen würde: dass das Gerenderte gültiges Kubernetes ist.

## Verifikation

```
$ helm lint --strict satisfactory
1 chart(s) linted, 0 chart(s) failed
```

**Helper-Audit:** 13 aufgerufen, 13 definiert, `diff` der beiden Listen leer.

**Negativprobe — vier Ebenen:**

```
--set bogusTopLevel=true                     -> at '': 'bogusTopLevel' not allowed
--set server.resources.requests.bogusCpu=1   -> at '/server/resources/requests': 'bogusCpu' not allowed
--set game.maxPlayer=4                       -> at '/game': 'maxPlayer' not allowed      (Singular statt maxPlayers)
--set server.storageClass=longhorn           -> at '/server': 'storageClass' not allowed
```

Die letzte ist der realistischste Fall: Andere Charts dieses Repos haben `storageClass`, dieses hier **nicht** — es nutzt die Default-StorageClass. Ein hier gesetzter Wert verschwände heute wirkungslos.

## Validierung gegen die real ausgerollten Werte

Bundle `fleet-cd/satisfactory/`, Release `satisfactory`, gepinnt auf `4.0.0+upv1.9.10`.

Die Werte-Datei setzt `scaleDown: true` (Server nicht in Benutzung, PVC bleibt stehen), `game.experimental: false` und einen vollständigen `server.resources`-Block mit eigenen Requests **und** Limits.

**Liste abgewiesener Schlüssel: leer.** Gegengeprüft, dass die Stilllegung erhalten bleibt: Das Rendering mit den Bundle-Werten ergibt weiterhin `replicas: 0`. Vor dem Hochziehen auf `5.0.0` ist **nichts zu bereinigen**.

Refs #68, Refs #99.
