### PR TITLE
minecraft-router: strict values.schema.json + Null-Absicherung (Welle 2, #68/#99)

### DIFF
--- a/minecraft-router/Chart.yaml
+++ b/minecraft-router/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://avatars.githubusercontent.com/u/988985
 
 type: application
 
-version: 2.0.0+up1.46.4
+version: 3.0.0+up1.46.4
 appVersion: "1.46.4"
 
 maintainers:

--- a/minecraft-router/templates/_helpers.tpl
+++ b/minecraft-router/templates/_helpers.tpl
@@ -114,3 +114,170 @@ template-chart is the reference implementation.
 1
 {{- end -}}
 {{- end -}}
+
+{{/*
+Merge a user-supplied values sub-tree onto a dict of chart defaults so that a
+null / empty override falls back to the defaults instead of erasing them.
+
+Input: dict "defaults" <dict> "given" <dict|nil> "path" <string, optional
+values path used in error messages>. Output: YAML of the merged dict (consume
+it with fromYaml).
+
+Why this exists (issue #99): Helm merges values maps recursively, but an
+override key written without children — e.g. a leftover
+
+  securityContext:
+
+after deleting its last remaining sub-key — is YAML null. Where the chart
+defines a default, Helm treats that null as a deletion of the default; the
+template then renders "securityContext: null": no readOnlyRootFilesystem, no
+dropped capabilities, no allowPrivilegeEscalation: false. The workload starts
+and reports healthy while being unhardened, so nothing points at the mistake.
+The same shape erases a probe (it disappears) or the resources block (no
+requests, no computed limits). This helper defines the opposite semantics: an
+empty block means "chart defaults apply".
+
+Rules:
+  - a nil "given" is treated as an empty dict (all defaults apply).
+  - a key whose override value is null keeps the default (nulls never delete).
+  - a key present in both as a map is merged recursively, so a partially
+    filled block only overrides the keys it actually sets.
+  - a scalar override for a key the defaults define as a map is rejected with
+    a message naming the values path, instead of failing later with a template
+    field error.
+  - any other set value wins as given, including an explicit false or 0 —
+    Helm's "default" and sprig's "mergeOverwrite" would both swallow those
+    zero values, hence the explicit kindIs "invalid" nil check.
+  - keys only present in the override are passed through unchanged.
+
+NOTE: like the helpers above, this is duplicated into every chart's
+templates/_helpers.tpl with the chart's name as define prefix, because charts
+in this repo deliberately have no dependencies.
+*/}}
+{{- define "minecraft-router.defaultedDict" -}}
+{{- $defaults := .defaults | default dict -}}
+{{- $given := .given -}}
+{{- $path := .path | default "value" -}}
+{{- if kindIs "invalid" $given -}}
+{{- $given = dict -}}
+{{- end -}}
+{{- if not (kindIs "map" $given) -}}
+{{- fail (printf "%s must be a mapping or null, got %s (%v)" $path (kindOf $given) $given) -}}
+{{- end -}}
+{{- $out := deepCopy $defaults -}}
+{{- range $key, $value := $given -}}
+{{- if not (kindIs "invalid" $value) -}}
+{{- $default := index $defaults $key -}}
+{{- if and (kindIs "map" $value) (kindIs "map" $default) -}}
+{{- $_ := set $out $key (fromYaml (include "minecraft-router.defaultedDict" (dict "defaults" $default "given" $value "path" (printf "%s.%s" $path $key)))) -}}
+{{- else if kindIs "map" $default -}}
+{{- fail (printf "%s.%s must be a mapping or null, got %s (%v)" $path $key (kindOf $value) $value) -}}
+{{- else -}}
+{{- $_ := set $out $key $value -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- toYaml $out -}}
+{{- end -}}
+
+{{/*
+Pick one sub-block out of a values block that may itself be null.
+
+Input: dict "block" <dict|nil> "key" <string> "path" <string>.
+Returns YAML of dict "value" <the sub-block, may be nil>, after rejecting a
+non-mapping block with a message that names the values path. Needed because
+".Values.server.securityContext" can itself be erased.
+*/}}
+{{- define "minecraft-router.subBlock" -}}
+{{- $block := .block -}}
+{{- if kindIs "invalid" $block -}}
+{{- $block = dict -}}
+{{- end -}}
+{{- if not (kindIs "map" $block) -}}
+{{- fail (printf "%s must be a mapping or null, got %s (%v)" .path (kindOf $block) $block) -}}
+{{- end -}}
+{{- toYaml (dict "value" (index $block .key)) -}}
+{{- end -}}
+
+{{/*
+The effective security contexts, probes and resources (issue #99).
+
+The defaults below MUST stay in sync with the corresponding blocks in
+values.yaml, which stays the documented, user-facing place for them; this copy
+is only the fallback for the case where an override has erased the block.
+
+Two things a rebuilt default probe must not lose:
+  - the API port is addressed by NAME ("api-port"), not by number, so the probe
+    keeps working if server.apiPort is overridden.
+  - mc-router has no /health endpoint even in 1.46.4, so GET /routes is the
+    health signal, and the "Accept: application/json" header belongs to it (it
+    was mandatory in 1.25.1 and is the correct request for a JSON endpoint).
+
+The pod context deliberately pins uid/gid 10000 even though the image declares
+USER 65532 since 1.46.0, so the runtime identity does not silently change with
+the base image.
+*/}}
+{{- define "minecraft-router.podSecurityContext" -}}
+{{- $given := (fromYaml (include "minecraft-router.subBlock" (dict "block" . "key" "pod" "path" "server.securityContext"))).value -}}
+{{- $defaults := dict
+      "runAsNonRoot" true
+      "runAsUser" 10000
+      "runAsGroup" 10000
+      "fsGroup" 10000
+      "fsGroupChangePolicy" "Always" -}}
+{{- include "minecraft-router.defaultedDict" (dict "defaults" $defaults "given" $given "path" "server.securityContext.pod") -}}
+{{- end -}}
+
+{{- define "minecraft-router.containerSecurityContext" -}}
+{{- $given := (fromYaml (include "minecraft-router.subBlock" (dict "block" . "key" "container" "path" "server.securityContext"))).value -}}
+{{- $defaults := dict
+      "allowPrivilegeEscalation" false
+      "readOnlyRootFilesystem" true
+      "runAsNonRoot" true
+      "capabilities" (dict "drop" (list "ALL") "add" (list)) -}}
+{{- include "minecraft-router.defaultedDict" (dict "defaults" $defaults "given" $given "path" "server.securityContext.container") -}}
+{{- end -}}
+
+{{- define "minecraft-router.probeHttpGet" -}}
+{{- dict "path" "/routes" "port" "api-port" "httpHeaders" (list (dict "name" "Accept" "value" "application/json")) | toYaml -}}
+{{- end -}}
+
+{{- define "minecraft-router.livenessProbe" -}}
+{{- $defaults := dict
+      "httpGet" (fromYaml (include "minecraft-router.probeHttpGet" .))
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 3 -}}
+{{- include "minecraft-router.defaultedDict" (dict "defaults" $defaults "given" . "path" "server.livenessProbe") -}}
+{{- end -}}
+
+{{- define "minecraft-router.readinessProbe" -}}
+{{- $defaults := dict
+      "httpGet" (fromYaml (include "minecraft-router.probeHttpGet" .))
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 3 -}}
+{{- include "minecraft-router.defaultedDict" (dict "defaults" $defaults "given" . "path" "server.readinessProbe") -}}
+{{- end -}}
+
+{{- define "minecraft-router.startupProbe" -}}
+{{- $defaults := dict
+      "httpGet" (fromYaml (include "minecraft-router.probeHttpGet" .))
+      "periodSeconds" 2
+      "timeoutSeconds" 5
+      "failureThreshold" 15 -}}
+{{- include "minecraft-router.defaultedDict" (dict "defaults" $defaults "given" . "path" "server.startupProbe") -}}
+{{- end -}}
+
+{{/*
+The effective resources block, fed into the resources helper above so that an
+erased "resources:" still yields the chart's requests and computed limits
+instead of a container without any resource accounting.
+*/}}
+{{- define "minecraft-router.effectiveResources" -}}
+{{- $defaults := dict
+      "limitFactor" 3
+      "requests" (dict "cpu" "100m" "memory" "50Mi" "ephemeral-storage" "50Mi") -}}
+{{- $merged := fromYaml (include "minecraft-router.defaultedDict" (dict "defaults" $defaults "given" . "path" "server.resources")) -}}
+{{- include "minecraft-router.resources" $merged -}}
+{{- end -}}

--- a/minecraft-router/templates/minecraft-router.deployment.yaml
+++ b/minecraft-router/templates/minecraft-router.deployment.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       automountServiceAccountToken: false
       securityContext:
-        {{- toYaml .Values.server.securityContext.pod | nindent 8 }}
+        {{- include "minecraft-router.podSecurityContext" .Values.server.securityContext | nindent 8 }}
       containers:
         - name: {{ .Release.Name }}-{{ .Chart.Name }}-deployment
           image: "itzg/mc-router:{{ .Chart.AppVersion }}"
@@ -65,15 +65,15 @@ spec:
               protocol: TCP
               containerPort: {{ .Values.server.apiPort }}
           livenessProbe:
-            {{- toYaml .Values.server.livenessProbe | nindent 12 }}
+            {{- include "minecraft-router.livenessProbe" .Values.server.livenessProbe | nindent 12 }}
           readinessProbe:
-            {{- toYaml .Values.server.readinessProbe | nindent 12 }}
+            {{- include "minecraft-router.readinessProbe" .Values.server.readinessProbe | nindent 12 }}
           startupProbe:
-            {{- toYaml .Values.server.startupProbe | nindent 12 }}
+            {{- include "minecraft-router.startupProbe" .Values.server.startupProbe | nindent 12 }}
           resources:
-            {{- include "minecraft-router.resources" .Values.server.resources | nindent 12 }}
+            {{- include "minecraft-router.effectiveResources" .Values.server.resources | nindent 12 }}
           securityContext:
-            {{- toYaml .Values.server.securityContext.container | nindent 12 }}
+            {{- include "minecraft-router.containerSecurityContext" .Values.server.securityContext | nindent 12 }}
           volumeMounts:
             - name: config-mount
               mountPath: /data/custom-routing-config.json

--- a/minecraft-router/values.schema.json
+++ b/minecraft-router/values.schema.json
@@ -1,0 +1,189 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "minecraft-router values",
+  "description": "Strict values schema (issue #68). additionalProperties is false on every chart-owned object level, so a key that the chart does not read is rejected at render time instead of being silently ignored. The only objects that stay open are the ones passed verbatim into the Kubernetes pod spec (probes, security contexts, global) - the chart does not interpret their contents, so it cannot judge which keys are meaningful. The hardening, probe and resources blocks additionally accept null, because an erased block falls back to the chart defaults (issue #99).",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "global": {
+      "description": "Helm's conventional cross-chart values. Unused by this chart, kept open so an umbrella install cannot break on it.",
+      "type": "object"
+    },
+    "scaleDown": {
+      "type": "boolean"
+    },
+    "mappings": {
+      "description": "Routing table: which client-facing hostname is proxied to which backend. Required and must not be empty - the chart fails loudly on a missing or empty list, so this block is deliberately NOT null-safe (issue #99 covers only the silent class). A change here rolls the router pod via the checksum/config annotation.",
+      "type": ["array", "null"],
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["domain", "internalUrl"],
+        "properties": {
+          "domain": {
+            "description": "Client-facing hostname the Minecraft client connects to.",
+            "type": ["string", "null"]
+          },
+          "internalUrl": {
+            "description": "Cluster-internal address of the backend server.",
+            "type": ["string", "null"]
+          },
+          "port": {
+            "description": "Overrides server.backendPort for this single backend.",
+            "type": ["integer", "null"],
+            "minimum": 1,
+            "maximum": 65535
+          }
+        }
+      }
+    },
+    "server": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "replicas": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "outwardPort": {
+          "description": "nodePort of the router Service. 25565 is deliberately outside the Kubernetes default node-port range - the cluster runs an extended --service-node-port-range, and Minecraft clients connect to this exact port.",
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "port": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "backendPort": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "apiPort": {
+          "description": "Port of the mc-router HTTP API. Not exposed by the Service; only the probes talk to it.",
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "resources": {
+          "$ref": "#/definitions/resources"
+        },
+        "livenessProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "readinessProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "startupProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "securityContext": {
+          "$ref": "#/definitions/securityContext"
+        },
+        "env": {
+          "description": "Extra environment variables. This is also how every mc-router option the chart does not model explicitly is set: mc-router parses its flags with go-flagsfiller, so \"--some-flag\" is settable as \"SOME_FLAG\".",
+          "$ref": "#/definitions/env"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "resources": {
+      "description": "May be null / empty: the chart then falls back to its default requests and computed limits (issue #99) instead of rendering a container without resource accounting.",
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "limitFactor": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "requests": {
+          "$ref": "#/definitions/resourceList"
+        },
+        "limits": {
+          "$ref": "#/definitions/resourceList"
+        }
+      }
+    },
+    "resourceList": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "cpu": {
+          "type": ["string", "number", "null"]
+        },
+        "memory": {
+          "type": ["string", "number", "null"]
+        },
+        "ephemeral-storage": {
+          "type": ["string", "number", "null"]
+        },
+        "ephemeralStorage": {
+          "type": ["string", "number", "null"]
+        }
+      }
+    },
+    "env": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "valueFrom": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "secretKeyRef": {
+                "$ref": "#/definitions/keyRef"
+              },
+              "configMapKeyRef": {
+                "$ref": "#/definitions/keyRef"
+              }
+            }
+          }
+        }
+      }
+    },
+    "keyRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "key"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        }
+      }
+    },
+    "securityContext": {
+      "description": "May be null / empty at any level: the chart then falls back to its hardening defaults (issue #99) instead of rendering an unhardened workload.",
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "pod": {
+          "description": "Merged onto the chart's pod hardening defaults and rendered as the pod's securityContext; kept open because the chart does not interpret the individual fields.",
+          "type": ["object", "null"]
+        },
+        "container": {
+          "description": "Merged onto the chart's container hardening defaults and rendered as the container's securityContext; kept open because the chart does not interpret the individual fields.",
+          "type": ["object", "null"]
+        }
+      }
+    },
+    "probe": {
+      "description": "Merged onto the chart's probe defaults and rendered as a container probe; kept open because the chart does not interpret the individual fields. May be null / empty, which means the defaults apply (issue #99) rather than the probe disappearing.",
+      "type": ["object", "null"]
+    }
+  }
+}


### PR DESCRIPTION
**Letztes Chart der Welle 2** aus #68. **2.0.0 → 3.0.0** (major, appVersion unverändert bei 1.46.4).

**Kein Ingress-Gate** — der Router hat keinen Ingress (Clients erreichen ihn über einen NodePort). Prüfpunkt über beide Quellen gelaufen: `ingress.domain` kommt weder in `templates/` noch in `values.yaml` vor.

---

# 1. Strict `values.schema.json` (#68)

`additionalProperties: false` auf allen chart-eigenen Objektebenen: oberste Ebene, `server`, `server.resources` mit `.requests`/`.limits`, `env[]` mit `valueFrom` und beiden KeyRefs, `securityContext` — **und den Einträgen der `mappings`-Liste**, in denen `domain` und `internalUrl` als `required` deklariert sind.

Die Mapping-Einträge sind der Grund, warum das Schema hier besonders nützlich ist. Aus dem Kommentar in der produktiven Werte-Datei:

> *„Getting these wrong fails silently: the servers stay healthy and running, the router reports nothing, and nobody can connect."*

Genau diese Klasse deckt das Schema jetzt ab, soweit sie strukturell ist:

```
--set 'mappings[0].url=x'   ->  at '/mappings/0': additional properties 'url' not allowed
```

Ein Tippfehler im **Schlüsselnamen** wird abgewiesen. Ein falscher **Wert** (etwa ein Service-Name mit falschem Namespace-Segment) bleibt naturgemäß außerhalb der Reichweite eines Schemas — das ist die Grenze, die #68 von Anfang an benennt.

`mappings` selbst bleibt bewusst **nicht** null-sicher: Das Chart scheitert bei fehlender oder leerer Routing-Tabelle laut und mit eigener Meldung — laute Klasse, die #99 ausnimmt. Ein Router ohne Routen ist nicht betriebsfähig und hat keinen sinnvollen Default.

# 2. Null-Absicherung für Härtung, Probes und Ressourcen (#99)

**Zwei Dinge, die eine rekonstruierte Default-Probe hier nicht verlieren darf** — beide nachgemessen:

1. **Der API-Port wird über seinen Namen adressiert** (`api-port`), nicht über die Nummer. Ein Default mit fester Portnummer würde brechen, sobald jemand `server.apiPort` überschreibt.
2. **Der `Accept: application/json`-Header gehört zum Request.** mc-router hat auch in 1.46.4 keinen `/health`-Endpunkt — `GET /routes` ist das Health-Signal, und der Header ist der korrekte Request für einen JSON-Endpunkt (in 1.25.1 war er sogar zwingend).

Beides überlebt den geleerten Block:

```yaml
          livenessProbe:
            failureThreshold: 3
            httpGet:
              httpHeaders:
              - name: Accept
                value: application/json     # <- erhalten
              path: /routes
              port: api-port                # <- Portname erhalten
            periodSeconds: 10
            timeoutSeconds: 5
```

Der Pod-Context pinnt weiterhin **uid/gid 10000**, obwohl das Image seit 1.46.0 `USER 65532` deklariert — damit die Laufzeit-Identität sich nicht still mit dem Base-Image ändert. Auch das bildet der Fallback exakt ab.

**Wächter geprüft:** keine. **NOTES.txt:** nicht vorhanden.

---

## Nachweis 1: erased Block → vorher, nachher

**Vorher** (`2.0.0`): `securityContext: null`, `livenessProbe: null`.

**Nachher**:

```yaml
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              add: []
              drop:
              - ALL
            readOnlyRootFilesystem: true
            runAsNonRoot: true
```

plus die vollständige Default-Probe oben und die berechneten Limits aus dem geleerten `resources.limits`.

## Nachweis 2: ein bewusst gesetztes `false` / `0` gewinnt weiterhin

`--set server.securityContext.container.readOnlyRootFilesystem=false` → `false`.
`--set server.startupProbe.failureThreshold=0` → `0`.

## Nachweis 3: das Rendering ändert sich nicht

```
$ diff <(helm template t <2.0.0> -f ci/minecraft-router/test-values.yaml) \
       <(helm template t minecraft-router -f ci/minecraft-router/test-values.yaml)
(keine Ausgabe — byte-identisch)
```

Ohne Ausnahme: Dieser PR fügt keinen Kommentar ins Template ein.

## Verifikation

```
$ helm lint --strict minecraft-router
1 chart(s) linted, 0 chart(s) failed
```

**Helper-Audit:** 13 aufgerufen, 13 definiert, `diff` leer.

**Negativprobe — vier Ebenen:**

```
--set bogusTopLevel=true                     -> at '': 'bogusTopLevel' not allowed
--set server.resources.requests.bogusCpu=1   -> at '/server/resources/requests': 'bogusCpu' not allowed
--set 'mappings[0].url=x'                    -> at '/mappings/0': 'url' not allowed
--set server.nodePort=25565                  -> at '/server': 'nodePort' not allowed
```

Die letzte ist ein realistischer Fall: Der Schlüssel heißt `server.outwardPort`, aber „nodePort" ist der Kubernetes-Begriff und liegt näher — heute verschwände er wirkungslos, und der Router wäre auf dem erwarteten Port nicht erreichbar.

## Validierung gegen die real ausgerollten Werte

Bundle `fleet-cd/minecraft-router/`, Release `mc-router`, gepinnt auf `1.0.1+up1.46.4`. Bundle-Datei und `helm get values mc-router -n mc-router` **deckungsgleich**.

**Liste abgewiesener Schlüssel: leer.** Gesetzt werden die drei Mappings (sultan-saladin, oceanblock, ftb-skies) und `server.outwardPort: 25565`. Gegengeprüft, dass alle drei Routen im Rendering erhalten bleiben. Vor dem Hochziehen auf `3.0.0` ist **nichts zu bereinigen**.

Refs #68, Refs #99.
