### PR TITLE
cyberchef: seccompProfile RuntimeDefault in the pod context

### DIFF
--- a/cyberchef/Chart.yaml
+++ b/cyberchef/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://raw.githubusercontent.com/gchq/CyberChef/master/src/web/static/ima
 
 type: application
 
-version: 8.0.0+up11.4.0
+version: 9.0.0+up11.4.0
 appVersion: "11.4.0"
 
 maintainers:

--- a/cyberchef/templates/_helpers.tpl
+++ b/cyberchef/templates/_helpers.tpl
@@ -214,7 +214,8 @@ default probe needs no further context.
 {{- $defaults := dict
       "runAsNonRoot" true
       "runAsUser" 101
-      "runAsGroup" 101 -}}
+      "runAsGroup" 101
+      "seccompProfile" (dict "type" "RuntimeDefault") -}}
 {{- include "cyberchef.defaultedDict" (dict "defaults" $defaults "given" $given "path" "cyberchef.securityContext.pod") -}}
 {{- end -}}
 

--- a/cyberchef/values.yaml
+++ b/cyberchef/values.yaml
@@ -16,6 +16,15 @@ cyberchef:
       runAsNonRoot: true
       runAsUser: 101
       runAsGroup: 101
+      # RuntimeDefault applies the container runtime's default seccomp filter,
+      # which blocks the syscalls a normal workload never makes. It sits in the
+      # pod context on purpose: from here it covers every container in the pod
+      # including init containers, while a container-level seccompProfile would
+      # have to be repeated for each one (and silently missed on the next one
+      # added). A container that genuinely needs a different filter can still
+      # override it under securityContext.container, which wins over this value.
+      seccompProfile:
+        type: RuntimeDefault
     container:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true


### PR DESCRIPTION
Adds `seccompProfile: RuntimeDefault` to cyberchef — first chart of the seccomp series for #84, and the one that establishes the pattern for the rest.

## Where the value goes, and why

`seccompProfile` can sit in the pod context or the container context, and the container value overrides the pod value. This series puts it in the **pod context** everywhere. The reason is not style, it is coverage — measured, not assumed:

Rendering paperless-ngx (a chart with an init container) and scanning it shows `AVD-KSV-0104` firing **once per container**:

```
KSV-0104 (MEDIUM): container "ci-pl-paperless-ngx-sfs" ... should specify a seccomp profile
KSV-0104 (MEDIUM): container "init-run-ownership" ... should specify a seccomp profile
```

That init container carries its **own hardcoded** `securityContext` (it runs as root with `CHOWN` to hand `/run` to the paperless uid). A container-level `seccompProfile` would therefore have to be written a second time, by hand, into a context that exists for an unrelated reason — and would be silently missed on the next container anyone adds. From the pod context one line covers all of them, and a container that genuinely needs a different filter can still override it under `securityContext.container`, because the container value wins.

Both placements clear the finding for a single-container pod, so the scanner alone does not decide this; init-container coverage does.

## Verification

**Rendering and lint**

- `helm lint --strict cyberchef` — 0 findings.
- The rendered pod spec carries `seccompProfile: {type: RuntimeDefault}` in the pod context.
- Trivy on the rendered manifest: `KSV-0030` and `KSV-0104` are **gone** (both present before this change). The only MEDIUM+ finding left is `KSV-0125` (trusted registries), which is the policy decision noted on #84, not a chart defect.

**Null-safety (#99)** — cyberchef's `_helpers.tpl` keeps its own copy of the pod defaults, so the fallback had to move with `values.yaml`. It did:

```
helm template ... --set cyberchef.securityContext=null
  →  seccompProfile:
       type: RuntimeDefault
```

An erased `securityContext:` block still renders the profile instead of dropping it. `NOTES.txt` does not read any of the touched helpers.

**k3d** (throwaway cluster `seccomp-cyberchef`, created with `--kubeconfig-switch-context=false`, all calls with explicit `--context`, deleted afterwards; the global context was never used or changed)

- Pod `Running`, `1/1`, **0 restarts**.
- The profile is live on the object, not just in the manifest:
  `pod=RuntimeDefault ctr=` — the container inherits it, as intended.
- **The kernel actually applied it** — inside the container:

  ```
  NoNewPrivs:       1
  Seccomp:          2
  Seccomp_filters:  1
  ```

  `Seccomp: 2` is `SECCOMP_MODE_FILTER` with one filter loaded. This is the check that separates "the field is set" from "the filter is enforced".

**Core function still works, not just Ready** — nginx serves the app under the filter:

- `GET /` → **HTTP 200**, 77440 bytes, `<title>CyberChef</title>`
- `GET /assets/main.js` → **HTTP 200**, 12549446 bytes

A 12.5 MB static asset served in full is the chart's entire job; the profile does not interfere with it.

**CI install-test** — ran `ci/run-install-test.sh cyberchef` verbatim against the k3d cluster (isolated `KUBECONFIG`, no `SKIP` path): real install, `OK: chart 'cyberchef' installed and all workloads are Ready.`

## Version

**Major** (`8.0.0+up11.4.0` → `9.0.0+up11.4.0`): runtime behavior changes. It stays invisible for this workload — a static file server makes no exotic syscalls — but the rule in §2 keys on the behavior change, not on whether it happens to be noticeable here.

The value is user-configurable in the usual place (`cyberchef.securityContext.pod`), so it can be dropped or set to `Unconfined` without a chart change if a filter ever bites.

Refs #84
