### PR TITLE
samba: remove the unimplemented globalConfig value

### DIFF
--- a/samba/Chart.yaml
+++ b/samba/Chart.yaml
@@ -5,6 +5,6 @@ icon: https://avatars.githubusercontent.com/u/13281359
 
 type: application
 
-version: 6.0.0+up4.23.10
+version: 7.0.0+up4.23.10
 
 appVersion: 4.23.10

--- a/samba/values.schema.json
+++ b/samba/values.schema.json
@@ -82,10 +82,6 @@
         "securityContext": {
           "$ref": "#/definitions/securityContext"
         },
-        "globalConfig": {
-          "description": "Currently read by no template - see the note in the PR that introduced this schema. Kept allowed because it is part of the published values surface; whether it gets implemented or removed is a separate decision.",
-          "type": ["string", "null"]
-        },
         "storageClass": {
           "type": ["string", "null"]
         }

--- a/samba/values.yaml
+++ b/samba/values.yaml
@@ -95,5 +95,4 @@ samba:
           - SETGID
           - SETUID
 
-  globalConfig: null
   storageClass: longhorn


### PR DESCRIPTION
`samba.globalConfig` hat seit dem ersten Commit des Charts in `values.yaml` gestanden und wurde von **keinem Template gelesen**. Wer ihn setzte, bekam still gar nichts. Umgesetzt wird die Entscheidung aus #117: **entfernen statt implementieren**.

## Änderung

- `samba.globalConfig` aus `samba/values.yaml` entfernt.
- Die zugehörige Property aus `samba/values.schema.json` entfernt. `additionalProperties` steht auf dem `samba`-Objekt bereits auf `false`, der Schlüssel wird damit ab sofort **abgewiesen** statt ignoriert.
- Version: `6.0.0+up4.23.10` → `7.0.0+up4.23.10` (**Major** — eine veröffentlichte Value verschwindet und wird künftig zurückgewiesen).

## Nachweis: der Schlüssel wird abgewiesen

```console
$ helm template smb samba -f ci/samba/test-values.yaml --set samba.globalConfig=foo
Error: values don't meet the specifications of the schema(s) in the following chart(s):
samba:
- at '/samba': additional properties 'globalConfig' not allowed
```

Statt stiller Wirkungslosigkeit also eine Meldung, die den Schlüssel beim Namen nennt.

## Nachweis: betrieblich folgenlos

- **Fleet-Bundle** (`fleet-cd/cluster-smb/`, nur gelesen): `grep -rn globalConfig` über `cluster-smb.values.yaml` und `fleet.yaml` → kein Treffer.
- **Ausgerollter Stand** (`helm get values cluster-smb -n cluster-smb`): Die user-supplied values setzen den Schlüssel nicht. Er taucht ausschließlich unter `--all` als der chart-eigene Default `globalConfig: null` auf — also genau der Eintrag, der hier verschwindet.
- **Rendering unverändert:** `helm template` mit den CI-Values ist vor und nach der Änderung **byte-identisch**. Das bestätigt unabhängig, dass der Schlüssel wirklich tot war.

## Validierung

- `helm lint --strict samba` → 1 chart linted, **0 failed**, keine Findings. (Die `[INFO] Missing required value`-Zeilen stammen vom Default-Render ohne Values und stehen unverändert auch auf `main`.)
- `helm template` mit `ci/samba/test-values.yaml` rendert sauber durch.

Fixes #117
