### PR TITLE
Add NOTES.txt to the patchmon chart

### DIFF
--- a/patchmon/Chart.yaml
+++ b/patchmon/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://raw.githubusercontent.com/PatchMon/PatchMon/main/frontend/public/a
 
 type: application
 
-version: 6.0.0+up2.1.3
+version: 6.1.0+up2.1.3
 appVersion: "2.1.3"
 
 maintainers:

--- a/patchmon/templates/NOTES.txt
+++ b/patchmon/templates/NOTES.txt
@@ -1,0 +1,100 @@
+{{- $replicas := include "patchmon.replicas" (dict "scaleDown" .Values.scaleDown "replicas" .Values.patchmon.server.replicas) -}}
+{{- /* The effective (null-safe) probe helper, so the budget below matches the
+       container even when the startupProbe block has been erased (#99). */ -}}
+{{- $startup := fromYaml (include "patchmon.server.startupProbe" (dict "given" .Values.patchmon.server.startupProbe "root" $)) -}}
+{{- $budget := mul (int $startup.periodSeconds) (int $startup.failureThreshold) -}}
+{{- $name := printf "%s-%s" .Release.Name .Chart.Name -}}
+PatchMon {{ .Chart.AppVersion }} — release {{ .Release.Name }} in namespace {{ .Release.Namespace }}.
+
+ACCESS
+{{- if .Values.ingress.enabled }}
+  https://{{ .Values.ingress.domain }}
+
+  While cert-manager is still issuing the certificate the browser warns:
+
+    kubectl -n {{ .Release.Namespace }} get certificate tls-{{ $name }}-ingress
+{{- else }}
+  ingress.enabled is false, so there is no Ingress. Reach it directly with
+
+    kubectl -n {{ .Release.Namespace }} port-forward svc/{{ $name }}-service 3000:80
+
+  ingress.domain stays required even without an Ingress — the server's
+  CORS_ORIGIN is built from it — and it is still {{ .Values.ingress.domain }} here. The server
+  answers 403 to any Host header it does not know, so address it under that
+  name rather than as plain localhost:
+
+    curl -H "Host: {{ .Values.ingress.domain }}" http://localhost:3000/health
+{{- end }}
+
+THE FOUR 1PASSWORD ITEMS AND THE FIELDS THEY MUST CONTAIN
+  The OnePasswordItem CRs only carry the item paths; which *fields* each item
+  needs is decided in the deployment, which is a tedious place to look it up.
+  A missing field does not fail the install — the container starts with the
+  variable empty and misbehaves later.
+
+  secrets.postgresSecretRef -> {{ .Values.secrets.postgresSecretRef | default "(not set)" }}
+    database-url
+
+  secrets.redisSecretRef -> {{ .Values.secrets.redisSecretRef | default "(not set)" }}
+    host, port, username, password, db
+
+  secrets.patchmonSecretRef -> {{ .Values.secrets.patchmonSecretRef | default "(not set)" }}
+    jwt-secret, encryption-key, session-secret
+
+  secrets.oidcSecretRef -> {{ .Values.secrets.oidcSecretRef | default "(not set)" }}
+    issuer-url, client-id, client-secret, redirect-uri, requested-scopes,
+    button-text, user-group-name, admin-group-name
+
+  Watch them materialize:
+
+    kubectl -n {{ .Release.Namespace }} get onepassworditem
+
+SIGN-IN IS OIDC-ONLY — THERE IS NO LOCAL ACCOUNT TO FALL BACK ON
+  The chart sets OIDC_DISABLE_LOCAL_AUTH=true, so the login form is gone and
+  there is no built-in admin. If the OIDC item is wrong, nobody gets in —
+  including you. Users are created on first login with the "readonly" role;
+  admin rights follow the group named in the item's admin-group-name field.
+  The item's redirect-uri has to point back at this installation{{ if .Values.ingress.enabled }} under
+  https://{{ .Values.ingress.domain }}{{ end }}, and it must match what is registered at the
+  identity provider exactly.
+{{- if .Values.ingress.enabled }}
+
+A WRONG ingress.domain KEEPS THE POD OUT OF READY FOREVER
+  The 2.x server answers 403 to any request whose Host header is neither
+  loopback nor a CORS_ORIGIN host, and CORS_ORIGIN is built from
+  ingress.domain. The probes therefore send "Host: {{ .Values.ingress.domain }}" explicitly.
+  If that value is not the hostname the server is actually reached under, the
+  probes get 403, the pod never turns Ready and nothing in the log looks like
+  a configuration error — just repeated 403s.
+{{- end }}
+
+GIVE THE FIRST START TIME
+  The server waits for the database and runs its migrations at boot, and the
+  first 2.x start rebuilds the database indexes, which takes minutes on slow
+  storage. The startup probe budget is {{ $budget }}s ({{ div $budget 60 }} minutes) before Kubernetes
+  starts killing the container — a slow first boot is expected, not a hang:
+
+    kubectl -n {{ .Release.Namespace }} logs deploy/{{ $name }}-deployment -f
+
+ONE REPLICA ONLY
+  The server registers itself in the Redis presence registry under its pod
+  hostname, which the chart pins to {{ $name }}-server. A second
+  replica would register the same identity, so this chart supports exactly
+  one — raising patchmon.server.replicas does not scale it out.
+{{- if .Values.patchmon.guacd.enabled }}
+
+GUACD SIDECAR IS ON
+  patchmon.guacd.enabled is true, so {{ .Values.patchmon.guacd.image }} runs beside the
+  server and it is reached at 127.0.0.1:4822 — in-browser RDP for Windows
+  hosts, which upstream still labels beta. The sidecar is pinned separately
+  from the chart's appVersion and needs its own review at upgrade time. It
+  listens on the pod only; nothing exposes 4822 outside.
+{{- end }}
+{{- if eq $replicas "0" }}
+
+SCALED TO ZERO
+  {{ if .Values.scaleDown }}scaleDown: true{{ else }}patchmon.server.replicas: 0{{ end }} — the deployment runs with replicas: 0. Secrets,
+  Service{{ if .Values.ingress.enabled }} and Ingress{{ end }} stay in place, and the agents on your hosts keep
+  retrying, so nothing is lost; they simply report nothing until you set it
+  back and upgrade again.
+{{- end }}


### PR DESCRIPTION
Adds `patchmon/templates/NOTES.txt`. Refs #43.

Chart version `6.0.0+up2.1.3` → `6.1.0+up2.1.3` (minor, purely additive).

## What it prints and why

patchmon is the first chart in this series with real secrets, so the centre of gravity is different: the `OnePasswordItem` CRs carry only the item *paths*, while the **fields** each item must contain are decided in the deployment's `secretKeyRef` blocks. That is exactly the "you would otherwise dig it out of the template" information, so the notes list it per item:

| values key | fields the 1Password item must contain |
| --- | --- |
| `secrets.postgresSecretRef` | `database-url` |
| `secrets.redisSecretRef` | `host`, `port`, `username`, `password`, `db` |
| `secrets.patchmonSecretRef` | `jwt-secret`, `encryption-key`, `session-secret` |
| `secrets.oidcSecretRef` | `issuer-url`, `client-id`, `client-secret`, `redirect-uri`, `requested-scopes`, `button-text`, `user-group-name`, `admin-group-name` |

Cross-checked against `ci/patchmon/fixtures.yaml`, which sets exactly these keys. The notes print the configured `op://` path next to each, and say why it matters: a missing field does not fail the install — the container starts with an empty variable and misbehaves later.

The warnings this chart earns:

- **Sign-in is OIDC-only.** The chart sets `OIDC_DISABLE_LOCAL_AUTH=true`, so there is no login form and no built-in admin. A wrong OIDC item locks everyone out, including the operator. New users arrive as `readonly`; admin rights follow the item's `admin-group-name`.
- **A wrong `ingress.domain` never becomes Ready.** Verified, not inherited from a comment (below).
- **Give the first start time.** Migrations plus the 2.x index rebuild; the notes print the actual startup budget and state that a slow first boot is not a hang.
- **One replica only.** The server registers in the Redis presence registry under its pod hostname, which the chart pins — so raising `replicas` does not scale it out.

Conditional: the **guacd sidecar** block only when enabled, the **scaled-to-zero** block only when it applies, and the access section switches between Ingress URL and `port-forward`.

## Verified rather than assumed

**The 403-on-unknown-Host behaviour.** The values file asserts it; I measured it against the running server — same pod, same endpoint, only the `Host` header differing:

```
Host: patchmon.ci.local  -> 200
Host: evil.example.com   -> 403
```

That is what makes the warning worth printing: the probes send that header, so a wrong `ingress.domain` produces a pod that never turns Ready, with nothing in the log resembling a config error — just repeated 403s.

**The guacd sidecar actually runs** under the hardened context, rather than merely rendering:

```
ci-patchmon-deployment-9dd594577-gw8js  containers=ci-patchmon-server ci-patchmon-guacd  ready=true true
```

**The startup budget is computed, not typed.** It comes from the null-safe `patchmon.server.startupProbe` helper (`periodSeconds × failureThreshold`), so it tracks overrides and survives an erased probe block. At defaults it renders as `600s (10 minutes)`.

## One chart bug found (not fixed here)

`values.yaml` says of `ingress.enabled`:

> Set to false to omit the Ingress entirely (the required domain and clusterIssuer values are then not needed either, because they are only read inside the Ingress template).

The domain half is wrong. `ingress.domain` is *also* read by the deployment for `CORS_ORIGIN`, so with `ingress.enabled: false` and no domain the render fails:

```
Error: execution error at (patchmon/templates/patchmon.deployment.yaml:137:33): A Domain/Host must be provided
```

Only `clusterIssuer` really becomes optional. I left the comment alone (out of scope for an additive notes PR) and instead made the notes state the true behaviour in the no-Ingress branch. Happy to fix the comment in a follow-up.

## Verification

`helm lint --strict patchmon` → `1 chart(s) linted, 0 chart(s) failed`.

Beyond the usual real install, this chart was run through **the repository's own install test** locally — `ci/run-install-test.sh patchmon` with its committed fixtures (stub CRD, postgres, redis, dex) against a throwaway k3d cluster, pointed at an isolated kubeconfig so it could not reach any other context:

```
deployment "ci-patchmon-deployment" successfully rolled out
OK: chart 'patchmon' installed and all workloads are Ready.
```

`helm template` does not render `NOTES.txt`, so all output below is from real installs/upgrades with `--wait`.

### Variant A — CI values, defaults (no guacd, not scaled down)

```
PatchMon 2.1.3 — release ci in namespace default.

ACCESS
  https://patchmon.ci.local

  While cert-manager is still issuing the certificate the browser warns:

    kubectl -n default get certificate tls-ci-patchmon-ingress

THE FOUR 1PASSWORD ITEMS AND THE FIELDS THEY MUST CONTAIN
  The OnePasswordItem CRs only carry the item paths; which *fields* each item
  needs is decided in the deployment, which is a tedious place to look it up.
  A missing field does not fail the install — the container starts with the
  variable empty and misbehaves later.

  secrets.postgresSecretRef -> op://ci/patchmon-postgres
    database-url

  secrets.redisSecretRef -> op://ci/patchmon-redis
    host, port, username, password, db

  secrets.patchmonSecretRef -> op://ci/patchmon
    jwt-secret, encryption-key, session-secret

  secrets.oidcSecretRef -> op://ci/patchmon-oidc
    issuer-url, client-id, client-secret, redirect-uri, requested-scopes,
    button-text, user-group-name, admin-group-name

  Watch them materialize:

    kubectl -n default get onepassworditem

SIGN-IN IS OIDC-ONLY — THERE IS NO LOCAL ACCOUNT TO FALL BACK ON
  The chart sets OIDC_DISABLE_LOCAL_AUTH=true, so the login form is gone and
  there is no built-in admin. If the OIDC item is wrong, nobody gets in —
  including you. Users are created on first login with the "readonly" role;
  admin rights follow the group named in the item's admin-group-name field.
  The item's redirect-uri has to point back at this installation under
  https://patchmon.ci.local, and it must match what is registered at the
  identity provider exactly.

A WRONG ingress.domain KEEPS THE POD OUT OF READY FOREVER
  The 2.x server answers 403 to any request whose Host header is neither
  loopback nor a CORS_ORIGIN host, and CORS_ORIGIN is built from
  ingress.domain. The probes therefore send "Host: patchmon.ci.local" explicitly.
  If that value is not the hostname the server is actually reached under, the
  probes get 403, the pod never turns Ready and nothing in the log looks like
  a configuration error — just repeated 403s.

GIVE THE FIRST START TIME
  The server waits for the database and runs its migrations at boot, and the
  first 2.x start rebuilds the database indexes, which takes minutes on slow
  storage. The startup probe budget is 600s (10 minutes) before Kubernetes
  starts killing the container — a slow first boot is expected, not a hang:

    kubectl -n default logs deploy/ci-patchmon-deployment -f

ONE REPLICA ONLY
  The server registers itself in the Redis presence registry under its pod
  hostname, which the chart pins to ci-patchmon-server. A second
  replica would register the same identity, so this chart supports exactly
  one — raising patchmon.server.replicas does not scale it out.
```

Both conditional blocks are correctly absent.

### Variant B — `patchmon.guacd.enabled=true`

```
GUACD SIDECAR IS ON
  patchmon.guacd.enabled is true, so guacamole/guacd:1.6.0 runs beside the
  server and it is reached at 127.0.0.1:4822 — in-browser RDP for Windows
  hosts, which upstream still labels beta. The sidecar is pinned separately
  from the chart's appVersion and needs its own review at upgrade time. It
  listens on the pod only; nothing exposes 4822 outside.
```

### Variant C — `scaleDown=true`

```
SCALED TO ZERO
  scaleDown: true — the deployment runs with replicas: 0. Secrets,
  Service and Ingress stay in place, and the agents on your hosts keep
  retrying, so nothing is lost; they simply report nothing until you set it
  back and upgrade again.
```

### Variant D — `ingress.enabled=false`

```
ACCESS
  ingress.enabled is false, so there is no Ingress. Reach it directly with

    kubectl -n default port-forward svc/ci2-patchmon-service 3000:80

  ingress.domain stays required even without an Ingress — the server's
  CORS_ORIGIN is built from it — and it is still patchmon.ci.local here. The server
  answers 403 to any Host header it does not know, so address it under that
  name rather than as plain localhost:

    curl -H "Host: patchmon.ci.local" http://localhost:3000/health
```

The k3d cluster stays up for the remaining charts in this batch and is deleted at the end.
