### PR TITLE
calibre-web-automated: strict values.schema.json + Ingress-Gate + Null-Absicherung (Welle 2, #68/#93/#99)

### DIFF
--- a/calibre-web-automated/Chart.yaml
+++ b/calibre-web-automated/Chart.yaml
@@ -5,7 +5,7 @@ name: calibre-web-automated
 description: A Helm chart to deploy calibere-web-automated
 icon: https://raw.githubusercontent.com/crocodilestick/Calibre-Web-Automated/main/README_images/cwa-logo-round-dark.png
 
-version: 4.0.0+upv4.0.6
+version: 5.0.0+upv4.0.6
 appVersion: v4.0.6
 
 maintainers:

--- a/calibre-web-automated/templates/_helpers.tpl
+++ b/calibre-web-automated/templates/_helpers.tpl
@@ -114,3 +114,173 @@ template-chart is the reference implementation.
 1
 {{- end -}}
 {{- end -}}
+
+{{/*
+Merge a user-supplied values sub-tree onto a dict of chart defaults so that a
+null / empty override falls back to the defaults instead of erasing them.
+
+Input: dict "defaults" <dict> "given" <dict|nil> "path" <string, optional
+values path used in error messages>. Output: YAML of the merged dict (consume
+it with fromYaml).
+
+Why this exists (issue #99): Helm merges values maps recursively, but an
+override key written without children — e.g. a leftover
+
+  securityContext:
+
+after deleting its last remaining sub-key — is YAML null. Where the chart
+defines a default, Helm treats that null as a deletion of the default; the
+template then renders "securityContext: null". The workload starts and reports
+healthy while being unhardened, so nothing points at the mistake. The same
+shape erases a probe (it disappears) or the resources block (no requests, no
+computed limits). This helper defines the opposite semantics: an empty block
+means "chart defaults apply".
+
+Rules:
+  - a nil "given" is treated as an empty dict (all defaults apply).
+  - a key whose override value is null keeps the default (nulls never delete).
+  - a key present in both as a map is merged recursively, so a partially
+    filled block only overrides the keys it actually sets.
+  - a scalar override for a key the defaults define as a map is rejected with
+    a message naming the values path, instead of failing later with a template
+    field error.
+  - any other set value wins as given, including an explicit false or 0 —
+    Helm's "default" and sprig's "mergeOverwrite" would both swallow those
+    zero values, hence the explicit kindIs "invalid" nil check.
+  - keys only present in the override are passed through unchanged.
+
+NOTE: like the helpers above, this is duplicated into every chart's
+templates/_helpers.tpl with the chart's name as define prefix, because charts
+in this repo deliberately have no dependencies.
+*/}}
+{{- define "calibre-web-automated.defaultedDict" -}}
+{{- $defaults := .defaults | default dict -}}
+{{- $given := .given -}}
+{{- $path := .path | default "value" -}}
+{{- if kindIs "invalid" $given -}}
+{{- $given = dict -}}
+{{- end -}}
+{{- if not (kindIs "map" $given) -}}
+{{- fail (printf "%s must be a mapping or null, got %s (%v)" $path (kindOf $given) $given) -}}
+{{- end -}}
+{{- $out := deepCopy $defaults -}}
+{{- range $key, $value := $given -}}
+{{- if not (kindIs "invalid" $value) -}}
+{{- $default := index $defaults $key -}}
+{{- if and (kindIs "map" $value) (kindIs "map" $default) -}}
+{{- $_ := set $out $key (fromYaml (include "calibre-web-automated.defaultedDict" (dict "defaults" $default "given" $value "path" (printf "%s.%s" $path $key)))) -}}
+{{- else if kindIs "map" $default -}}
+{{- fail (printf "%s.%s must be a mapping or null, got %s (%v)" $path $key (kindOf $value) $value) -}}
+{{- else -}}
+{{- $_ := set $out $key $value -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- toYaml $out -}}
+{{- end -}}
+
+{{/*
+Pick one sub-block out of a values block that may itself be null.
+
+Input: dict "block" <dict|nil> "key" <string> "path" <string>.
+Returns YAML of dict "value" <the sub-block, may be nil>, after rejecting a
+non-mapping block with a message that names the values path. Needed because
+".Values.cwa.securityContext" can itself be erased.
+*/}}
+{{- define "calibre-web-automated.subBlock" -}}
+{{- $block := .block -}}
+{{- if kindIs "invalid" $block -}}
+{{- $block = dict -}}
+{{- end -}}
+{{- if not (kindIs "map" $block) -}}
+{{- fail (printf "%s must be a mapping or null, got %s (%v)" .path (kindOf $block) $block) -}}
+{{- end -}}
+{{- toYaml (dict "value" (index $block .key)) -}}
+{{- end -}}
+
+{{/*
+The effective security contexts, probes and resources (issue #99).
+
+The defaults below MUST stay in sync with the corresponding blocks in
+values.yaml, which stays the documented, user-facing place for them; this copy
+is only the fallback for the case where an override has erased the block.
+
+IMPORTANT - this chart's hardening is a DOCUMENTED DEVIATION from the repo
+standard, and these fallbacks reproduce it exactly rather than "cleaning it
+up". Restoring the repo-standard hardening here would break the workload:
+
+  - No runAsNonRoot / runAsUser / runAsGroup: the CWA image boots via the
+    s6-overlay init system, whose stage-1/2 setup runs as uid 0 and then drops
+    the application to the PUID/PGID user (1000).
+  - readOnlyRootFilesystem stays false: in read-only mode the image disables
+    the PUID/PGID remapping, so the runtime uid would silently change from
+    1000 to the built-in 911 and break existing volume data, and its init
+    fails to write the ImageMagick policy under /etc.
+  - capabilities.add is NOT empty: the s6 init/supervision needs
+    CHOWN/DAC_OVERRIDE/FOWNER/SETGID/SETUID for the ownership fix-up and the
+    root->PUID drop, plus KILL so the root supervisor can signal the uid-1000
+    services (without it the pod cannot shut down cleanly and gets SIGKILLed).
+    Verified against v4.0.6.
+  - The pod context sets only fsGroup / fsGroupChangePolicy, no runAs* values.
+
+The probes address the container port by its name ("http"), so a rebuilt
+default probe needs no further context.
+*/}}
+{{- define "calibre-web-automated.podSecurityContext" -}}
+{{- $given := (fromYaml (include "calibre-web-automated.subBlock" (dict "block" . "key" "pod" "path" "cwa.securityContext"))).value -}}
+{{- $defaults := dict
+      "fsGroup" 1000
+      "fsGroupChangePolicy" "Always" -}}
+{{- include "calibre-web-automated.defaultedDict" (dict "defaults" $defaults "given" $given "path" "cwa.securityContext.pod") -}}
+{{- end -}}
+
+{{- define "calibre-web-automated.containerSecurityContext" -}}
+{{- $given := (fromYaml (include "calibre-web-automated.subBlock" (dict "block" . "key" "container" "path" "cwa.securityContext"))).value -}}
+{{- $defaults := dict
+      "allowPrivilegeEscalation" false
+      "readOnlyRootFilesystem" false
+      "capabilities" (dict
+        "drop" (list "ALL")
+        "add" (list "CHOWN" "DAC_OVERRIDE" "FOWNER" "KILL" "SETGID" "SETUID")) -}}
+{{- include "calibre-web-automated.defaultedDict" (dict "defaults" $defaults "given" $given "path" "cwa.securityContext.container") -}}
+{{- end -}}
+
+{{- define "calibre-web-automated.livenessProbe" -}}
+{{- $defaults := dict
+      "httpGet" (dict "path" "/" "port" "http")
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 3 -}}
+{{- include "calibre-web-automated.defaultedDict" (dict "defaults" $defaults "given" . "path" "cwa.livenessProbe") -}}
+{{- end -}}
+
+{{- define "calibre-web-automated.readinessProbe" -}}
+{{- $defaults := dict
+      "httpGet" (dict "path" "/" "port" "http")
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 3 -}}
+{{- include "calibre-web-automated.defaultedDict" (dict "defaults" $defaults "given" . "path" "cwa.readinessProbe") -}}
+{{- end -}}
+
+{{- define "calibre-web-automated.startupProbe" -}}
+{{- $defaults := dict
+      "httpGet" (dict "path" "/" "port" "http")
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 30 -}}
+{{- include "calibre-web-automated.defaultedDict" (dict "defaults" $defaults "given" . "path" "cwa.startupProbe") -}}
+{{- end -}}
+
+{{/*
+The effective resources block, fed into the resources helper above so that an
+erased "resources:" still yields the chart's requests and computed limits
+instead of a container without any resource accounting.
+*/}}
+{{- define "calibre-web-automated.effectiveResources" -}}
+{{- $defaults := dict
+      "limitFactor" 3
+      "requests" (dict "cpu" 0.1 "memory" "512Mi" "ephemeralStorage" "100Mi") -}}
+{{- $merged := fromYaml (include "calibre-web-automated.defaultedDict" (dict "defaults" $defaults "given" . "path" "cwa.resources")) -}}
+{{- include "calibre-web-automated.resources" $merged -}}
+{{- end -}}

--- a/calibre-web-automated/templates/calibre-web-automated.ingress.yaml
+++ b/calibre-web-automated/templates/calibre-web-automated.ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -26,3 +27,4 @@ spec:
     - hosts:
         - {{ required "A Domain/Host must be provided" .Values.ingress.domain }}
       secretName: tls-{{ .Release.Name }}-{{ .Chart.Name }}-ingress
+{{- end }}

--- a/calibre-web-automated/templates/calibre-web-automated.sfs.yaml
+++ b/calibre-web-automated/templates/calibre-web-automated.sfs.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       automountServiceAccountToken: false
       securityContext:
-        {{- toYaml .Values.cwa.securityContext.pod | nindent 8 }}
+        {{- include "calibre-web-automated.podSecurityContext" .Values.cwa.securityContext | nindent 8 }}
       containers:
         - name: {{ .Release.Name }}-{{ .Chart.Name }}-container
           image: "ghcr.io/crocodilestick/calibre-web-automated:{{ .Chart.AppVersion }}"
@@ -79,15 +79,15 @@ spec:
             - mountPath: "/cwa-book-ingest"
               name: cwa-consume
           livenessProbe:
-            {{- toYaml .Values.cwa.livenessProbe | nindent 12 }}
+            {{- include "calibre-web-automated.livenessProbe" .Values.cwa.livenessProbe | nindent 12 }}
           readinessProbe:
-            {{- toYaml .Values.cwa.readinessProbe | nindent 12 }}
+            {{- include "calibre-web-automated.readinessProbe" .Values.cwa.readinessProbe | nindent 12 }}
           startupProbe:
-            {{- toYaml .Values.cwa.startupProbe | nindent 12 }}
+            {{- include "calibre-web-automated.startupProbe" .Values.cwa.startupProbe | nindent 12 }}
           resources:
-            {{- include "calibre-web-automated.resources" .Values.cwa.resources | nindent 12 }}
+            {{- include "calibre-web-automated.effectiveResources" .Values.cwa.resources | nindent 12 }}
           securityContext:
-            {{- toYaml .Values.cwa.securityContext.container | nindent 12 }}
+            {{- include "calibre-web-automated.containerSecurityContext" .Values.cwa.securityContext | nindent 12 }}
       restartPolicy: Always
       volumes:
         # Deliberate naming exception (see README): both PVCs keep their

--- a/calibre-web-automated/values.schema.json
+++ b/calibre-web-automated/values.schema.json
@@ -1,0 +1,188 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "calibre-web-automated values",
+  "description": "Strict values schema (issue #68). additionalProperties is false on every chart-owned object level, so a key that the chart does not read is rejected at render time instead of being silently ignored. The only objects that stay open are the ones passed verbatim into the Kubernetes pod spec (probes, security contexts, global) - the chart does not interpret their contents, so it cannot judge which keys are meaningful. The hardening, probe and resources blocks additionally accept null, because an erased block falls back to the chart defaults (issue #99).",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "global": {
+      "description": "Helm's conventional cross-chart values. Unused by this chart, kept open so an umbrella install cannot break on it.",
+      "type": "object"
+    },
+    "scaleDown": {
+      "type": "boolean"
+    },
+    "secrets": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "cwaSecretRef": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "cwa": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "replicas": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "storage": {
+          "description": "Size of the library PVC. Not null-safe on purpose: an erased value yields an invalid PVC rather than a silently degraded workload.",
+          "type": ["string", "null"]
+        },
+        "storageClass": {
+          "type": ["string", "null"]
+        },
+        "timezone": {
+          "description": "Passed to the image as TZ.",
+          "type": ["string", "null"]
+        },
+        "maxUploadFileSize": {
+          "description": "Rendered into the ingress-nginx proxy-body-size annotation, so it only takes effect while the Ingress is enabled.",
+          "type": ["string", "null"]
+        },
+        "livenessProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "readinessProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "startupProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "resources": {
+          "$ref": "#/definitions/resources"
+        },
+        "securityContext": {
+          "$ref": "#/definitions/securityContext"
+        },
+        "env": {
+          "$ref": "#/definitions/env"
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "description": "Gates the whole Ingress template (issue #93). ingress.domain is read nowhere else in this chart, so switching the Ingress off makes both domain and clusterIssuer unnecessary.",
+          "type": "boolean"
+        },
+        "clusterIssuer": {
+          "type": ["string", "null"]
+        },
+        "domain": {
+          "type": ["string", "null"]
+        },
+        "className": {
+          "type": ["string", "null"]
+        },
+        "annotations": {
+          "description": "Extra Ingress annotations, merged with the cert-manager and proxy-body-size annotations the chart always sets. Free-form keys by nature.",
+          "type": "object"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "resources": {
+      "description": "May be null / empty: the chart then falls back to its default requests and computed limits (issue #99) instead of rendering a container without resource accounting.",
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "limitFactor": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "requests": {
+          "$ref": "#/definitions/resourceList"
+        },
+        "limits": {
+          "$ref": "#/definitions/resourceList"
+        }
+      }
+    },
+    "resourceList": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "cpu": {
+          "type": ["string", "number", "null"]
+        },
+        "memory": {
+          "type": ["string", "number", "null"]
+        },
+        "ephemeral-storage": {
+          "type": ["string", "number", "null"]
+        },
+        "ephemeralStorage": {
+          "type": ["string", "number", "null"]
+        }
+      }
+    },
+    "env": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "valueFrom": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "secretKeyRef": {
+                "$ref": "#/definitions/keyRef"
+              },
+              "configMapKeyRef": {
+                "$ref": "#/definitions/keyRef"
+              }
+            }
+          }
+        }
+      }
+    },
+    "keyRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "key"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        }
+      }
+    },
+    "securityContext": {
+      "description": "May be null / empty at any level: the chart then falls back to its hardening defaults (issue #99). Note that this chart's hardening is a documented deviation from the repo standard (s6-overlay needs a root init, a writable root filesystem and a non-empty capabilities.add), and the fallbacks reproduce that deviation exactly.",
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "pod": {
+          "description": "Merged onto the chart's pod defaults and rendered as the pod's securityContext; kept open because the chart does not interpret the individual fields.",
+          "type": ["object", "null"]
+        },
+        "container": {
+          "description": "Merged onto the chart's container defaults and rendered as the container's securityContext; kept open because the chart does not interpret the individual fields.",
+          "type": ["object", "null"]
+        }
+      }
+    },
+    "probe": {
+      "description": "Merged onto the chart's probe defaults and rendered as a container probe; kept open because the chart does not interpret the individual fields. May be null / empty, which means the defaults apply (issue #99) rather than the probe disappearing.",
+      "type": ["object", "null"]
+    }
+  }
+}

--- a/calibre-web-automated/values.yaml
+++ b/calibre-web-automated/values.yaml
@@ -84,6 +84,10 @@ cwa:
   env: []
 
 ingress:
+  # Set to false to omit the Ingress entirely. Unlike some other charts here,
+  # ingress.domain is read nowhere but in the Ingress template, so switching
+  # the Ingress off makes both domain and clusterIssuer unnecessary.
+  enabled: true
   clusterIssuer: null
   domain: null
   className: nginx


### PR DESCRIPTION
Siebtes Chart der **Welle 2** aus #68. **4.0.0 → 5.0.0** (major, appVersion unverändert bei `v4.0.6`). Alle drei Änderungen.

---

# 1. Strict `values.schema.json` (#68)

`additionalProperties: false` auf allen chart-eigenen Objektebenen: oberste Ebene, `cwa`, `cwa.resources` mit `.requests`/`.limits`, `env[]` mit `valueFrom` und beiden KeyRefs, `securityContext`, `ingress`, `secrets`.

`cwa.storage` bleibt **nicht** null-sicher: ein geleerter Wert ergibt eine ungültige PVC — laute Klasse.

# 2. Ingress-Gate (#93)

Ingress-Template gegatet, `ingress.enabled` mit Default `true`.

### Der Prüfpunkt liefert hier erstmals ein negatives Ergebnis — und das ist die Nachricht

Seit rallly prüfe ich vor jedem Gate-Einbau, ob `ingress.domain` außerhalb des Ingress-Templates gelesen wird, **in `values.yaml` und in `templates/`**. Bei calibre-web-automated ist die Antwort: **nein**.

```
$ grep -rn "ingress.domain" calibre-web-automated/templates/   -> nur die Ingress-Datei
$ grep -n  "ingress.domain" calibre-web-automated/values.yaml  -> (none)
```

Anders als bei rallly (`NEXT_PUBLIC_BASE_URL`), zipline (`CORE_DEFAULT_DOMAIN`), voucher-vault (`DOMAIN`) und outline (`URL`) braucht es hier also **keine** zusätzliche Absicherung, und das Gate befreit tatsächlich von **beiden** Werten — wie bei cyberchef.

Das ist ausdrücklich erwähnenswert, damit aus der Reihe der letzten Charts keine Faustregel wird: „Das Gate befreit nie von `domain`" gilt **dort, wo der Wert außerhalb gelesen wird**. Ob das so ist, ist zu prüfen, nicht anzunehmen — in beide Richtungen.

Belegt in beide Richtungen, `ingress.enabled=false` ohne `domain` **und** ohne `clusterIssuer`:

| | Ergebnis |
|---|---|
| **vorher** (`4.0.0`, ohne Gate) | `Error: A Cluster-Issuer must be provided` |
| **nachher** | rendert (exit 0), **0** Ingress-Objekte |

# 3. Null-Absicherung für Härtung, Probes und Ressourcen (#99)

**Der heikelste Fall der ganzen Welle.** Die Härtung dieses Charts ist eine **dokumentierte Abweichung** vom Repo-Standard, und die Fallbacks bilden sie exakt ab, statt den Standard „wiederherzustellen":

- **Keine `runAs*`-Werte.** Das CWA-Image (linuxserver.io-Stil) bootet über s6-overlay, dessen Stage-1/2-Setup als uid 0 läuft und die Anwendung anschließend auf PUID/PGID 1000 fallen lässt.
- **`readOnlyRootFilesystem` bleibt `false`.** Im Read-only-Modus deaktiviert das Image die PUID/PGID-Remappung — die Laufzeit-uid würde still von 1000 auf die eingebaute 911 wechseln und **bestehende Volume-Daten unbrauchbar machen**; zusätzlich scheitert die Init beim Schreiben der ImageMagick-Policy unter `/etc`.
- **`capabilities.add` ist nicht leer**, sondern trägt sechs Einträge, die s6 für den Ownership-Fix-up, den root→PUID-Drop und das Signalisieren der uid-1000-Dienste braucht (`KILL`; ohne ihn fährt der Pod nicht sauber herunter und wird SIGKILLed). Gegen v4.0.6 verifiziert.
- **Der Pod-Context setzt nur `fsGroup`/`fsGroupChangePolicy`**, keine `runAs*`-Werte.

Ein „aufgeräumter" Standard-Default wäre hier kein Aufräumen, sondern ein Ausfall — und zwar einer, der erst beim nächsten Pod-Start sichtbar würde.

**Nachgewiesen**, `cwa.securityContext.container` geleert — vorher `securityContext: null`, nachher:

```yaml
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              add:
              - CHOWN
              - DAC_OVERRIDE
              - FOWNER
              - KILL
              - SETGID
              - SETUID
              drop:
              - ALL
            readOnlyRootFilesystem: false
```

Und der Pod-Context bei geleertem `cwa.securityContext` — weiterhin **ohne** `runAs*`:

```yaml
      securityContext:
        fsGroup: 1000
        fsGroupChangePolicy: Always
```

**Probe-Kontext geprüft:** Die Probes adressieren den Port über seinen Namen (`http`), kein Zusatzkontext nötig. **Wächter geprüft:** keine — die Blöcke stehen ohne `{{- if }}` im Template.

---

## Nachweis 2: ein bewusst gesetztes `false` / `0` gewinnt weiterhin

Hier besonders aussagekräftig, weil der Chart-Default schon `false` ist: `--set cwa.securityContext.container.readOnlyRootFilesystem=true` rendert `readOnlyRootFilesystem: true`. Ein gesetzter Wert gewinnt also auch dann, wenn er vom Default **abweicht und der Default selbst ein Zero-Value ist**.

`--set cwa.startupProbe.failureThreshold=0` → `failureThreshold: 0`, restliche Probe-Defaults intakt.

## Nachweis 3: das Rendering ändert sich nicht

```
$ diff <(helm template t <4.0.0> -f ci/calibre-web-automated/test-values.yaml) \
       <(helm template t calibre-web-automated -f ci/calibre-web-automated/test-values.yaml)
(keine Ausgabe — byte-identisch)
```

Ohne Ausnahme: Dieser PR fügt keinen Kommentar ins Template ein.

## Verifikation

```
$ helm lint --strict calibre-web-automated
1 chart(s) linted, 0 chart(s) failed
```

**Helper-Audit:** 12 aufgerufen, 12 definiert, `diff` leer.

**Negativprobe — vier Ebenen:**

```
--set bogusTopLevel=true                  -> at '': 'bogusTopLevel' not allowed
--set cwa.resources.requests.bogusCpu=1   -> at '/cwa/resources/requests': 'bogusCpu' not allowed
--set ingress.enable=false                -> at '/ingress': 'enable' not allowed   (Tippfehler des Gate-Schlüssels)
--set cwa.timeZone=UTC                    -> at '/cwa': 'timeZone' not allowed     (Schlüssel heißt timezone)
```

---

## Validierung gegen die real ausgerollten Werte — **hier ist etwas zu tun**

Bundle `fleet-cd/calibre-web-automated/`, Release `calibre-web-automated` (Namespace `calibre-web`), gepinnt auf `3.1.0+upv4.0.6`.

**Liste abgewiesener Schlüssel: leer** — alle gesetzten Schlüssel sind bekannt. **Aber** die Bundle-Datei hat ein anderes Problem, und es ist dasselbe wie bei urlaubsverwaltung:

```
$ helm template … -f fleet-cd/calibre-web-automated/calibre-web-automated.values.yaml
Error: execution error at (…/calibre-web-automated.ingress.yaml:7:39):
A Cluster-Issuer must be provided
```

**Die Bundle-Datei setzt kein `ingress.clusterIssuer`.** Das ist kein Schaden dieses PRs — gegen den veröffentlichten `4.0.0` scheitert sie mit derselben Meldung (nur eine Zeilennummer früher, weil das Gate fehlt).

Bemerkenswert ist der Vergleich mit dem **ausgerollten** Stand:

```
$ helm get values calibre-web-automated -n calibre-web
ingress:
  clusterIssuer: letsencrypt-issuer     # <- im Live-Release vorhanden
  domain: books.jk-dev.de
```

Das Live-Release **hat** den Wert, die Bundle-Datei im Repo **nicht**. Beide sind hier also nicht deckungsgleich — der dritte Fall dieser Art nach urlaubsverwaltung und zipline, und wieder in dieselbe Richtung: Die gepflegte Datei ist schlechter als der ausgerollte Zustand, nicht besser.

**Arbeitsanweisung für die Cluster-Seite:** In `fleet-cd/calibre-web-automated/calibre-web-automated.values.yaml` ergänzen, **bevor** das Chart über `3.1.0+upv4.0.6` hinaus hochgezogen wird:

```yaml
ingress:
  clusterIssuer: letsencrypt-issuer   # am Live-Release abgelesen
  domain: books.jk-dev.de             # bleibt
```

Mit ergänztem Wert rendert das Bundle sauber durch (exit 0); die **Live-Werte** rendern schon heute ohne Änderung durch.

Refs #68, Refs #93, Refs #99.
