### PR TITLE
samba: strict values.schema.json + Null-Absicherung (Welle 2, #68/#99)

### DIFF
--- a/samba/Chart.yaml
+++ b/samba/Chart.yaml
@@ -5,6 +5,6 @@ icon: https://avatars.githubusercontent.com/u/13281359
 
 type: application
 
-version: 5.0.0+up4.23.10
+version: 6.0.0+up4.23.10
 
 appVersion: 4.23.10

--- a/samba/templates/_helpers.tpl
+++ b/samba/templates/_helpers.tpl
@@ -114,3 +114,168 @@ template-chart is the reference implementation.
 1
 {{- end -}}
 {{- end -}}
+
+{{/*
+Merge a user-supplied values sub-tree onto a dict of chart defaults so that a
+null / empty override falls back to the defaults instead of erasing them.
+
+Input: dict "defaults" <dict> "given" <dict|nil> "path" <string, optional
+values path used in error messages>. Output: YAML of the merged dict (consume
+it with fromYaml).
+
+Why this exists (issue #99): Helm merges values maps recursively, but an
+override key written without children — e.g. a leftover
+
+  securityContext:
+
+after deleting its last remaining sub-key — is YAML null. Where the chart
+defines a default, Helm treats that null as a deletion of the default; the
+template then renders "securityContext: null". The workload starts and reports
+healthy while being unhardened, so nothing points at the mistake. The same
+shape erases a probe (it disappears) or the resources block (no requests, no
+computed limits). This helper defines the opposite semantics: an empty block
+means "chart defaults apply".
+
+Rules:
+  - a nil "given" is treated as an empty dict (all defaults apply).
+  - a key whose override value is null keeps the default (nulls never delete).
+  - a key present in both as a map is merged recursively, so a partially
+    filled block only overrides the keys it actually sets.
+  - a scalar override for a key the defaults define as a map is rejected with
+    a message naming the values path, instead of failing later with a template
+    field error.
+  - any other set value wins as given, including an explicit false or 0 —
+    Helm's "default" and sprig's "mergeOverwrite" would both swallow those
+    zero values, hence the explicit kindIs "invalid" nil check.
+  - keys only present in the override are passed through unchanged.
+
+NOTE: like the helpers above, this is duplicated into every chart's
+templates/_helpers.tpl with the chart's name as define prefix, because charts
+in this repo deliberately have no dependencies.
+*/}}
+{{- define "samba.defaultedDict" -}}
+{{- $defaults := .defaults | default dict -}}
+{{- $given := .given -}}
+{{- $path := .path | default "value" -}}
+{{- if kindIs "invalid" $given -}}
+{{- $given = dict -}}
+{{- end -}}
+{{- if not (kindIs "map" $given) -}}
+{{- fail (printf "%s must be a mapping or null, got %s (%v)" $path (kindOf $given) $given) -}}
+{{- end -}}
+{{- $out := deepCopy $defaults -}}
+{{- range $key, $value := $given -}}
+{{- if not (kindIs "invalid" $value) -}}
+{{- $default := index $defaults $key -}}
+{{- if and (kindIs "map" $value) (kindIs "map" $default) -}}
+{{- $_ := set $out $key (fromYaml (include "samba.defaultedDict" (dict "defaults" $default "given" $value "path" (printf "%s.%s" $path $key)))) -}}
+{{- else if kindIs "map" $default -}}
+{{- fail (printf "%s.%s must be a mapping or null, got %s (%v)" $path $key (kindOf $value) $value) -}}
+{{- else -}}
+{{- $_ := set $out $key $value -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- toYaml $out -}}
+{{- end -}}
+
+{{/*
+Pick one sub-block out of a values block that may itself be null.
+
+Input: dict "block" <dict|nil> "key" <string> "path" <string>.
+Returns YAML of dict "value" <the sub-block, may be nil>, after rejecting a
+non-mapping block with a message that names the values path. Needed because
+".Values.samba.securityContext" can itself be erased.
+*/}}
+{{- define "samba.subBlock" -}}
+{{- $block := .block -}}
+{{- if kindIs "invalid" $block -}}
+{{- $block = dict -}}
+{{- end -}}
+{{- if not (kindIs "map" $block) -}}
+{{- fail (printf "%s must be a mapping or null, got %s (%v)" .path (kindOf $block) $block) -}}
+{{- end -}}
+{{- toYaml (dict "value" (index $block .key)) -}}
+{{- end -}}
+
+{{/*
+The effective security contexts, probes and resources (issue #99).
+
+The defaults below MUST stay in sync with the corresponding blocks in
+values.yaml, which stays the documented, user-facing place for them; this copy
+is only the fallback for the case where an override has erased the block.
+
+IMPORTANT - this chart's hardening is a DOCUMENTED DEVIATION forced by the
+ghcr.io/dockur/samba image, and these fallbacks reproduce it exactly rather
+than restoring the repo standard, which would break the file server:
+
+  - No runAsNonRoot: the entrypoint creates the Unix users from users.conf
+    (groupadd/adduser/usermod) and smbd impersonates the authenticated share
+    user per session; both require starting as root.
+  - readOnlyRootFilesystem stays false: the entrypoint writes /etc/passwd and
+    /etc/group, the /etc/samba.conf healthcheck symlink, mkdir /shared and the
+    Samba TDB databases under /var/lib/samba.
+  - capabilities.add is NOT empty: NET_BIND_SERVICE (ports 445/139),
+    SETUID/SETGID (per-session impersonation) and CHOWN/FOWNER/DAC_OVERRIDE
+    (managing share files on behalf of the users).
+  - The pod context sets only fsGroup, no runAs* values.
+
+SMB is not an HTTP protocol, so the probes target the SMB TCP port directly.
+*/}}
+{{- define "samba.podSecurityContext" -}}
+{{- $given := (fromYaml (include "samba.subBlock" (dict "block" . "key" "pod" "path" "samba.securityContext"))).value -}}
+{{- $defaults := dict
+      "fsGroup" 1000 -}}
+{{- include "samba.defaultedDict" (dict "defaults" $defaults "given" $given "path" "samba.securityContext.pod") -}}
+{{- end -}}
+
+{{- define "samba.containerSecurityContext" -}}
+{{- $given := (fromYaml (include "samba.subBlock" (dict "block" . "key" "container" "path" "samba.securityContext"))).value -}}
+{{- $defaults := dict
+      "allowPrivilegeEscalation" false
+      "readOnlyRootFilesystem" false
+      "capabilities" (dict
+        "drop" (list "ALL")
+        "add" (list "CHOWN" "DAC_OVERRIDE" "FOWNER" "NET_BIND_SERVICE" "SETGID" "SETUID")) -}}
+{{- include "samba.defaultedDict" (dict "defaults" $defaults "given" $given "path" "samba.securityContext.container") -}}
+{{- end -}}
+
+{{- define "samba.livenessProbe" -}}
+{{- $defaults := dict
+      "tcpSocket" (dict "port" 445)
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 3 -}}
+{{- include "samba.defaultedDict" (dict "defaults" $defaults "given" . "path" "samba.livenessProbe") -}}
+{{- end -}}
+
+{{- define "samba.readinessProbe" -}}
+{{- $defaults := dict
+      "tcpSocket" (dict "port" 445)
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 3 -}}
+{{- include "samba.defaultedDict" (dict "defaults" $defaults "given" . "path" "samba.readinessProbe") -}}
+{{- end -}}
+
+{{- define "samba.startupProbe" -}}
+{{- $defaults := dict
+      "tcpSocket" (dict "port" 445)
+      "periodSeconds" 5
+      "timeoutSeconds" 5
+      "failureThreshold" 30 -}}
+{{- include "samba.defaultedDict" (dict "defaults" $defaults "given" . "path" "samba.startupProbe") -}}
+{{- end -}}
+
+{{/*
+The effective resources block, fed into the resources helper above so that an
+erased "resources:" still yields the chart's requests and computed limits
+instead of a container without any resource accounting.
+*/}}
+{{- define "samba.effectiveResources" -}}
+{{- $defaults := dict
+      "limitFactor" 3
+      "requests" (dict "memory" "50Mi" "cpu" 0.1 "ephemeralStorage" "50Mi") -}}
+{{- $merged := fromYaml (include "samba.defaultedDict" (dict "defaults" $defaults "given" . "path" "samba.resources")) -}}
+{{- include "samba.resources" $merged -}}
+{{- end -}}

--- a/samba/templates/samba.sfs.yaml
+++ b/samba/templates/samba.sfs.yaml
@@ -73,19 +73,19 @@ spec:
               mountPath: "/shares/{{ $value.name }}"
             {{- end }}
           livenessProbe:
-            {{- toYaml .Values.samba.livenessProbe | nindent 12 }}
+            {{- include "samba.livenessProbe" .Values.samba.livenessProbe | nindent 12 }}
           readinessProbe:
-            {{- toYaml .Values.samba.readinessProbe | nindent 12 }}
+            {{- include "samba.readinessProbe" .Values.samba.readinessProbe | nindent 12 }}
           startupProbe:
-            {{- toYaml .Values.samba.startupProbe | nindent 12 }}
+            {{- include "samba.startupProbe" .Values.samba.startupProbe | nindent 12 }}
           resources:
-            {{- include "samba.resources" .Values.samba.resources | nindent 12 }}
+            {{- include "samba.effectiveResources" .Values.samba.resources | nindent 12 }}
           securityContext:
-            {{- toYaml .Values.samba.securityContext.container | nindent 12 }}
+            {{- include "samba.containerSecurityContext" .Values.samba.securityContext | nindent 12 }}
       restartPolicy: Always
       automountServiceAccountToken: false
       securityContext:
-        {{- toYaml .Values.samba.securityContext.pod | nindent 8 }}
+        {{- include "samba.podSecurityContext" .Values.samba.securityContext | nindent 8 }}
       volumes:
         - name: smb-config
           configMap:

--- a/samba/values.schema.json
+++ b/samba/values.schema.json
@@ -1,0 +1,192 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "samba values",
+  "description": "Strict values schema (issue #68). additionalProperties is false on every chart-owned object level, so a key that the chart does not read is rejected at render time instead of being silently ignored. The only objects that stay open are the ones passed verbatim into the Kubernetes pod spec (probes, security contexts, global) - the chart does not interpret their contents, so it cannot judge which keys are meaningful. The hardening, probe and resources blocks additionally accept null, because an erased block falls back to the chart defaults (issue #99).",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "global": {
+      "description": "Helm's conventional cross-chart values. Unused by this chart, kept open so an umbrella install cannot break on it.",
+      "type": "object"
+    },
+    "scaleDown": {
+      "type": "boolean"
+    },
+    "secrets": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "sambaUsersSecretRef": {
+          "description": "op:// item path for the users.conf Secret. Note the exact name: a shortened 'sambaUsersRef' is NOT read by the chart.",
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "samba": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "replicas": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "smbNodePort": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "netbiosNodePort": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "shares": {
+          "description": "One SMB share per entry. Each entry drives a share section in smb.conf, a PVC and a volumeMount, so the list is part of the pod template - changing it restarts the workload by design.",
+          "type": ["array", "null"],
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": ["string", "null"]
+              },
+              "validUsers": {
+                "description": "Comma-separated user list, rendered as 'valid users' in the share section.",
+                "type": ["string", "null"]
+              },
+              "description": {
+                "type": ["string", "null"]
+              },
+              "size": {
+                "description": "Size of the PVC provisioned for this share.",
+                "type": ["string", "null"]
+              }
+            }
+          }
+        },
+        "env": {
+          "$ref": "#/definitions/env"
+        },
+        "livenessProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "readinessProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "startupProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "resources": {
+          "$ref": "#/definitions/resources"
+        },
+        "securityContext": {
+          "$ref": "#/definitions/securityContext"
+        },
+        "globalConfig": {
+          "description": "Currently read by no template - see the note in the PR that introduced this schema. Kept allowed because it is part of the published values surface; whether it gets implemented or removed is a separate decision.",
+          "type": ["string", "null"]
+        },
+        "storageClass": {
+          "type": ["string", "null"]
+        }
+      }
+    }
+  },
+  "definitions": {
+    "resources": {
+      "description": "May be null / empty: the chart then falls back to its default requests and computed limits (issue #99) instead of rendering a container without resource accounting.",
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "limitFactor": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "requests": {
+          "$ref": "#/definitions/resourceList"
+        },
+        "limits": {
+          "$ref": "#/definitions/resourceList"
+        }
+      }
+    },
+    "resourceList": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "cpu": {
+          "type": ["string", "number", "null"]
+        },
+        "memory": {
+          "type": ["string", "number", "null"]
+        },
+        "ephemeral-storage": {
+          "type": ["string", "number", "null"]
+        },
+        "ephemeralStorage": {
+          "type": ["string", "number", "null"]
+        }
+      }
+    },
+    "env": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "valueFrom": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "secretKeyRef": {
+                "$ref": "#/definitions/keyRef"
+              },
+              "configMapKeyRef": {
+                "$ref": "#/definitions/keyRef"
+              }
+            }
+          }
+        }
+      }
+    },
+    "keyRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "key"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        }
+      }
+    },
+    "securityContext": {
+      "description": "May be null / empty at any level: the chart then falls back to its hardening defaults (issue #99). Note that this chart's hardening is a documented deviation forced by the image (root start for user creation and per-session impersonation, writable root filesystem, non-empty capabilities.add), and the fallbacks reproduce that deviation exactly.",
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "pod": {
+          "description": "Merged onto the chart's pod defaults and rendered as the pod's securityContext; kept open because the chart does not interpret the individual fields.",
+          "type": ["object", "null"]
+        },
+        "container": {
+          "description": "Merged onto the chart's container defaults and rendered as the container's securityContext; kept open because the chart does not interpret the individual fields.",
+          "type": ["object", "null"]
+        }
+      }
+    },
+    "probe": {
+      "description": "Merged onto the chart's probe defaults and rendered as a container probe; kept open because the chart does not interpret the individual fields. May be null / empty, which means the defaults apply (issue #99) rather than the probe disappearing.",
+      "type": ["object", "null"]
+    }
+  }
+}


### PR DESCRIPTION
Achtes Chart der **Welle 2** aus #68. **5.0.0 → 6.0.0** (major, appVersion unverändert bei 4.23.10).

**Kein Ingress-Gate** — samba hat keinen Ingress (SMB und NetBIOS per NodePort). Prüfpunkt trotzdem über beide Quellen gelaufen: `ingress.domain` kommt weder in `templates/` noch in `values.yaml` vor.

**Nicht angefasst** (wie abgestimmt): die `users.conf`/`checksum/config`-Grenze aus #82. Helm sieht den Secret-Inhalt nie, kann ihn also nicht hashen; der Kommentar in `values.yaml`, der den manuellen `kubectl rollout restart` dokumentiert, bleibt unverändert stehen.

---

# 1. Strict `values.schema.json` (#68)

`additionalProperties: false` auf allen chart-eigenen Objektebenen: oberste Ebene, `samba`, `samba.resources` mit `.requests`/`.limits`, `env[]`, `securityContext`, `secrets` — **und den Einträgen der `samba.shares`-Liste**, die je eine Share-Sektion in `smb.conf`, eine PVC und einen volumeMount erzeugen.

# 2. Null-Absicherung für Härtung, Probes und Ressourcen (#99)

Wie bei calibre-web-automated ist die Härtung hier eine **dokumentierte Abweichung**, diesmal erzwungen vom `ghcr.io/dockur/samba`-Image. Die Fallbacks bilden sie exakt ab:

- **Kein `runAsNonRoot`**: Der Entrypoint legt die Unix-User aus `users.conf` an (`groupadd`/`adduser`/`usermod`), und `smbd` impersoniert den authentifizierten Share-User pro Session — beides erfordert einen Start als root.
- **`readOnlyRootFilesystem: false`**: Der Entrypoint schreibt beim Start nach `/etc/passwd` und `/etc/group`, legt den `/etc/samba.conf`-Healthcheck-Symlink und `/shared` an und pflegt die Samba-TDB-Datenbanken unter `/var/lib/samba`.
- **`capabilities.add` mit sechs Einträgen**: `NET_BIND_SERVICE` (Ports 445/139), `SETUID`/`SETGID` (Impersonation pro Session), `CHOWN`/`FOWNER`/`DAC_OVERRIDE` (Verwaltung der Share-Dateien im Auftrag der User).
- **Der Pod-Context setzt nur `fsGroup`**, keine `runAs*`-Werte.

Ein Standard-Default hätte den Fileserver arbeitsunfähig gemacht.

**Probe-Kontext geprüft:** Die Probes zielen direkt auf den SMB-TCP-Port `445` — SMB ist kein HTTP-Protokoll, ein httpGet-Default wäre hier sinnlos. **Wächter geprüft:** keine.

---

## Nachweis 1: erased Block → vorher, nachher

`samba.securityContext.container` geleert — **vorher** `securityContext: null`, **nachher**:

```yaml
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              add:
              - CHOWN
              - DAC_OVERRIDE
              - FOWNER
              - NET_BIND_SERVICE
              - SETGID
              - SETUID
              drop:
              - ALL
            readOnlyRootFilesystem: false
```

Geleerte Probe — vorher `livenessProbe: null`, nachher die vollständige Default-Probe auf `tcpSocket: 445`. Geleerter Pod-Context — weiterhin nur `fsGroup: 1000`, **ohne** `runAs*`.

## Nachweis 2: ein bewusst gesetztes `false` / `0` gewinnt weiterhin

`--set samba.securityContext.container.readOnlyRootFilesystem=true` → `true`. Wie bei calibre aussagekräftig, weil der Chart-Default hier selbst `false` ist.

`--set samba.startupProbe.failureThreshold=0` → `0`.

## Nachweis 3: das Rendering ändert sich nicht

```
$ diff <(helm template t <5.0.0> -f ci/samba/test-values.yaml) \
       <(helm template t samba -f ci/samba/test-values.yaml)
(keine Ausgabe — byte-identisch)
```

## Verifikation

```
$ helm lint --strict samba
1 chart(s) linted, 0 chart(s) failed
```

**Helper-Audit:** 12 aufgerufen, 12 definiert, `diff` leer.

**Negativprobe — vier Ebenen, darunter zwei realistische Fälle:**

```
--set bogusTopLevel=true                    -> at '': 'bogusTopLevel' not allowed
--set samba.resources.requests.bogusCpu=1   -> at '/samba/resources/requests': 'bogusCpu' not allowed
--set secrets.sambaUsersRef=x               -> at '/secrets': 'sambaUsersRef' not allowed
--set 'samba.shares[0].users=a'             -> at '/samba/shares/0': 'users' not allowed
```

Die dritte ist kein konstruierter Fall — **genau dieser Schlüssel steht heute in der produktiven Bundle-Datei**, siehe unten.

---

## Validierung gegen die real ausgerollten Werte — **hier ist etwas zu tun**

Bundle `fleet-cd/cluster-smb/`, Release `cluster-smb`, gepinnt auf `3.1.1+up4.23.10`.

**Bundle-Datei und ausgerollter Stand sind nicht deckungsgleich**, und diesmal ist es ein falsch benannter Schlüssel:

| | `secrets`-Schlüssel |
|---|---|
| Bundle-Datei im Repo | `sambaUsersRef` |
| **Live-Release** (`helm get values cluster-smb -n cluster-smb`) | `sambaUsersSecretRef` |
| vom Chart gelesen | `sambaUsersSecretRef` |

**Liste abgewiesener Schlüssel:**

```
$ helm template cluster-smb samba -f fleet-cd/cluster-smb/cluster-smb.values.yaml
samba:
- at '/secrets': additional properties 'sambaUsersRef' not allowed
```

**Kein Schaden dieses PRs:** Gegen den veröffentlichten `5.0.0` **ohne** Schema scheitert dieselbe Datei bereits heute — nur mit einer Meldung, die die Ursache nicht nennt:

```
Error: execution error at (samba/templates/samba-users.secret.yaml:6:15):
A secret-reference for the samba-users-secret must be provided
```

Genau der Unterschied, um den es in #68 geht: Das Schema sagt **welcher Schlüssel falsch ist**, statt nur zu melden, dass irgendetwas fehlt.

Die **Live-Werte** rendern dagegen unverändert gegen dieses Chart durch (exit 0) — der ausgerollte Zustand ist also korrekt, nur die gepflegte Datei nicht. Der dritte Fall dieser Art nach urlaubsverwaltung, zipline und calibre-web-automated.

**Arbeitsanweisung für die Cluster-Seite:** In `fleet-cd/cluster-smb/cluster-smb.values.yaml` `secrets.sambaUsersRef` in `secrets.sambaUsersSecretRef` umbenennen, **bevor** das Chart über `3.1.1+up4.23.10` hinaus hochgezogen wird. Der Wert selbst (`vaults/Kubernetes-Cluster/items/samba-users`) stimmt und bleibt.

---

## Nebenbefund, den ich nicht behebe: `samba.globalConfig` wird von keinem Template gelesen

```
$ grep -rn "globalConfig" samba/
samba/values.yaml:98:  globalConfig: null
```

Der Schlüssel steht seit dem allerersten Commit des Charts (`7d0efea`) in `values.yaml` und wurde **nie** von einem Template ausgewertet. Das ist dieselbe Klasse wie cyberchefs totes `ingress.enabled` vor #93: ein Schalter, der etwas verspricht und nichts tut.

Ich habe ihn **nicht** entfernt, weil hier zwei sinnvolle Auflösungen möglich sind und die Wahl eine inhaltliche Entscheidung ist — genau wie bei #93, wo aus dem toten `ingress.enabled` ein funktionierendes Gate wurde statt einer Löschung:

- **implementieren**: als `[global]`-Ergänzung in die `smb.conf` rendern (die ConfigMap hat den Abschnitt bereits, nur ohne Erweiterungspunkt), oder
- **entfernen**: dann weist das Schema ihn künftig ab.

Für den Übergang ist er im Schema erlaubt und mit dem Hinweis dokumentiert, dass ihn derzeit niemand liest. Weder die Bundle-Datei noch der Live-Stand setzen ihn, eine Entscheidung in beide Richtungen ist also gefahrlos.

Refs #68, Refs #99.
