### PR TITLE
gotenberg: seccompProfile RuntimeDefault in the pod context

### DIFF
--- a/gotenberg/Chart.yaml
+++ b/gotenberg/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://gotenberg.dev/img/logo.png
 
 type: application
 
-version: 7.0.0+up8.36.0
+version: 8.0.0+up8.36.0
 appVersion: "8.36.0"
 
 maintainers:

--- a/gotenberg/templates/_helpers.tpl
+++ b/gotenberg/templates/_helpers.tpl
@@ -214,7 +214,8 @@ rebuilt default probe needs no further context.
 {{- $defaults := dict
       "runAsNonRoot" true
       "runAsUser" 1001
-      "runAsGroup" 1001 -}}
+      "runAsGroup" 1001
+      "seccompProfile" (dict "type" "RuntimeDefault") -}}
 {{- include "gotenberg.defaultedDict" (dict "defaults" $defaults "given" $given "path" "gotenberg.securityContext.pod") -}}
 {{- end -}}
 

--- a/gotenberg/values.yaml
+++ b/gotenberg/values.yaml
@@ -16,6 +16,20 @@ gotenberg:
       runAsNonRoot: true
       runAsUser: 1001
       runAsGroup: 1001
+      # RuntimeDefault applies the container runtime's default seccomp filter,
+      # which blocks the syscalls a normal workload never makes. It sits in the
+      # pod context on purpose: from here it covers every container in the pod
+      # including init containers, while a container-level seccompProfile would
+      # have to be repeated for each one (and silently missed on the next one
+      # added). A container that genuinely needs a different filter can still
+      # override it under securityContext.container, which wins over this value.
+      #
+      # Verified against both conversion engines, because a browser sandbox is
+      # the classic case where a syscall filter bites: Chromium HTML->PDF and
+      # LibreOffice document->PDF both still return real PDFs under the filter,
+      # and /health reports chromium and libreoffice as "up".
+      seccompProfile:
+        type: RuntimeDefault
     container:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true


### PR DESCRIPTION
Adds `seccompProfile: RuntimeDefault` to gotenberg — second chart of the seccomp series for #84, and the one where the filter was most likely to actually bite.

## Where the value goes, and why (unchanged across the series)

`seccompProfile` can sit in the pod context or the container context, and the container value overrides the pod value. This series puts it in the **pod context** everywhere — decided by measurement, not preference.

Rendering a chart with an init container and scanning it shows `AVD-KSV-0104` firing **once per container**:

```
KSV-0104 (MEDIUM): container "ci-pl-paperless-ngx-sfs" ... should specify a seccomp profile
KSV-0104 (MEDIUM): container "init-run-ownership" ... should specify a seccomp profile
```

That init container carries its **own hardcoded** `securityContext`, which exists for an entirely unrelated reason (it runs as root with `CHOWN` to hand `/run` to the paperless uid). On container level the profile would have to be written into it a second time by hand — and would be silently missed on the next container anyone adds. From the pod context one line covers all of them, and a container that genuinely needs a different filter can still override it under `securityContext.container`.

Both placements clear the finding for a single-container pod, so the scanner alone does not decide this; init-container coverage does. The uniformity across the series is deliberate, not incidental.

## The risk here was real, so it was tested, not assumed

Gotenberg drives **headless Chromium and LibreOffice**. Browser sandboxes are the classic casualty of a restrictive syscall filter, so "the pod is Ready" would have been a worthless result for this chart — a conversion service that starts but returns errors on every conversion is exactly the silent failure this repo fights.

Both engines were exercised through the Service under the filter:

| route | result |
|---|---|
| `GET /health` | HTTP 200 — `chromium: up`, `libreoffice: up` |
| `POST /forms/chromium/convert/html` | HTTP 200, 13260 bytes, `PDF document, version 1.4, 1 pages` |
| `POST /forms/libreoffice/convert` | HTTP 200, 14096 bytes, `PDF document, version 1.7, 1 pages` |

And the PDFs are not empty shells — decompressing the Chromium output's content stream yields the two text runs actually rendered:

```
<003600480046004600520050005300030057004800560057> Tj   →  "Seccomp test"
<0035005800510057004C0050004800270048004900440058004F0057> Tj   →  "RuntimeDefault"
```

which is precisely the input HTML. The page was rendered, not just produced.

## Verification

**Rendering and lint**

- `helm lint --strict gotenberg` — 0 findings.
- The rendered pod spec carries `seccompProfile: {type: RuntimeDefault}` in the pod context.
- Trivy, measured on both sides. Before (rendered from `origin/main`): `KSV-0030` **and** `KSV-0104` present. After: **both gone**. The only MEDIUM+ finding left is `KSV-0125` (trusted registries), the policy decision noted on #84, not a chart defect.

**Null-safety (#99)** — gotenberg keeps its own copy of the pod defaults in `_helpers.tpl`, so the fallback had to move with `values.yaml`. It did: `helm template --set gotenberg.securityContext=null` still renders `RuntimeDefault`. An erased `securityContext:` block cannot silently drop the profile. `NOTES.txt` does not read any of the touched helpers.

**k3d** (throwaway cluster `seccomp-gotenberg`, created with `--kubeconfig-switch-context=false`, every call with an explicit `--context`, deleted afterwards; the global context was never used or changed)

- Pod `1/1 Running`, **0 restarts**, `pod=RuntimeDefault` on the live object.
- **The kernel actually applied it** — read inside the running container:

  ```
  NoNewPrivs:       1
  Seccomp:          2
  Seccomp_filters:  1
  ```

  `Seccomp: 2` is `SECCOMP_MODE_FILTER` with one filter loaded — the difference between "the field is in the manifest" and "the filter is enforced". A set field the kernel ignores would be exactly the kind of paper security this whole programme works against.

**CI install-test** — ran `ci/run-install-test.sh gotenberg` verbatim against the k3d cluster (isolated `KUBECONFIG`, no `SKIP` path): real install, `OK: chart 'gotenberg' installed and all workloads are Ready.`

## Version

**Major** (`7.0.0+up8.36.0` → `8.0.0+up8.36.0`): runtime behavior changes. Invisible here because both engines tolerate the filter, but §2 keys on the behavior change, not on whether it happens to show.

The value stays user-configurable at `gotenberg.securityContext.pod`, so it can be relaxed without a chart change if a future image version needs it.

Refs #84
