### PR TITLE
matrix-synapse: strict values.schema.json + Ingress-Gate + Null-Absicherung (Welle 3, #68/#93/#99)

### DIFF
--- a/matrix-synapse/Chart.yaml
+++ b/matrix-synapse/Chart.yaml
@@ -3,7 +3,7 @@ name: matrix-synapse
 description: A Helm chart to deploy a Matrix Synapse server on Kubernetes
 icon: https://raw.githubusercontent.com/element-hq/synapse/develop/docs/favicon.png
 type: application
-version: 6.0.0+upv1.159.0
+version: 7.0.0+upv1.159.0
 appVersion: "v1.159.0"
 maintainers:
   - name: jklein

--- a/matrix-synapse/templates/_helpers.tpl
+++ b/matrix-synapse/templates/_helpers.tpl
@@ -114,3 +114,227 @@ template-chart is the reference implementation.
 1
 {{- end -}}
 {{- end -}}
+
+{{/*
+Merge a user-supplied values sub-tree onto a dict of chart defaults so that a
+null / empty override falls back to the defaults instead of erasing them.
+
+Input: dict "defaults" <dict> "given" <dict|nil> "path" <string, optional
+values path used in error messages>. Output: YAML of the merged dict (consume
+it with fromYaml).
+
+Why this exists (issue #99): Helm merges values maps recursively, but an
+override key written without children — e.g. a leftover
+
+  securityContext:
+
+after deleting its last remaining sub-key — is YAML null. Where the chart
+defines a default, Helm treats that null as a deletion of the default; the
+template then renders "securityContext: null": no readOnlyRootFilesystem, no
+dropped capabilities, no allowPrivilegeEscalation: false. The workload starts
+and reports healthy while being unhardened, so nothing points at the mistake.
+The same shape erases a probe (it disappears) or the resources block (no
+requests, no computed limits). This helper defines the opposite semantics: an
+empty block means "chart defaults apply".
+
+Rules:
+  - a nil "given" is treated as an empty dict (all defaults apply).
+  - a key whose override value is null keeps the default (nulls never delete).
+  - a key present in both as a map is merged recursively, so a partially
+    filled block only overrides the keys it actually sets.
+  - a scalar override for a key the defaults define as a map is rejected with
+    a message naming the values path, instead of failing later with a template
+    field error.
+  - any other set value wins as given, including an explicit false or 0 —
+    Helm's "default" and sprig's "mergeOverwrite" would both swallow those
+    zero values, hence the explicit kindIs "invalid" nil check.
+  - keys only present in the override are passed through unchanged.
+
+NOTE: like the helpers above, this is duplicated into every chart's
+templates/_helpers.tpl with the chart's name as define prefix, because charts
+in this repo deliberately have no dependencies.
+*/}}
+{{- define "matrix-synapse.defaultedDict" -}}
+{{- $defaults := .defaults | default dict -}}
+{{- $given := .given -}}
+{{- $path := .path | default "value" -}}
+{{- if kindIs "invalid" $given -}}
+{{- $given = dict -}}
+{{- end -}}
+{{- if not (kindIs "map" $given) -}}
+{{- fail (printf "%s must be a mapping or null, got %s (%v)" $path (kindOf $given) $given) -}}
+{{- end -}}
+{{- $out := deepCopy $defaults -}}
+{{- range $key, $value := $given -}}
+{{- if not (kindIs "invalid" $value) -}}
+{{- $default := index $defaults $key -}}
+{{- if and (kindIs "map" $value) (kindIs "map" $default) -}}
+{{- $_ := set $out $key (fromYaml (include "matrix-synapse.defaultedDict" (dict "defaults" $default "given" $value "path" (printf "%s.%s" $path $key)))) -}}
+{{- else if kindIs "map" $default -}}
+{{- fail (printf "%s.%s must be a mapping or null, got %s (%v)" $path $key (kindOf $value) $value) -}}
+{{- else -}}
+{{- $_ := set $out $key $value -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- toYaml $out -}}
+{{- end -}}
+
+{{/*
+Pick one sub-block out of a values block that may itself be null.
+
+Input: dict "block" <dict|nil> "key" <string> "path" <string>.
+Returns YAML of dict "value" <the sub-block, may be nil>, after rejecting a
+non-mapping block with a message that names the values path. Needed because
+".Values.matrix.securityContext" can itself be erased.
+*/}}
+{{- define "matrix-synapse.subBlock" -}}
+{{- $block := .block -}}
+{{- if kindIs "invalid" $block -}}
+{{- $block = dict -}}
+{{- end -}}
+{{- if not (kindIs "map" $block) -}}
+{{- fail (printf "%s must be a mapping or null, got %s (%v)" .path (kindOf $block) $block) -}}
+{{- end -}}
+{{- toYaml (dict "value" (index $block .key)) -}}
+{{- end -}}
+
+{{/*
+The effective security contexts, probes and resources of BOTH workloads
+(issue #99) - the Synapse StatefulSet and the delegation nginx Deployment.
+
+The defaults below MUST stay in sync with the corresponding blocks in
+values.yaml, which stays the documented, user-facing place for them; this copy
+is only the fallback for the case where an override has erased the block.
+
+Synapse specifics a rebuilt default must not lose:
+  - uid/gid 1000 matches the previous gosu default, so existing PVC data stays
+    accessible. The upstream image only drops privileges itself when started as
+    root; with an explicit non-root runAsUser it runs directly as that user.
+  - the probes hit /health on the named "http" port and set scheme HTTP
+    explicitly.
+  - the startup budget is 10s x 30 = 300s (migrations, cache warmup).
+
+Delegation nginx specifics:
+  - it runs as the image's unprivileged nginx user (uid 101) and its pod
+    context deliberately has NO fsGroup - it mounts no volume that needs one.
+  - its probes hit /.well-known/matrix/server, which is the endpoint the whole
+    workload exists for, with a shorter 3s timeout.
+*/}}
+{{- define "matrix-synapse.podSecurityContext" -}}
+{{- $given := (fromYaml (include "matrix-synapse.subBlock" (dict "block" . "key" "pod" "path" "matrix.securityContext"))).value -}}
+{{- $defaults := dict
+      "runAsNonRoot" true
+      "runAsUser" 1000
+      "runAsGroup" 1000
+      "fsGroup" 1000
+      "fsGroupChangePolicy" "Always" -}}
+{{- include "matrix-synapse.defaultedDict" (dict "defaults" $defaults "given" $given "path" "matrix.securityContext.pod") -}}
+{{- end -}}
+
+{{- define "matrix-synapse.containerSecurityContext" -}}
+{{- $given := (fromYaml (include "matrix-synapse.subBlock" (dict "block" . "key" "container" "path" "matrix.securityContext"))).value -}}
+{{- $defaults := dict
+      "allowPrivilegeEscalation" false
+      "readOnlyRootFilesystem" true
+      "runAsNonRoot" true
+      "capabilities" (dict "drop" (list "ALL")) -}}
+{{- include "matrix-synapse.defaultedDict" (dict "defaults" $defaults "given" $given "path" "matrix.securityContext.container") -}}
+{{- end -}}
+
+{{- define "matrix-synapse.probeHttpGet" -}}
+{{- dict "path" "/health" "port" "http" "scheme" "HTTP" | toYaml -}}
+{{- end -}}
+
+{{- define "matrix-synapse.livenessProbe" -}}
+{{- $defaults := dict
+      "httpGet" (fromYaml (include "matrix-synapse.probeHttpGet" .))
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 3 -}}
+{{- include "matrix-synapse.defaultedDict" (dict "defaults" $defaults "given" . "path" "matrix.livenessProbe") -}}
+{{- end -}}
+
+{{- define "matrix-synapse.readinessProbe" -}}
+{{- $defaults := dict
+      "httpGet" (fromYaml (include "matrix-synapse.probeHttpGet" .))
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 3 -}}
+{{- include "matrix-synapse.defaultedDict" (dict "defaults" $defaults "given" . "path" "matrix.readinessProbe") -}}
+{{- end -}}
+
+{{- define "matrix-synapse.startupProbe" -}}
+{{- $defaults := dict
+      "httpGet" (fromYaml (include "matrix-synapse.probeHttpGet" .))
+      "periodSeconds" 10
+      "timeoutSeconds" 5
+      "failureThreshold" 30 -}}
+{{- include "matrix-synapse.defaultedDict" (dict "defaults" $defaults "given" . "path" "matrix.startupProbe") -}}
+{{- end -}}
+
+{{- define "matrix-synapse.effectiveResources" -}}
+{{- $defaults := dict
+      "limitFactor" 3
+      "requests" (dict "memory" "1Gi" "cpu" "1" "ephemeralStorage" "1Gi") -}}
+{{- $merged := fromYaml (include "matrix-synapse.defaultedDict" (dict "defaults" $defaults "given" . "path" "matrix.resources")) -}}
+{{- include "matrix-synapse.resources" $merged -}}
+{{- end -}}
+
+{{- define "matrix-synapse.delegation.podSecurityContext" -}}
+{{- $given := (fromYaml (include "matrix-synapse.subBlock" (dict "block" . "key" "pod" "path" "matrix.delegation.securityContext"))).value -}}
+{{- $defaults := dict
+      "runAsNonRoot" true
+      "runAsUser" 101
+      "runAsGroup" 101 -}}
+{{- include "matrix-synapse.defaultedDict" (dict "defaults" $defaults "given" $given "path" "matrix.delegation.securityContext.pod") -}}
+{{- end -}}
+
+{{- define "matrix-synapse.delegation.containerSecurityContext" -}}
+{{- $given := (fromYaml (include "matrix-synapse.subBlock" (dict "block" . "key" "container" "path" "matrix.delegation.securityContext"))).value -}}
+{{- $defaults := dict
+      "allowPrivilegeEscalation" false
+      "readOnlyRootFilesystem" true
+      "runAsNonRoot" true
+      "capabilities" (dict "drop" (list "ALL")) -}}
+{{- include "matrix-synapse.defaultedDict" (dict "defaults" $defaults "given" $given "path" "matrix.delegation.securityContext.container") -}}
+{{- end -}}
+
+{{- define "matrix-synapse.delegation.probeHttpGet" -}}
+{{- dict "path" "/.well-known/matrix/server" "port" "http" "scheme" "HTTP" | toYaml -}}
+{{- end -}}
+
+{{- define "matrix-synapse.delegation.livenessProbe" -}}
+{{- $defaults := dict
+      "httpGet" (fromYaml (include "matrix-synapse.delegation.probeHttpGet" .))
+      "periodSeconds" 10
+      "timeoutSeconds" 3
+      "failureThreshold" 3 -}}
+{{- include "matrix-synapse.defaultedDict" (dict "defaults" $defaults "given" . "path" "matrix.delegation.livenessProbe") -}}
+{{- end -}}
+
+{{- define "matrix-synapse.delegation.readinessProbe" -}}
+{{- $defaults := dict
+      "httpGet" (fromYaml (include "matrix-synapse.delegation.probeHttpGet" .))
+      "periodSeconds" 10
+      "timeoutSeconds" 3
+      "failureThreshold" 3 -}}
+{{- include "matrix-synapse.defaultedDict" (dict "defaults" $defaults "given" . "path" "matrix.delegation.readinessProbe") -}}
+{{- end -}}
+
+{{- define "matrix-synapse.delegation.startupProbe" -}}
+{{- $defaults := dict
+      "httpGet" (fromYaml (include "matrix-synapse.delegation.probeHttpGet" .))
+      "periodSeconds" 5
+      "timeoutSeconds" 3
+      "failureThreshold" 30 -}}
+{{- include "matrix-synapse.defaultedDict" (dict "defaults" $defaults "given" . "path" "matrix.delegation.startupProbe") -}}
+{{- end -}}
+
+{{- define "matrix-synapse.delegation.effectiveResources" -}}
+{{- $defaults := dict
+      "limitFactor" 3
+      "requests" (dict "memory" "64Mi" "cpu" "125m" "ephemeralStorage" "50Mi") -}}
+{{- $merged := fromYaml (include "matrix-synapse.defaultedDict" (dict "defaults" $defaults "given" . "path" "matrix.delegation.resources")) -}}
+{{- include "matrix-synapse.resources" $merged -}}
+{{- end -}}

--- a/matrix-synapse/templates/matrix-delegation-nginx.configmap.yaml
+++ b/matrix-synapse/templates/matrix-delegation-nginx.configmap.yaml
@@ -26,12 +26,12 @@ data:
         listen 8080;
 
         location /.well-known/matrix/server {
-          return 200 '{"m.server": "{{ .Values.ingress.domain }}:443"}';
+          return 200 '{"m.server": "{{ required "A Domain/Host must be provided (ingress.domain)" .Values.ingress.domain }}:443"}';
           add_header Content-Type application/json;
         }
       
         location /.well-known/matrix/client {
-          return 200 '{"m.homeserver": {"base_url": "https://{{ .Values.ingress.domain }}"}}';
+          return 200 '{"m.homeserver": {"base_url": "https://{{ required "A Domain/Host must be provided (ingress.domain)" .Values.ingress.domain }}"}}';
           add_header Content-Type application/json;
           add_header "Access-Control-Allow-Origin" *;
         }

--- a/matrix-synapse/templates/matrix-delegation-nginx.deployment.yaml
+++ b/matrix-synapse/templates/matrix-delegation-nginx.deployment.yaml
@@ -24,12 +24,12 @@ spec:
     spec:
       automountServiceAccountToken: false
       securityContext:
-        {{- toYaml .Values.matrix.delegation.securityContext.pod | nindent 8 }}
+        {{- include "matrix-synapse.delegation.podSecurityContext" .Values.matrix.delegation.securityContext | nindent 8 }}
       containers:
         - name: {{ .Release.Name }}-{{ .Chart.Name }}-delegation-nginx
           image: "{{ .Values.matrix.delegation.image.repository }}:{{ .Values.matrix.delegation.image.tag }}"
           securityContext:
-            {{- toYaml .Values.matrix.delegation.securityContext.container | nindent 12 }}
+            {{- include "matrix-synapse.delegation.containerSecurityContext" .Values.matrix.delegation.securityContext | nindent 12 }}
           ports:
             - containerPort: 8080
               name: http
@@ -43,13 +43,13 @@ spec:
             - name: tmp
               mountPath: /tmp
           resources:
-            {{- include "matrix-synapse.resources" .Values.matrix.delegation.resources | nindent 12 }}
+            {{- include "matrix-synapse.delegation.effectiveResources" .Values.matrix.delegation.resources | nindent 12 }}
           readinessProbe:
-            {{- toYaml .Values.matrix.delegation.readinessProbe | nindent 12 }}
+            {{- include "matrix-synapse.delegation.readinessProbe" .Values.matrix.delegation.readinessProbe | nindent 12 }}
           livenessProbe:
-            {{- toYaml .Values.matrix.delegation.livenessProbe | nindent 12 }}
+            {{- include "matrix-synapse.delegation.livenessProbe" .Values.matrix.delegation.livenessProbe | nindent 12 }}
           startupProbe:
-            {{- toYaml .Values.matrix.delegation.startupProbe | nindent 12 }}
+            {{- include "matrix-synapse.delegation.startupProbe" .Values.matrix.delegation.startupProbe | nindent 12 }}
       volumes:
         - name: tmp
           emptyDir: {}

--- a/matrix-synapse/templates/matrix-synapse.ingress.yaml
+++ b/matrix-synapse/templates/matrix-synapse.ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -41,3 +42,4 @@ spec:
     - hosts:
         - {{ required "A Domain/Host must be provided" .Values.ingress.domain }}
       secretName: tls-{{ .Release.Name }}-{{ .Chart.Name }}-ingress
+{{- end }}

--- a/matrix-synapse/templates/matrix-synapse.sfs.yaml
+++ b/matrix-synapse/templates/matrix-synapse.sfs.yaml
@@ -18,12 +18,12 @@ spec:
     spec:
       automountServiceAccountToken: false
       securityContext:
-        {{- toYaml .Values.matrix.securityContext.pod | nindent 8 }}
+        {{- include "matrix-synapse.podSecurityContext" .Values.matrix.securityContext | nindent 8 }}
       containers:
         - name: "{{ .Release.Name }}-{{ .Chart.Name }}-container"
           image: "ghcr.io/element-hq/synapse:{{ .Chart.AppVersion }}"
           securityContext:
-            {{- toYaml .Values.matrix.securityContext.container | nindent 12 }}
+            {{- include "matrix-synapse.containerSecurityContext" .Values.matrix.securityContext | nindent 12 }}
           env:
             - name: SYNAPSE_SERVER_NAME
               value: "{{ required "You must provide a Server-Name" .Values.matrix.serverName }}"
@@ -56,13 +56,13 @@ spec:
               containerPort: 8008
               protocol: TCP
           readinessProbe:
-            {{- toYaml .Values.matrix.readinessProbe | nindent 12 }}
+            {{- include "matrix-synapse.readinessProbe" .Values.matrix.readinessProbe | nindent 12 }}
           livenessProbe:
-            {{- toYaml .Values.matrix.livenessProbe | nindent 12 }}
+            {{- include "matrix-synapse.livenessProbe" .Values.matrix.livenessProbe | nindent 12 }}
           startupProbe:
-            {{- toYaml .Values.matrix.startupProbe | nindent 12 }}
+            {{- include "matrix-synapse.startupProbe" .Values.matrix.startupProbe | nindent 12 }}
           resources:
-            {{- include "matrix-synapse.resources" .Values.matrix.resources | nindent 12 }}
+            {{- include "matrix-synapse.effectiveResources" .Values.matrix.resources | nindent 12 }}
           volumeMounts:
             - name: matrix-synapse-volume
               mountPath: /data

--- a/matrix-synapse/values.schema.json
+++ b/matrix-synapse/values.schema.json
@@ -1,0 +1,238 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "matrix-synapse values",
+  "description": "Strict values schema (issue #68). additionalProperties is false on every chart-owned object level, so a key that the chart does not read is rejected at render time instead of being silently ignored. The only objects that stay open are the ones passed verbatim into the Kubernetes pod spec (probes, security contexts, global) - the chart does not interpret their contents, so it cannot judge which keys are meaningful. The hardening, probe and resources blocks of BOTH workloads additionally accept null, because an erased block falls back to the chart defaults (issue #99).",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "global": {
+      "description": "Helm's conventional cross-chart values. Unused by this chart, kept open so an umbrella install cannot break on it.",
+      "type": "object"
+    },
+    "scaleDown": {
+      "type": "boolean"
+    },
+    "secrets": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "configSecretRef": {
+          "description": "op:// item path for homeserver.yaml. Changing the item CONTENT does not restart Synapse - Helm never sees it, so it cannot be hashed (#82); restart the StatefulSet by hand.",
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "matrix": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "replicas": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "serverName": {
+          "type": ["string", "null"]
+        },
+        "timezone": {
+          "type": ["string", "null"]
+        },
+        "securityContext": {
+          "$ref": "#/definitions/securityContext"
+        },
+        "livenessProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "readinessProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "startupProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "env": {
+          "$ref": "#/definitions/env"
+        },
+        "resources": {
+          "$ref": "#/definitions/resources"
+        },
+        "delegation": {
+          "description": "The delegation nginx Deployment, which serves the /.well-known/matrix/* endpoints. Disabled by default.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "replicas": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "serverUrl": {
+              "type": ["string", "null"]
+            },
+            "image": {
+              "description": "Auxiliary image, pinned independently of appVersion (which tracks Synapse).",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "repository": {
+                  "type": ["string", "null"]
+                },
+                "tag": {
+                  "type": ["string", "number", "null"]
+                }
+              }
+            },
+            "securityContext": {
+              "$ref": "#/definitions/securityContext"
+            },
+            "livenessProbe": {
+              "$ref": "#/definitions/probe"
+            },
+            "readinessProbe": {
+              "$ref": "#/definitions/probe"
+            },
+            "startupProbe": {
+              "$ref": "#/definitions/probe"
+            },
+            "resources": {
+              "$ref": "#/definitions/resources"
+            }
+          }
+        }
+      }
+    },
+    "storage": {
+      "description": "The data PVC. Not null-safe on purpose: an erased block yields an invalid PVC rather than a silently degraded workload.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "amount": {
+          "type": ["string", "null"]
+        },
+        "storageClass": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "description": "Gates the whole Ingress template (issue #93). false omits the Ingress and makes clusterIssuer unnecessary - but NOT domain, which the delegation nginx also serves in its /.well-known/matrix/* endpoints.",
+          "type": "boolean"
+        },
+        "domain": {
+          "type": ["string", "null"]
+        },
+        "clusterIssuer": {
+          "type": ["string", "null"]
+        },
+        "className": {
+          "type": ["string", "null"]
+        },
+        "annotations": {
+          "description": "Extra Ingress annotations, merged with the cert-manager annotation the chart always sets. Free-form keys by nature.",
+          "type": "object"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "resources": {
+      "description": "May be null / empty: the chart then falls back to its default requests and computed limits (issue #99) instead of rendering a container without resource accounting.",
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "limitFactor": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "requests": {
+          "$ref": "#/definitions/resourceList"
+        },
+        "limits": {
+          "$ref": "#/definitions/resourceList"
+        }
+      }
+    },
+    "resourceList": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "cpu": {
+          "type": ["string", "number", "null"]
+        },
+        "memory": {
+          "type": ["string", "number", "null"]
+        },
+        "ephemeral-storage": {
+          "type": ["string", "number", "null"]
+        },
+        "ephemeralStorage": {
+          "type": ["string", "number", "null"]
+        }
+      }
+    },
+    "env": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "valueFrom": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "secretKeyRef": {
+                "$ref": "#/definitions/keyRef"
+              },
+              "configMapKeyRef": {
+                "$ref": "#/definitions/keyRef"
+              }
+            }
+          }
+        }
+      }
+    },
+    "keyRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "key"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        }
+      }
+    },
+    "securityContext": {
+      "description": "May be null / empty at any level: the chart then falls back to its hardening defaults (issue #99) instead of rendering an unhardened workload.",
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "pod": {
+          "description": "Merged onto the chart's pod hardening defaults and rendered as the pod's securityContext; kept open because the chart does not interpret the individual fields.",
+          "type": ["object", "null"]
+        },
+        "container": {
+          "description": "Merged onto the chart's container hardening defaults and rendered as the container's securityContext; kept open because the chart does not interpret the individual fields.",
+          "type": ["object", "null"]
+        }
+      }
+    },
+    "probe": {
+      "description": "Merged onto the chart's probe defaults and rendered as a container probe; kept open because the chart does not interpret the individual fields. May be null / empty, which means the defaults apply (issue #99) rather than the probe disappearing.",
+      "type": ["object", "null"]
+    }
+  }
+}

--- a/matrix-synapse/values.yaml
+++ b/matrix-synapse/values.yaml
@@ -151,6 +151,11 @@ storage:
   storageClass: longhorn-encrypted
 
 ingress:
+  # Set to false to omit the Ingress entirely. Note that ingress.domain is also
+  # read by the delegation nginx, which serves it in the /.well-known/matrix/*
+  # endpoints, so it stays required whenever matrix.delegation.enabled is true.
+  # Only clusterIssuer becomes unnecessary.
+  enabled: true
   domain: null
   clusterIssuer: null
   className: nginx


### PR DESCRIPTION
Zweites Chart der **Welle 3** aus #68 — und mit paperless-ngx das zweite mit zwei Workloads. **6.0.0 → 7.0.0** (major, appVersion unverändert bei `v1.159.0`).

`freesailarr` ist bewusst nicht Teil dieser Welle: Das Chart liegt noch nicht auf `main` (PR #59).

**Unangetastet**: die `checksum/config`-Annotation am Delegations-nginx aus #82 (im Diff nachprüfbar — sie taucht dort nicht auf).

---

# 1. Strict `values.schema.json` (#68)

`additionalProperties: false` auf allen chart-eigenen Objektebenen: oberste Ebene, `secrets`, `matrix`, `matrix.resources` mit `.requests`/`.limits`, `env[]`, `securityContext`, der komplette `matrix.delegation`-Block mit **eigenen** Contexts, Probes und `resources`, `matrix.delegation.image`, `storage`, `ingress`.

`storage` bleibt **nicht** null-sicher: ein geleerter Block ergibt eine ungültige PVC — laute Klasse.

# 2. Ingress-Gate (#93)

Ingress-Template gegatet, `ingress.enabled` mit Default `true`.

### Der Prüfpunkt findet hier einen zweiten Leser — und der ist besonders unangenehm

`ingress.domain` wird außerhalb des Ingress-Templates gelesen: Der Delegations-nginx serviert ihn in seinen `/.well-known/matrix/{server,client}`-Endpunkten, **ohne** Absicherung. Diese Endpunkte sind genau das, wofür der Workload existiert — über sie findet die Föderation den Homeserver.

Nachgestellt an einer Kopie **mit** Gate, aber **ohne** die Absicherung (`ingress.enabled=false`, Delegation an, kein `domain`):

```
return 200 '{"m.server": ":443"}';
return 200 '{"m.homeserver": {"base_url": "https://"}}';
```

Das rendert, startet und meldet grün — und beantwortet jede Föderationsanfrage mit einer kaputten Adresse. Beide Lesezugriffe stehen deshalb jetzt unter `required()`:

```
$ helm template t matrix-synapse --set ingress.enabled=false --set matrix.delegation.enabled=true …
Error: execution error at (…/matrix-delegation-nginx.deployment.yaml:23:28):
A Domain/Host must be provided (ingress.domain)
```

Sechster Fall desselben Musters (patchmon, rallly, zipline, voucher-vault, outline, jetzt matrix-synapse). **Das Gate macht `clusterIssuer` entbehrlich, nicht `domain`.**

| Fall | Ergebnis |
|---|---|
| Gate an (Default) | 1 Ingress, well-known unverändert |
| Gate aus, `domain` gesetzt, **kein** `clusterIssuer` | rendert, **0** Ingress, well-known weiter korrekt befüllt |
| Gate aus, Delegation an, **kein** `domain` | scheitert laut (siehe oben) |

# 3. Null-Absicherung für Härtung, Probes und Ressourcen (#99) — beide Workloads

Je Workload: Pod-Context, Container-Context, drei Probes, `resources`.

**Was die rekonstruierten Defaults auseinanderhalten müssen** — beide Workloads haben eigene, inhaltlich verschiedene Probes, und ein gemeinsamer Default wäre für einen von beiden falsch:

| | Synapse | Delegations-nginx |
|---|---|---|
| Probe-Pfad | `/health` | `/.well-known/matrix/server` |
| Timeout | 5s | 3s |
| Startup | 10s × 30 = 300s (Migrationen, Cache-Warmup) | 5s × 30 = 150s |
| Pod-Context | uid/gid 1000 **mit** `fsGroup` (PVC) | uid/gid 101 **ohne** `fsGroup` (kein Volume, das eine braucht) |

Beides nachgemessen: Mit geleerten Blöcken auf beiden Seiten rendert das Ergebnis wieder mit `path: /health` **und** `path: /.well-known/matrix/server`, mit `periodSeconds: 10` bzw. `5`.

Die uid/gid 1000 bei Synapse entspricht dem früheren gosu-Default — deshalb bleiben bestehende PVC-Daten zugänglich, und ein „aufgeräumter" anderer Wert wäre hier ein Datenzugriffsproblem.

---

## Nachweis 1: erased Block → vorher, nachher

Werte-Datei mit geleerten Blöcken in **beiden** Workloads (`matrix.securityContext.container`, `matrix.livenessProbe`, `matrix.delegation.securityContext.container`, `matrix.delegation.startupProbe`, `matrix.delegation.resources.limits`).

**Vorher** (`6.0.0`): **4** `null`-Vorkommen im gerenderten Manifest.
**Nachher**: **0** — jeder Block ist durch seine Defaults ersetzt, jeweils die des richtigen Workloads.

## Nachweis 2: ein bewusst gesetztes `false` / `0` gewinnt weiterhin

`--set matrix.securityContext.container.readOnlyRootFilesystem=false` → `false` (der zweite Container behält `true`).
`--set matrix.delegation.startupProbe.failureThreshold=0` → `0`.

## Nachweis 3: das Rendering ändert sich nicht — zweifach

```
$ diff <(helm template t <6.0.0> -f ci/matrix-synapse/test-values.yaml) <(helm template t matrix-synapse …)
(keine Ausgabe — byte-identisch)

$ diff <(helm template matrix-synapse <6.0.0> -f <Bundle-Werte>) <(helm template matrix-synapse matrix-synapse -f …)
(keine Ausgabe — byte-identisch)
```

Die CI-Werte aktivieren die Delegation, der Vergleich deckt also **beide** Workloads ab.

## Verifikation

```
$ helm lint --strict matrix-synapse
1 chart(s) linted, 0 chart(s) failed
```

**Helper-Audit:** 20 aufgerufen, 20 definiert, `diff` leer.

**Negativprobe:**

```
--set bogusTopLevel=true                                -> at '': 'bogusTopLevel' not allowed
--set matrix.delegation.resources.requests.bogusCpu=1   -> at '/matrix/delegation/resources/requests': 'bogusCpu' not allowed
--set ingress.enable=false                              -> at '/ingress': 'enable' not allowed
```

## Validierung gegen die real ausgerollten Werte

Bundle `fleet-cd/matrix-synapse/matrix/`, Release `matrix-synapse`, gepinnt auf `6.0.0+upv1.159.0`. Bundle-Datei und `helm get values matrix-synapse -n matrix-synapse` **deckungsgleich**.

**Liste abgewiesener Schlüssel: leer.** Gesetzt werden `secrets.configSecretRef`, `matrix.{serverName,timezone}`, `matrix.delegation.{enabled,serverUrl}` und `ingress.{domain,clusterIssuer}` — alle bekannt und gefüllt.

Erfreulich: Der Kommentar am Kopf der Bundle-Datei dokumentiert bereits die Umstellung auf den `secrets`-Block aus Chart 6.0.0 („configSecretRef used to sit under matrix"). Das ist die Migration, die bei zipline und samba **nicht** nachgezogen wurde — hier wurde sie gemacht und aufgeschrieben. Vor dem Hochziehen auf `7.0.0` ist **nichts zu bereinigen**.

Refs #68, Refs #93, Refs #99.
