### PR TITLE
gotenberg: small requests, explicit higher limits

### DIFF
--- a/gotenberg/Chart.yaml
+++ b/gotenberg/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://gotenberg.dev/img/logo.png
 
 type: application
 
-version: 6.0.0+up8.36.0
+version: 7.0.0+up8.36.0
 appVersion: "8.36.0"
 
 maintainers:

--- a/gotenberg/templates/NOTES.txt
+++ b/gotenberg/templates/NOTES.txt
@@ -38,28 +38,45 @@ NO AUTHENTICATION, AND THIS CHART CANNOT ADD ANY
   and the URL routes make the server fetch whatever URL they are handed. Keep
   it cluster-internal; do not put an Ingress in front of it without auth.
 
-MEMORY IS THE LIMIT YOU HIT FIRST
-  Chromium and LibreOffice hold the whole document in memory. With this
-  release's limit of {{ index $limits "memory" | default "(none set)" }}, a 20-page HTML converts in well under a second,
-  while a 25 MB HTML is enough to get the container OOM-killed.
-  How you notice: the caller gets no HTTP error — the connection is dropped
-  mid-request — and the pod's RESTARTS counter goes up. Confirm with
+BIG CONVERSIONS RUN OUT OF TIME BEFORE THEY RUN OUT OF MEMORY
+  Chromium and LibreOffice hold the whole document in memory, so a conversion
+  is a short, memory-hungry burst. This release limits the container to
 
-    kubectl -n {{ .Release.Namespace }} get pod -l app={{ .Release.Name }}-{{ .Chart.Name }}-deployment -o jsonpath='{.items[*].status.containerStatuses[*].lastState.terminated.reason}'
+    memory:            {{ index $limits "memory" | default "(none set)" }}
+    ephemeral-storage: {{ index $limits "ephemeral-storage" | default "(none set)" }}
 
-  which then prints OOMKilled. Raise gotenberg.resources.requests.memory (the
-  limit follows at limitFactor x request) or set an explicit limit.
+  against deliberately smaller requests: the pod reserves little while it
+  idles and grows into the limits only while converting.
 
-TEMP SPACE IS TIGHT, AND RUNNING OUT LOOKS DIFFERENT
-  /tmp and /home/gotenberg are emptyDirs, so they count against the container's
-  ephemeral-storage limit of {{ index $limits "ephemeral-storage" | default "(none set)" }}. Chromium's profile alone takes about 4 MB,
-  and the uploaded file plus the rendered PDF come on top.
-  How you notice: the pod does not restart, it disappears — a fresh one takes
-  its place and the old one is left in status Evicted, with the message naming
-  ephemeral-storage. Raise gotenberg.resources.requests.ephemeralStorage.
+  Those limits are set so the 30-second request timeout below is what a
+  too-large document hits first. An 18 MB HTML converts in about 22 seconds
+  and stays well inside them; a document heavy enough to exhaust the memory
+  limit would have run past the 30 seconds anyway, so raising memory further
+  does not turn a failing conversion into a successful one — splitting the
+  document does.
+
+  If you do need to change them, set gotenberg.resources.limits.memory and
+  .limits.ephemeralStorage. Both are set explicitly now, so raising the
+  matching request no longer drags the limit along at limitFactor x request.
+
+  Should a conversion still hit a limit, the two failures look different and
+  neither of them reports an HTTP error to the caller:
+
+  - Out of memory: the connection is dropped mid-request and the pod's
+    RESTARTS counter goes up. Confirm with
+
+      kubectl -n {{ .Release.Namespace }} get pod -l app={{ .Release.Name }}-{{ .Chart.Name }}-deployment -o jsonpath='{.items[*].status.containerStatuses[*].lastState.terminated.reason}'
+
+    which then prints OOMKilled.
+
+  - Out of ephemeral storage: /tmp and /home/gotenberg are emptyDirs and count
+    against the ephemeral-storage limit — Chromium's profile alone takes about
+    4 MB, and the uploaded file plus the rendered PDF come on top. The pod does
+    not restart, it disappears: a fresh one takes its place and the old one is
+    left in status Evicted, with the message naming ephemeral-storage.
 
 REQUESTS TIME OUT AFTER 30 SECONDS
   That is Gotenberg's own default, and since the chart passes no flags it
-  cannot be changed here. Large conversions get close: the 25 MB document
-  above still needed 19 seconds once it had memory enough to finish. Callers
-  that need longer must split the document instead.
+  cannot be changed here. This is the ceiling large conversions actually meet:
+  an 18 MB HTML needs about 22 seconds, and a 25 MB one does not finish inside
+  the 30. Callers that need longer must split the document instead.

--- a/gotenberg/templates/_helpers.tpl
+++ b/gotenberg/templates/_helpers.tpl
@@ -263,7 +263,8 @@ instead of a container without any resource accounting.
 {{- define "gotenberg.effectiveResources" -}}
 {{- $defaults := dict
       "limitFactor" 3
-      "requests" (dict "cpu" 0.1 "memory" "512Mi" "ephemeralStorage" "10Mi") -}}
+      "requests" (dict "cpu" 0.1 "memory" "512Mi" "ephemeralStorage" "10Mi")
+      "limits" (dict "memory" "3Gi" "ephemeralStorage" "256Mi") -}}
 {{- $merged := fromYaml (include "gotenberg.defaultedDict" (dict "defaults" $defaults "given" . "path" "gotenberg.resources")) -}}
 {{- include "gotenberg.resources" $merged -}}
 {{- end -}}

--- a/gotenberg/values.yaml
+++ b/gotenberg/values.yaml
@@ -54,7 +54,27 @@ gotenberg:
     # limitFactor x the request, an explicitly set limit always wins, and a
     # CPU limit is only set when configured explicitly under "limits".
     limitFactor: 3
+    # The requests stay small on purpose: gotenberg idles at a few dozen MB,
+    # so reserving conversion-sized capacity on the node would waste it
+    # around the clock. Conversions are short bursts, and the limits below
+    # cover the burst instead (issue #106).
     requests:
       cpu: 0.1
       memory: 512Mi
       ephemeralStorage: 10Mi
+    # Set explicitly rather than left to limitFactor x request, because the
+    # computed limits (1536Mi / 30Mi) were too small for real documents.
+    # Measured with the official image, HTML converted via Chromium:
+    #   - 18 MB HTML: OOMKilled at 2Gi and 2560Mi, converts at 3Gi in ~22s
+    #     (21 MB PDF). 12 MB HTML already OOM-kills at the old 1536Mi.
+    #   - Raising memory alone only moves the failure: with 3Gi memory and
+    #     the old 30Mi ephemeral limit, /tmp peaked at 40 MB on a single
+    #     conversion and at ~125 MB over a short series, and the pod was
+    #     evicted ("ephemeral local storage usage exceeds the total limit of
+    #     containers 30Mi") instead of OOM-killed.
+    # Memory beyond 3Gi buys nothing: gotenberg's own request timeout is 30s
+    # and the chart passes no flags to change it, so a document that needs
+    # more memory than this has already run out of time.
+    limits:
+      memory: 3Gi
+      ephemeralStorage: 256Mi


### PR DESCRIPTION
Umsetzung der Entscheidung aus #106: **Request klein lassen, Limits explizit anheben** — und das **ephemeral-storage-Limit zwingend mit**, damit der Fehler nicht bloß von OOM zu Eviction verschoben wird.

## Änderung

| | vorher (limitFactor 3 x request) | nachher (explizit) |
|---|---|---|
| memory request | 512Mi | 512Mi (unverändert) |
| memory limit | 1536Mi | **3Gi** |
| ephemeral-storage request | 10Mi | 10Mi (unverändert) |
| ephemeral-storage limit | 30Mi | **256Mi** |

Requests bleiben klein — der Pod reserviert im Leerlauf weiterhin wenig, das Scheduling bleibt günstig. Neue Mechanik war nicht nötig: ein explizit gesetztes Limit gewinnt bereits über den `limitFactor`-Rechenweg.

Version: `6.0.0+up8.36.0` → `7.0.0+up8.36.0` (**Major**).

## Messreihe

Wegwerf-k3d-Cluster, offizielles Image `gotenberg/gotenberg:8.36.0`, HTML über Chromium, Temp-Verbrauch wie in der Ursprungsmessung per `du -sb` mit 4 Hz im laufenden Container. Dokument ist ein realistischer Langbericht (Fließtext mit Überschriften und gelegentlichen Tabellen), kein konstruierter Extremfall.

**Kalibrierung gegen die Reihe im Issue:** 80 KB HTML → HTTP 200 in 0,63 s, Temp-Peak 3,3 MB (im Issue: 75 KB → 0,5 s, 3,7 MB). Gleiche Größenordnung, die Methode ist also vergleichbar.

### Memory-Schwelle eingegrenzt

| Eingabe | Memory-Limit | Ergebnis |
|---|---|---|
| 12 MB HTML | **1536Mi** (bisheriges Limit) | **OOMKilled**, curl exit 52, RESTARTS 1 |
| 12 MB HTML | 2Gi | HTTP 200 in 13,2 s, 14 MB PDF |
| 18 MB HTML | 2Gi | **OOMKilled** |
| 18 MB HTML | 2560Mi | **OOMKilled** |
| 18 MB HTML | **3Gi** | HTTP 200 in 22,5 s, 21 MB PDF |
| 25 MB HTML | 3Gi | OOM nach 29,1 s |
| 25 MB HTML | 4Gi | **HTTP 503** — Timeout nach 30 s |

Bemerkenswert: schon **12 MB** kippen am alten Limit, nicht erst 25 MB.

### Warum 3Gi und nicht mehr

Die letzte Zeile ist der Grund. Gotenbergs **eigener Request-Timeout von 30 s** ist ein Flag, das dieses Chart nicht setzt — er ist also nicht verhandelbar. Ein 18-MB-Dokument braucht ~22 s und liegt damit knapp darunter; ein 25-MB-Dokument läuft auch mit 4Gi in den Timeout. Mehr Memory macht aus einer scheiternden Konvertierung also keine erfolgreiche, es verschiebt sie nur von OOM auf 503. 3Gi ist damit der kleinste gemessene Wert, der das größte Dokument trägt, das überhaupt noch ins Zeitbudget passt.

### ephemeral-storage: der Fehler wäre sonst nur verschoben

Genau der im Issue benannte Effekt, empirisch erzwungen. Mit **3Gi Memory und dem alten 30Mi-Limit**:

- Einzelne 18-MB-Konvertierung: HTTP 200, aber Temp-Peak **40,3 MB** — der Pod läuft also im Erfolgsfall über sein Limit und entgeht der Eviction nur, weil der Ausschlag kürzer ist als das Housekeeping-Intervall des Kubelet.
- Fünf Konvertierungen hintereinander: Peak **125 MB**, und ab der vierten:

```
gb-gotenberg-deployment-59bbccdf86-wktf7 phase=Failed reason=Evicted
  msg=Pod ephemeral local storage usage exceeds the total limit of containers 30Mi.
```

RESTARTS blieb dabei **0** — der Pod ist nicht neu gestartet, sondern verschwunden und ersetzt worden, der alte blieb als `Evicted` stehen. Also genau die unangenehmere Fehlerart.

Dieselbe Reihe mit **3Gi + 256Mi**: 5/5 Konvertierungen HTTP 200, keine Eviction, keine Restarts.

256Mi liegt damit gut 2x über dem gemessenen 125-MB-Peak und ~5x über den im Issue dokumentierten 46,4 MB. Da nur das *Limit* steigt und der Request bei 10Mi bleibt, kostet der Kopfraum nichts, solange er ungenutzt ist.

## Mitgezogen: die Helper-Defaults

`gotenberg.effectiveResources` hält eine **eigene Kopie** der Defaults (Fallback für einen gelöschten `resources:`-Block, #99). Ohne Nachziehen wäre ein erased Block auf die *alten* berechneten Limits zurückgefallen. Geprüft:

```console
$ helm template gb gotenberg --set gotenberg.resources=null | grep -A3 limits:
            limits:
              ephemeral-storage: 256Mi
              memory: 3Gi
```

## Mitgezogen: die NOTES.txt

Die Zahlen stimmten dank `effectiveResources` automatisch — der **Text** nicht:

1. Die Überschrift **"MEMORY IS THE LIMIT YOU HIT FIRST"** stimmt nicht mehr. Sie heißt jetzt *"BIG CONVERSIONS RUN OUT OF TIME BEFORE THEY RUN OUT OF MEMORY"* — mit diesen Limits ist der 30-s-Timeout das bindende Ende.
2. Der Ratschlag *"Raise gotenberg.resources.requests.memory (the limit follows at limitFactor x request)"* war ab jetzt schlicht **falsch**: Bei explizit gesetzten Limits zieht der Request das Limit nicht mehr mit. Der Text nennt jetzt `resources.limits.memory` / `.limits.ephemeralStorage` und sagt ausdrücklich, dass die Kopplung entfällt.
3. Die Schwelle wandert: statt "25 MB HTML genügt für einen OOM-Kill" jetzt "18 MB HTML konvertiert in ~22 s und bleibt gut innerhalb der Limits".
4. `TEMP SPACE IS TIGHT` ist keine zutreffende Überschrift mehr — der Abschnitt ist als Unterpunkt in die Fehlerbild-Liste gewandert. **Die Erkennungsmerkmale bleiben vollständig erhalten** (OOM: Verbindung reißt ab, RESTARTS steigt, `lastState.terminated.reason` = OOMKilled; Eviction: Pod verschwindet und wird ersetzt, alter bleibt `Evicted` mit ephemeral-storage in der Meldung) — die Warnung klingt nur nicht mehr schärfer, als der neue Zustand rechtfertigt.

Die Limit-Ausgabe steht jetzt auf eigenen Zeilen, damit der Umbruch nicht von der Länge des eingesetzten Wertes abhängt:

```
  is a short, memory-hungry burst. This release limits the container to

    memory:            3Gi
    ephemeral-storage: 256Mi

  against deliberately smaller requests: the pod reserves little while it
  idles and grows into the limits only while converting.
```

**Beide Ausgabevarianten geprüft:** Normalfall wie oben; `--set scaleDown=true` rendert zusätzlich den `SCALED TO ZERO`-Block unverändert korrekt. Ebenso geprüft: gelöschter `resources:`-Block (zeigt 3Gi/256Mi, nicht `(none set)`) und eigene Limits (`--set ...limits.memory=6Gi` → NOTES zeigt `6Gi` / `1Gi`).

## Validierung

- `helm lint --strict gotenberg` → 1 chart linted, **0 failed**.
- `helm template` in vier Varianten (Defaults, erased `resources:`, eigene Limits, `scaleDown=true`).
- **Echter Install aus den Chart-Defaults** (ohne `--set`) im k3d: angewandt wurden `requests={"cpu":"100m","ephemeral-storage":"10Mi","memory":"512Mi"}`, `limits={"ephemeral-storage":"256Mi","memory":"3Gi"}`. Anschließend konvertiert:

```
  small.html  (   82830 bytes): http=200 elapsed=0.65s pdf=  121220 bytes
  mid12.html  ( 12633387 bytes): http=200 elapsed=12.4s pdf=14035457 bytes
  mid18.html  ( 18951328 bytes): http=200 elapsed=20.7s pdf=21050143 bytes
  restarts: 0    keine Evicted-Pods
```

Das 12-MB-Dokument, das am alten Limit OOM-gekillt wurde, läuft damit durch.

Der Messcluster war ein eigener Wegwerf-Cluster, alle Aufrufe mit explizitem `--context`, angelegt ohne Context-Switch und danach gelöscht.

## Betrieb

Der ausgerollte Release `cluster-gotenberg` bekommt beim nächsten Upgrade das höhere Limit. Der Request ändert sich nicht, das Scheduling bleibt also unverändert; der Pod darf während einer Konvertierung nur weiter wachsen als bisher.

Fixes #106
