### PR TITLE
apache-tika: seccompProfile RuntimeDefault in the pod context

### DIFF
--- a/apache-tika/Chart.yaml
+++ b/apache-tika/Chart.yaml
@@ -5,5 +5,5 @@ icon: https://www.apache.org/logos/res/tika/default.png
 
 type: application
 
-version: 9.1.0+up3.3.1.0.full
+version: 10.0.0+up3.3.1.0.full
 appVersion: "3.3.1.0-full"

--- a/apache-tika/templates/_helpers.tpl
+++ b/apache-tika/templates/_helpers.tpl
@@ -214,7 +214,8 @@ default probe needs no further context.
 {{- $defaults := dict
       "runAsNonRoot" true
       "runAsUser" 35002
-      "runAsGroup" 35002 -}}
+      "runAsGroup" 35002
+      "seccompProfile" (dict "type" "RuntimeDefault") -}}
 {{- include "apache-tika.defaultedDict" (dict "defaults" $defaults "given" $given "path" "tika.securityContext.pod") -}}
 {{- end -}}
 

--- a/apache-tika/values.yaml
+++ b/apache-tika/values.yaml
@@ -15,6 +15,19 @@ tika:
       runAsNonRoot: true
       runAsUser: 35002
       runAsGroup: 35002
+      # RuntimeDefault applies the container runtime's default seccomp filter,
+      # which blocks the syscalls a normal workload never makes. It sits in the
+      # pod context on purpose: from here it covers every container in the pod
+      # including init containers, while a container-level seccompProfile would
+      # have to be repeated for each one (and silently missed on the next one
+      # added). A container that genuinely needs a different filter can still
+      # override it under securityContext.container, which wins over this value.
+      #
+      # Verified against a real extraction, not just a reachable port: the
+      # -full image loads its parsers dynamically, so a filter that blocked
+      # one would show up as HTTP 200 with empty text rather than as an error.
+      seccompProfile:
+        type: RuntimeDefault
     container:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true


### PR DESCRIPTION
Adds `seccompProfile: RuntimeDefault` to apache-tika — third chart of the seccomp series for #84.

## Where the value goes, and why (unchanged across the series)

`seccompProfile` can sit in the pod context or the container context, and the container value overrides the pod value. This series puts it in the **pod context** everywhere — decided by measurement, not preference.

Rendering a chart with an init container and scanning it shows `AVD-KSV-0104` firing **once per container**:

```
KSV-0104 (MEDIUM): container "ci-pl-paperless-ngx-sfs" ... should specify a seccomp profile
KSV-0104 (MEDIUM): container "init-run-ownership" ... should specify a seccomp profile
```

That init container carries its **own hardcoded** `securityContext`, which exists for an entirely unrelated reason (it runs as root with `CHOWN` to hand `/run` to the paperless uid). On container level the profile would have to be written into it a second time by hand — and would be silently missed on the next container anyone adds. From the pod context one line covers all of them, and a container that genuinely needs a different filter can still override it under `securityContext.container`.

Both placements clear the finding for a single-container pod, so the scanner alone does not decide this; init-container coverage does. The uniformity across the series is deliberate, not incidental.

## Why "the port answers" would have been the wrong test here

The `-full` image loads its parsers **dynamically**. A syscall the filter blocked inside one of them would not surface as a crash or an error code — it would surface as **HTTP 200 with empty text**, which is indistinguishable from a working service unless you look at the payload. So the core function was checked by extracting real content, three different code paths:

| request | result |
|---|---|
| `GET /version` | `Apache Tika 3.3.1` |
| `PUT /tika` with a **PDF** (PDFBox parser) | HTTP 200 → `Seccomp test` / `RuntimeDefault` |
| `PUT /tika` with **HTML** (HTML parser) | HTTP 200 → `Seccomp test` / `RuntimeDefault` |
| `PUT /meta` with a PDF (detector + metadata) | HTTP 200 → `Content-Type: application/pdf`, `pdf:PDFVersion: 1.4`, `xmpTPg:NPages: 1` |

The PDF used as input is the one **gotenberg produced under its own seccomp profile** in #130. So the two charts chain end to end with the filter active on both sides: Chromium rendered the document, Tika read the text back out of it — and the extracted string matches the original input HTML exactly. The metadata even names the producer, `Skia/PDF m151`, which is Chromium's PDF backend.

## Verification

**Rendering and lint**

- `helm lint --strict apache-tika` — 0 findings.
- The rendered pod spec carries `seccompProfile: {type: RuntimeDefault}` in the pod context.
- Trivy, measured on both sides. Before (rendered from `origin/main`): `KSV-0030` **and** `KSV-0104` present. After: **both gone**. Remaining MEDIUM+ finding is `KSV-0125` (trusted registries), the policy decision noted on #84.

**Null-safety (#99)** — apache-tika keeps its own copy of the pod defaults in `_helpers.tpl` (values path `tika.securityContext`), so the fallback had to move with `values.yaml`. It did: `helm template --set tika.securityContext=null` still renders `RuntimeDefault`. `NOTES.txt` does not read any of the touched helpers.

**k3d** (throwaway cluster `seccomp-apache-tika`, `--kubeconfig-switch-context=false`, every call with an explicit `--context`, deleted afterwards; the global context was never used or changed)

- Pod `1/1 Running`, **0 restarts**, `pod=RuntimeDefault` on the live object.
- **The kernel actually applied it** — read inside the running container:

  ```
  NoNewPrivs:       1
  Seccomp:          2
  Seccomp_filters:  1
  ```

  `Seccomp: 2` is `SECCOMP_MODE_FILTER` with one filter loaded — the difference between "the field is in the manifest" and "the filter is enforced".

**CI install-test** — ran `ci/run-install-test.sh apache-tika` verbatim against the k3d cluster (isolated `KUBECONFIG`, no `SKIP` path): real install, `OK: chart 'apache-tika' installed and all workloads are Ready.`

## Version

**Major** (`9.1.0+up3.3.1.0.full` → `10.0.0+up3.3.1.0.full`): runtime behavior changes. The value stays user-configurable at `tika.securityContext.pod`.

Refs #84
