### PR TITLE
homeassistant: strict values.schema.json + Null-Absicherung (Welle 2, #68/#99)

### DIFF
--- a/homeassistant/Chart.yaml
+++ b/homeassistant/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to deploy Home Assistant on Kubernetes
 icon: https://www.home-assistant.io/images/home-assistant-logo.svg
 type: application
 
-version: 5.0.0+up2026.8.3
+version: 6.0.0+up2026.8.3
 
 appVersion: "2026.8.3"
 

--- a/homeassistant/templates/_helpers.tpl
+++ b/homeassistant/templates/_helpers.tpl
@@ -114,3 +114,165 @@ template-chart is the reference implementation.
 1
 {{- end -}}
 {{- end -}}
+
+{{/*
+Merge a user-supplied values sub-tree onto a dict of chart defaults so that a
+null / empty override falls back to the defaults instead of erasing them.
+
+Input: dict "defaults" <dict> "given" <dict|nil> "path" <string, optional
+values path used in error messages>. Output: YAML of the merged dict (consume
+it with fromYaml).
+
+Why this exists (issue #99): Helm merges values maps recursively, but an
+override key written without children — e.g. a leftover
+
+  securityContext:
+
+after deleting its last remaining sub-key — is YAML null. Where the chart
+defines a default, Helm treats that null as a deletion of the default; the
+template then renders "securityContext: null". The workload starts and reports
+healthy while being unhardened, so nothing points at the mistake. The same
+shape erases a probe (it disappears) or the resources block (no requests, no
+computed limits). This helper defines the opposite semantics: an empty block
+means "chart defaults apply".
+
+Rules:
+  - a nil "given" is treated as an empty dict (all defaults apply).
+  - a key whose override value is null keeps the default (nulls never delete).
+  - a key present in both as a map is merged recursively, so a partially
+    filled block only overrides the keys it actually sets.
+  - a scalar override for a key the defaults define as a map is rejected with
+    a message naming the values path, instead of failing later with a template
+    field error.
+  - any other set value wins as given, including an explicit false or 0 —
+    Helm's "default" and sprig's "mergeOverwrite" would both swallow those
+    zero values, hence the explicit kindIs "invalid" nil check.
+  - keys only present in the override are passed through unchanged.
+
+NOTE: like the helpers above, this is duplicated into every chart's
+templates/_helpers.tpl with the chart's name as define prefix, because charts
+in this repo deliberately have no dependencies.
+*/}}
+{{- define "homeassistant.defaultedDict" -}}
+{{- $defaults := .defaults | default dict -}}
+{{- $given := .given -}}
+{{- $path := .path | default "value" -}}
+{{- if kindIs "invalid" $given -}}
+{{- $given = dict -}}
+{{- end -}}
+{{- if not (kindIs "map" $given) -}}
+{{- fail (printf "%s must be a mapping or null, got %s (%v)" $path (kindOf $given) $given) -}}
+{{- end -}}
+{{- $out := deepCopy $defaults -}}
+{{- range $key, $value := $given -}}
+{{- if not (kindIs "invalid" $value) -}}
+{{- $default := index $defaults $key -}}
+{{- if and (kindIs "map" $value) (kindIs "map" $default) -}}
+{{- $_ := set $out $key (fromYaml (include "homeassistant.defaultedDict" (dict "defaults" $default "given" $value "path" (printf "%s.%s" $path $key)))) -}}
+{{- else if kindIs "map" $default -}}
+{{- fail (printf "%s.%s must be a mapping or null, got %s (%v)" $path $key (kindOf $value) $value) -}}
+{{- else -}}
+{{- $_ := set $out $key $value -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- toYaml $out -}}
+{{- end -}}
+
+{{/*
+Pick one sub-block out of a values block that may itself be null.
+
+Input: dict "block" <dict|nil> "key" <string> "path" <string>.
+Returns YAML of dict "value" <the sub-block, may be nil>, after rejecting a
+non-mapping block with a message that names the values path. Needed because
+".Values.securityContext" can itself be erased.
+*/}}
+{{- define "homeassistant.subBlock" -}}
+{{- $block := .block -}}
+{{- if kindIs "invalid" $block -}}
+{{- $block = dict -}}
+{{- end -}}
+{{- if not (kindIs "map" $block) -}}
+{{- fail (printf "%s must be a mapping or null, got %s (%v)" .path (kindOf $block) $block) -}}
+{{- end -}}
+{{- toYaml (dict "value" (index $block .key)) -}}
+{{- end -}}
+
+{{/*
+The effective security contexts, probes and resources (issue #99).
+
+The defaults below MUST stay in sync with the corresponding blocks in
+values.yaml, which stays the documented, user-facing place for them; this copy
+is only the fallback for the case where an override has erased the block.
+
+Like several other charts here, this one keeps replicas, resources, probes and
+securityContext at the TOP level of values.yaml, so the paths in the error
+messages have no chart-name prefix.
+
+IMPORTANT - this chart's hardening is a DOCUMENTED DEVIATION and the fallbacks
+reproduce it exactly rather than restoring the repo standard:
+
+  - The pod context is deliberately EMPTY: the official Home Assistant
+    container must start as root (s6-overlay performs its setup as uid 0 and
+    the image supports no non-root user), so runAsNonRoot / runAsUser are not
+    set.
+  - capabilities.add keeps NET_RAW: Home Assistant's device discovery (DHCP
+    watcher, ping/arp integrations) uses raw sockets and logs "Operation not
+    permitted" without it.
+
+The probes address the container port by its name ("http").
+*/}}
+{{- define "homeassistant.podSecurityContext" -}}
+{{- $given := (fromYaml (include "homeassistant.subBlock" (dict "block" . "key" "pod" "path" "securityContext"))).value -}}
+{{- $defaults := dict -}}
+{{- include "homeassistant.defaultedDict" (dict "defaults" $defaults "given" $given "path" "securityContext.pod") -}}
+{{- end -}}
+
+{{- define "homeassistant.containerSecurityContext" -}}
+{{- $given := (fromYaml (include "homeassistant.subBlock" (dict "block" . "key" "container" "path" "securityContext"))).value -}}
+{{- $defaults := dict
+      "allowPrivilegeEscalation" false
+      "readOnlyRootFilesystem" true
+      "capabilities" (dict "drop" (list "ALL") "add" (list "NET_RAW")) -}}
+{{- include "homeassistant.defaultedDict" (dict "defaults" $defaults "given" $given "path" "securityContext.container") -}}
+{{- end -}}
+
+{{- define "homeassistant.livenessProbe" -}}
+{{- $defaults := dict
+      "httpGet" (dict "path" "/" "port" "http")
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 3 -}}
+{{- include "homeassistant.defaultedDict" (dict "defaults" $defaults "given" . "path" "livenessProbe") -}}
+{{- end -}}
+
+{{- define "homeassistant.readinessProbe" -}}
+{{- $defaults := dict
+      "httpGet" (dict "path" "/" "port" "http")
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 3 -}}
+{{- include "homeassistant.defaultedDict" (dict "defaults" $defaults "given" . "path" "readinessProbe") -}}
+{{- end -}}
+
+{{- define "homeassistant.startupProbe" -}}
+{{- $defaults := dict
+      "httpGet" (dict "path" "/" "port" "http")
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 30 -}}
+{{- include "homeassistant.defaultedDict" (dict "defaults" $defaults "given" . "path" "startupProbe") -}}
+{{- end -}}
+
+{{/*
+The effective resources block, fed into the resources helper above so that an
+erased "resources:" still yields the chart's requests and computed limits
+instead of a container without any resource accounting.
+*/}}
+{{- define "homeassistant.effectiveResources" -}}
+{{- $defaults := dict
+      "limitFactor" 3
+      "requests" (dict "cpu" 0.2 "memory" "512Mi" "ephemeralStorage" "128Mi") -}}
+{{- $merged := fromYaml (include "homeassistant.defaultedDict" (dict "defaults" $defaults "given" . "path" "resources")) -}}
+{{- include "homeassistant.resources" $merged -}}
+{{- end -}}

--- a/homeassistant/templates/homeassistant.sfs.yaml
+++ b/homeassistant/templates/homeassistant.sfs.yaml
@@ -30,13 +30,13 @@ spec:
     spec:
       automountServiceAccountToken: false
       securityContext:
-        {{- toYaml .Values.securityContext.pod | nindent 8 }}
+        {{- include "homeassistant.podSecurityContext" .Values.securityContext | nindent 8 }}
       containers:
         - name: "{{ .Release.Name }}-{{ .Chart.Name }}"
           image: "ghcr.io/home-assistant/home-assistant:{{ .Chart.AppVersion }}"
           imagePullPolicy: IfNotPresent
           securityContext:
-            {{- toYaml .Values.securityContext.container | nindent 12 }}
+            {{- include "homeassistant.containerSecurityContext" .Values.securityContext | nindent 12 }}
           env:
             - name: TZ
               value: "{{ .Values.core.timezone }}"
@@ -65,13 +65,13 @@ spec:
               containerPort: 8123
               protocol: TCP
           livenessProbe:
-            {{- toYaml .Values.livenessProbe | nindent 12 }}
+            {{- include "homeassistant.livenessProbe" .Values.livenessProbe | nindent 12 }}
           readinessProbe:
-            {{- toYaml .Values.readinessProbe | nindent 12 }}
+            {{- include "homeassistant.readinessProbe" .Values.readinessProbe | nindent 12 }}
           startupProbe:
-            {{- toYaml .Values.startupProbe | nindent 12 }}
+            {{- include "homeassistant.startupProbe" .Values.startupProbe | nindent 12 }}
           resources:
-            {{- include "homeassistant.resources" .Values.resources | nindent 12 }}
+            {{- include "homeassistant.effectiveResources" .Values.resources | nindent 12 }}
           volumeMounts:
             - mountPath: /config/configuration.yaml
               subPath: configuration.yaml

--- a/homeassistant/values.schema.json
+++ b/homeassistant/values.schema.json
@@ -1,0 +1,224 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "homeassistant values",
+  "description": "Strict values schema (issue #68). additionalProperties is false on every chart-owned object level, so a key that the chart does not read is rejected at render time instead of being silently ignored. The only objects that stay open are the ones passed verbatim into the Kubernetes pod spec (probes, security contexts, volumes, scheduling, global) - the chart does not interpret their contents, so it cannot judge which keys are meaningful. The hardening, probe and resources blocks additionally accept null, because an erased block falls back to the chart defaults (issue #99). Note that this chart keeps replicas, resources, probes and securityContext at the TOP level, and that its ingress block deliberately follows the upstream host/tls style (documented exception in the README).",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "global": {
+      "description": "Helm's conventional cross-chart values. Unused by this chart, kept open so an umbrella install cannot break on it.",
+      "type": "object"
+    },
+    "scaleDown": {
+      "type": "boolean"
+    },
+    "replicas": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "service": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": ["string", "null"]
+        },
+        "port": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "maximum": 65535
+        }
+      }
+    },
+    "ingress": {
+      "description": "Documented exception (README): this chart keeps the upstream-style flexible ingress values - host and tls lists instead of the repo's required domain/clusterIssuer pair. The list entries go verbatim into the Ingress spec, so they stay open.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "className": {
+          "description": "Set to \"\" to omit ingressClassName from the rendered Ingress.",
+          "type": ["string", "null"]
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "hosts": {
+          "type": ["array", "null"]
+        },
+        "tls": {
+          "type": ["array", "null"]
+        }
+      }
+    },
+    "securityContext": {
+      "$ref": "#/definitions/securityContext"
+    },
+    "resources": {
+      "$ref": "#/definitions/resources"
+    },
+    "livenessProbe": {
+      "$ref": "#/definitions/probe"
+    },
+    "readinessProbe": {
+      "$ref": "#/definitions/probe"
+    },
+    "startupProbe": {
+      "$ref": "#/definitions/probe"
+    },
+    "env": {
+      "$ref": "#/definitions/env"
+    },
+    "volumes": {
+      "description": "Additional volumes, rendered verbatim into the pod spec.",
+      "type": ["array", "null"]
+    },
+    "volumeMounts": {
+      "description": "Additional volumeMounts, rendered verbatim into the container.",
+      "type": ["array", "null"]
+    },
+    "nodeSelector": {
+      "description": "Rendered verbatim into the pod spec.",
+      "type": ["object", "null"]
+    },
+    "tolerations": {
+      "description": "Rendered verbatim into the pod spec.",
+      "type": ["array", "null"]
+    },
+    "affinity": {
+      "description": "Rendered verbatim into the pod spec.",
+      "type": ["object", "null"]
+    },
+    "core": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "timezone": {
+          "type": ["string", "null"]
+        },
+        "storage": {
+          "description": "The config PVC. Not null-safe on purpose: an erased block yields an invalid PVC rather than a silently degraded workload.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "size": {
+              "type": ["string", "null"]
+            },
+            "storageClass": {
+              "type": ["string", "null"]
+            }
+          }
+        }
+      }
+    },
+    "secrets": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "configSecretRef": {
+          "description": "op:// item path holding config, http-config and recorder-config. Changing the PATH restarts the pod via the checksum/secret-ref annotation; changing the item CONTENT does not - see the note in values.yaml (#82).",
+          "type": ["string", "null"]
+        }
+      }
+    }
+  },
+  "definitions": {
+    "resources": {
+      "description": "May be null / empty: the chart then falls back to its default requests and computed limits (issue #99) instead of rendering a container without resource accounting.",
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "limitFactor": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "requests": {
+          "$ref": "#/definitions/resourceList"
+        },
+        "limits": {
+          "$ref": "#/definitions/resourceList"
+        }
+      }
+    },
+    "resourceList": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "cpu": {
+          "type": ["string", "number", "null"]
+        },
+        "memory": {
+          "type": ["string", "number", "null"]
+        },
+        "ephemeral-storage": {
+          "type": ["string", "number", "null"]
+        },
+        "ephemeralStorage": {
+          "type": ["string", "number", "null"]
+        }
+      }
+    },
+    "env": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "valueFrom": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "secretKeyRef": {
+                "$ref": "#/definitions/keyRef"
+              },
+              "configMapKeyRef": {
+                "$ref": "#/definitions/keyRef"
+              }
+            }
+          }
+        }
+      }
+    },
+    "keyRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "key"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        }
+      }
+    },
+    "securityContext": {
+      "description": "May be null / empty at any level: the chart then falls back to its hardening defaults (issue #99). Note that this chart's hardening is a documented deviation - the pod context is deliberately empty because the image must start as root (s6-overlay), and capabilities.add keeps NET_RAW for device discovery.",
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "pod": {
+          "description": "Merged onto the chart's pod defaults (empty by design) and rendered as the pod's securityContext; kept open because the chart does not interpret the individual fields.",
+          "type": ["object", "null"]
+        },
+        "container": {
+          "description": "Merged onto the chart's container defaults and rendered as the container's securityContext; kept open because the chart does not interpret the individual fields.",
+          "type": ["object", "null"]
+        }
+      }
+    },
+    "probe": {
+      "description": "Merged onto the chart's probe defaults and rendered as a container probe; kept open because the chart does not interpret the individual fields. May be null / empty, which means the defaults apply (issue #99) rather than the probe disappearing.",
+      "type": ["object", "null"]
+    }
+  }
+}


### PR DESCRIPTION
Neuntes Chart der **Welle 2** aus #68. **5.0.0 → 6.0.0** (major, appVersion unverändert bei 2026.8.3).

**Kein Gate-Eingriff** — homeassistant wertet `ingress.enabled` bereits aus, und sein Ingress-Block behält die **upstream-typischen `hosts`/`tls`-Listen**, die die README als dokumentierte Ausnahme führt. Ich habe die Struktur nicht angetastet.

Prüfpunkt über beide Quellen: `ingress.domain` existiert in diesem Chart **überhaupt nicht** — weder in `templates/` noch in `values.yaml`.

---

# 1. Strict `values.schema.json` (#68)

`additionalProperties: false` auf allen chart-eigenen Objektebenen: oberste Ebene, `service`, `ingress`, `resources` mit `.requests`/`.limits`, `env[]`, `securityContext`, `core`, `core.storage`, `secrets`.

**Das Schema bildet die Ausnahme ab, statt sie zu begradigen.** `ingress.hosts` und `ingress.tls` bleiben als Listen offen, weil ihre Einträge wörtlich in die Ingress-Spec gehen; `ingress.className` bleibt erlaubt inklusive `""` (womit die Ingress-Klasse weggelassen wird). Der Repo-Standard `ingress.domain`/`clusterIssuer` wird hier **nicht** eingeführt — und genau deshalb weist das Schema ihn ab:

```
--set ingress.domain=ha.example.com  -> at '/ingress': 'domain' not allowed
```

Das ist die nützlichste Negativprobe dieses Charts: Wer die Konvention der anderen Charts hierher überträgt, bekommt jetzt eine Meldung statt eines wirkungslosen Schlüssels.

Ebenfalls offen bleiben die Pod-Spec-Durchreichungen `volumes`, `volumeMounts`, `nodeSelector`, `tolerations`, `affinity`.

`core.storage` bleibt **nicht** null-sicher: ein geleerter Block ergibt eine ungültige PVC — laute Klasse.

# 2. Null-Absicherung für Härtung, Probes und Ressourcen (#99)

Auch hier eine **dokumentierte Abweichung**, die die Fallbacks exakt abbilden:

- **Der Pod-Context ist absichtlich leer** (`pod: {}`). Der offizielle Home-Assistant-Container muss als root starten — s6-overlay erledigt sein Setup als uid 0, und das Image kennt keinen Non-root-User. `runAsNonRoot`/`runAsUser` sind deshalb bewusst nicht gesetzt, und der Fallback setzt sie auch nicht.
- **`capabilities.add` behält `NET_RAW`.** Ohne diese Capability nutzt Home Assistants Geräte-Erkennung (DHCP-Watcher, ping/arp-Integrationen) Raw-Sockets ohne Berechtigung und protokolliert „Operation not permitted".

**Wächter geprüft:** keine. **Probe-Kontext geprüft:** die Probes adressieren den Port über seinen Namen (`http`), kein Zusatzkontext nötig.

**NOTES.txt geprüft** (der Prüfpunkt aus #103): Die vorhandene `NOTES.txt` ruft **keine** Chart-Helper auf, gibt also keine Werte aus, die dem Release widersprechen könnten. Hier ist nichts nachzuziehen.

---

## Nachweis 1: erased Block → vorher, nachher

```yaml
securityContext:
  container:
livenessProbe:
resources:
  limits:
```

**Vorher** (`5.0.0`): `securityContext: null`, `livenessProbe: null`.

**Nachher**:

```yaml
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              add:
              - NET_RAW          # <- ohne dies bricht die Geräte-Erkennung
              drop:
              - ALL
            readOnlyRootFilesystem: true
          ...
          livenessProbe:
            failureThreshold: 3
            httpGet:
              path: /
              port: http
            periodSeconds: 10
            timeoutSeconds: 5
          ...
          resources:
            limits:
              ephemeral-storage: 384Mi
              memory: 1536Mi
            requests:
              cpu: 0.2
              ephemeral-storage: 128Mi
              memory: 512Mi
```

## Nachweis 2: ein bewusst gesetztes `false` / `0` gewinnt weiterhin

`--set securityContext.container.readOnlyRootFilesystem=false` → `false`.
`--set startupProbe.failureThreshold=0` → `0`, restliche Probe-Defaults intakt.

## Nachweis 3: das Rendering ändert sich nicht

```
$ diff <(helm template t <5.0.0> -f ci/homeassistant/test-values.yaml) \
       <(helm template t homeassistant -f ci/homeassistant/test-values.yaml)
(keine Ausgabe — byte-identisch)
```

## Verifikation

```
$ helm lint --strict homeassistant
1 chart(s) linted, 0 chart(s) failed
```

**Negativprobe — vier Ebenen:**

```
--set bogusTopLevel=true             -> at '': 'bogusTopLevel' not allowed
--set resources.requests.bogusCpu=1  -> at '/resources/requests': 'bogusCpu' not allowed
--set core.timeZone=UTC              -> at '/core': 'timeZone' not allowed   (Schlüssel heißt timezone)
--set ingress.domain=ha.example.com  -> at '/ingress': 'domain' not allowed  (Repo-Konvention, hier bewusst nicht vorhanden)
```

### Helper-Audit mit einem Fehlalarm, der Erwähnung verdient

Der Audit meldete zunächst **zwei aufgerufene, aber nicht definierte** Helper: `homeassistant.fullname` und `homeassistant.labels`. Nachgesehen statt geglaubt:

```
homeassistant/templates/tests/test-connection.yaml:4:
  {{/*  name: "{{ include "homeassistant.fullname" . }}-test-connection"*/}}
```

Beide Vorkommen stehen **innerhalb von Helm-Kommentaren** (`{{/* … */}}`) in einer vollständig auskommentierten Test-Datei — unverändert so auch auf `origin/main`. Helm löst sie nie auf, was `helm lint --strict` und jedes Rendering bestätigen. Kein Handlungsbedarf; der Audit-Grep unterscheidet nur Kommentare nicht, ist also ein Screening und kein Urteil.

## Validierung gegen die real ausgerollten Werte

Bundle `fleet-cd/homeassistant-jk/homeassistant/`, Release `homeassistant-jk`, gepinnt auf `5.0.0+up2026.8.3`. Bundle-Datei und `helm get values homeassistant-jk -n homeassistant-jk` **deckungsgleich** — nach vier Abweichungen in Folge das erste Bundle der Welle, bei dem beide Seiten übereinstimmen.

**Liste abgewiesener Schlüssel: leer.** Gesetzt werden `scaleDown: true`, der vollständige upstream-Ingress-Block, `secrets.configSecretRef` und `core.{timezone,storage.storageClass}` — alle bekannt.

Gegengeprüft, dass beide Zustände erhalten bleiben: Das Rendering mit den Bundle-Werten ergibt weiterhin **`replicas: 0`** (die Release ist bewusst heruntergefahren) **und** genau **ein Ingress-Objekt**. Vor dem Hochziehen auf `6.0.0` ist **nichts zu bereinigen**.

Refs #68, Refs #99.
