### PR TITLE
rallly: default smtp.rejectUnauthorized to true

### DIFF
--- a/rallly/Chart.yaml
+++ b/rallly/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://raw.githubusercontent.com/lukevella/rallly/main/apps/landing/publi
 
 type: application
 
-version: 6.0.0+up4.12.3
+version: 7.0.0+up4.12.3
 appVersion: "4.12.3"
 
 maintainers:

--- a/rallly/templates/rallly.deployment.yaml
+++ b/rallly/templates/rallly.deployment.yaml
@@ -73,7 +73,12 @@ spec:
                   name: {{ .Release.Name }}-{{ .Chart.Name }}-smtp-secret
                   key: password
             - name: SMTP_REJECT_UNAUTHORIZED
-              value: "{{ .Values.rallly.smtp.rejectUnauthorized }}"
+              {{- /* Not "| default true": an explicit false is a zero value, and
+                     "default" would swallow it and silently re-enable the check
+                     the operator just switched off. A nil (erased key) falls back
+                     to the chart default true, so the variable can never reach
+                     the app as an empty string (issues #109, #99). */}}
+              value: "{{ if kindIs "invalid" .Values.rallly.smtp.rejectUnauthorized }}true{{ else }}{{ .Values.rallly.smtp.rejectUnauthorized }}{{ end }}"
             - name: SMTP_TLS_SERVERNAME
               valueFrom:
                 secretKeyRef:

--- a/rallly/values.schema.json
+++ b/rallly/values.schema.json
@@ -46,8 +46,8 @@
               "type": "boolean"
             },
             "rejectUnauthorized": {
-              "description": "Passed to the app as SMTP_REJECT_UNAUTHORIZED. Read by the chart but deliberately without a default in values.yaml - see the note in the PR that introduced this schema.",
-              "type": ["boolean", "string", "null"]
+              "description": "Verify the mail server's TLS certificate; passed to the app as SMTP_REJECT_UNAUTHORIZED. Defaults to true (issue #109). Set false only for a mail server with a self-signed certificate. Strings are rejected: the env var is rendered from this value, and a string like \"yes\" would reach the app as a value it does not read as a boolean. Null means the chart default (true), as elsewhere in this chart (issue #99).",
+              "type": ["boolean", "null"]
             }
           }
         },

--- a/rallly/values.yaml
+++ b/rallly/values.yaml
@@ -16,6 +16,17 @@ rallly:
   replicas: 1
   smtp:
     enabled: false
+    # Verify the mail server's TLS certificate (passed to the app as
+    # SMTP_REJECT_UNAUTHORIZED). Leave this at true.
+    #
+    # Set it to false ONLY for a mail server with a self-signed certificate.
+    # Without that hint the symptom is misleading: the send fails with a
+    # certificate error naming the mail server, so the search starts at the
+    # mail server or its CA chain rather than at this value.
+    #
+    # false disables the certificate check entirely and exposes the SMTP
+    # session to a man-in-the-middle; prefer trusting the CA over setting it.
+    rejectUnauthorized: true
   allowedEmails: '*'
   supportEmail: null
   oidc:


### PR DESCRIPTION
Das Deployment liest `rallly.smtp.rejectUnauthorized` und rendert daraus `SMTP_REJECT_UNAUTHORIZED` — in `values.yaml` stand der Schlüssel aber nicht. Mit aktiviertem SMTP kam die Variable deshalb als **leerer String** bei der App an: eine Zertifikatsprüfung, die niemand konfiguriert hatte, in keine Richtung. Umgesetzt wird die Entscheidung aus #109: Default **`true`**.

## Änderung

- `rallly.smtp.rejectUnauthorized: true` in `values.yaml`, mit Kommentar an Ort und Stelle (s. u.).
- `values.schema.json`: `["boolean", "string", "null"]` → `["boolean", "null"]`. Strings werden abgewiesen — ein `"yes"` würde sonst genau so unbrauchbar bei der App landen wie der leere String.
- Deployment: Der Wert wird **nicht** mit `| default true` gerendert (Begründung unten).
- Version: `6.0.0+up4.12.3` → `7.0.0+up4.12.3` (**Major** — das Laufzeitverhalten des Mailversands ändert sich).

## Der Kommentar in values.yaml

```yaml
  smtp:
    enabled: false
    # Verify the mail server's TLS certificate (passed to the app as
    # SMTP_REJECT_UNAUTHORIZED). Leave this at true.
    #
    # Set it to false ONLY for a mail server with a self-signed certificate.
    # Without that hint the symptom is misleading: the send fails with a
    # certificate error naming the mail server, so the search starts at the
    # mail server or its CA chain rather than at this value.
    #
    # false disables the certificate check entirely and exposes the SMTP
    # session to a man-in-the-middle; prefer trusting the CA over setting it.
    rejectUnauthorized: true
```

## Warum kein `| default true`

`default` schluckt Zero-Values — ein ausdrückliches `false` wäre damit still wieder zu `true` geworden, also genau die Prüfung wieder eingeschaltet, die jemand bewusst abgeschaltet hat. Stattdessen die im Repo übliche `kindIs "invalid"`-Prüfung (#99): nur ein **nil** fällt auf `true` zurück, ein gesetztes `false` gewinnt.

## Nachweise (Rendering)

**Vorher, auf `main`** — `smtp.enabled=true`, Schlüssel ungesetzt:
```
            - name: SMTP_REJECT_UNAUTHORIZED
              value: ""
```

**Nachher** — `smtp.enabled=true`, Default:
```
            - name: SMTP_REJECT_UNAUTHORIZED
              value: "true"
```

**Zero-Value-Fall** — `--set rallly.smtp.rejectUnauthorized=false` gewinnt:
```
            - name: SMTP_REJECT_UNAUTHORIZED
              value: "false"
```

**Gelöschter Schlüssel** — `--set rallly.smtp.rejectUnauthorized=null` fällt auf den Default zurück, nicht auf den leeren String:
```
            - name: SMTP_REJECT_UNAUTHORIZED
              value: "true"
```

**String wird abgewiesen** — `--set-string rallly.smtp.rejectUnauthorized=yes`:
```
Error: values don't meet the specifications of the schema(s) in the following chart(s):
rallly:
- at '/rallly/smtp/rejectUnauthorized': got string, want null or boolean
```

## Betrieblich folgenlos

- Fleet-Bundle `fleet-cd/rallly/rallly.values.yaml` (nur gelesen): `rallly.smtp.enabled: false`.
- Ausgerollter Stand `helm get values rallly -n rallly`: ebenfalls `smtp.enabled: false`.

Mit deaktiviertem SMTP wird der ganze Block nicht gerendert — `helm template` mit den CI-Values ist vor und nach der Änderung **byte-identisch**.

## Validierung

- `helm lint --strict rallly -f ci/rallly/test-values.yaml` → 1 chart linted, **0 failed**.
- `helm template` in den fünf oben gezeigten Varianten.

Fixes #109
