### PR TITLE
template-chart: seccomp profile, unprivileged port, and placeholder fixes

### DIFF
--- a/ci/excluded-charts.txt
+++ b/ci/excluded-charts.txt
@@ -1,4 +1,4 @@
 # Charts excluded from the PR install-test, one per line: <chart> <reason>.
 # ci/run-install-test.sh skips these with the given reason.
 satisfactory the game-server image is multiple GB and Steam downloads 10GB+ game files on first start - impractical on a CI runner
-template-chart scaffold with placeholder image "registry/image:xxx", never published
+template-chart scaffold with placeholder image "ghcr.io/ORG/IMAGE:xxx", never published

--- a/template-chart/Chart.yaml
+++ b/template-chart/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://helm.sh/img/helm.svg
 
 type: application
 
-version: 3.0.0+upxxx
+version: 4.0.0+upxxx
 appVersion: "xxx"
 
 maintainers:

--- a/template-chart/templates/_helpers.tpl
+++ b/template-chart/templates/_helpers.tpl
@@ -229,7 +229,8 @@ guidelines"):
       "runAsUser" 20000
       "runAsGroup" 1000
       "fsGroup" 1000
-      "fsGroupChangePolicy" "Always" -}}
+      "fsGroupChangePolicy" "Always"
+      "seccompProfile" (dict "type" "RuntimeDefault") -}}
 {{- include "xxx.defaultedDict" (dict "defaults" $defaults "given" $given "path" "xxx.securityContext.pod") -}}
 {{- end -}}
 

--- a/template-chart/templates/xxx.configmap.yaml
+++ b/template-chart/templates/xxx.configmap.yaml
@@ -3,4 +3,8 @@ kind: ConfigMap
 metadata:
   name: "{{ .Release.Name }}-{{ .Chart.Name }}-configmap"
 data:
-  key: "value"
+  # Placeholder for the chart's real configuration keys. Named for what it is:
+  # a key literally called "key" matches the patterns secret scanners use to
+  # find hardcoded credentials, so every copy of this template inherited a
+  # false positive.
+  example-setting: "value"

--- a/template-chart/templates/xxx.deployment.yaml
+++ b/template-chart/templates/xxx.deployment.yaml
@@ -27,26 +27,34 @@ spec:
         {{- include "xxx.podSecurityContext" .Values.xxx.securityContext | nindent 8 }}
       containers:
         - name: {{ .Release.Name }}-{{ .Chart.Name }}-deployment
-          image: "registry/image:{{ .Chart.AppVersion }}"
+          # Fully qualified on purpose: an unqualified "registry/image" resolves
+          # to Docker Hub, which is how the repo accumulated its unqualified
+          # images. Replace host/org/image, keep the registry host.
+          image: "ghcr.io/ORG/IMAGE:{{ .Chart.AppVersion }}"
           imagePullPolicy: IfNotPresent
           env:
             {{- range $value := .Values.xxx.env }}
             {{- if $value.value }}
-            - name: {{ $value.name }}
-              value: {{ tpl $value.value $ }}
+            - name: {{ $value.name | quote }}
+              # quote is required, not cosmetic: a value like "8080" or "true"
+              # renders unquoted as a YAML number/bool, and the API server then
+              # rejects the whole manifest with "cannot unmarshal number into
+              # Go struct field EnvVar.value of type string". Every chart in
+              # this repo quotes here.
+              value: {{ tpl $value.value $ | quote }}
             {{- else if $value.valueFrom }}
             {{- if $value.valueFrom.secretKeyRef }}
             - name: {{ $value.name }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ tpl $value.valueFrom.secretKeyRef.name $ }}
-                  key: {{ tpl $value.valueFrom.secretKeyRef.key $ }}
+                  name: {{ tpl $value.valueFrom.secretKeyRef.name $ | quote }}
+                  key: {{ tpl $value.valueFrom.secretKeyRef.key $ | quote }}
             {{- else if $value.valueFrom.configMapKeyRef }}
             - name: {{ $value.name }}
               valueFrom:
                 configMapKeyRef:
-                  name: {{ tpl $value.valueFrom.configMapKeyRef.name $ }}
-                  key: {{ tpl $value.valueFrom.configMapKeyRef.key $ }}
+                  name: {{ tpl $value.valueFrom.configMapKeyRef.name $ | quote }}
+                  key: {{ tpl $value.valueFrom.configMapKeyRef.key $ | quote }}
             {{- end }}
             {{- end }}
             {{- end }}

--- a/template-chart/templates/xxx.sfs.yaml
+++ b/template-chart/templates/xxx.sfs.yaml
@@ -28,26 +28,34 @@ spec:
         {{- include "xxx.podSecurityContext" .Values.xxx.securityContext | nindent 8 }}
       containers:
         - name: {{ .Release.Name }}-{{ .Chart.Name }}-sfs
-          image: "registry/image:{{ .Chart.AppVersion }}"
+          # Fully qualified on purpose: an unqualified "registry/image" resolves
+          # to Docker Hub, which is how the repo accumulated its unqualified
+          # images. Replace host/org/image, keep the registry host.
+          image: "ghcr.io/ORG/IMAGE:{{ .Chart.AppVersion }}"
           imagePullPolicy: IfNotPresent
           env:
             {{- range $value := .Values.xxx.env }}
             {{- if $value.value }}
-            - name: {{ $value.name }}
-              value: {{ tpl $value.value $ }}
+            - name: {{ $value.name | quote }}
+              # quote is required, not cosmetic: a value like "8080" or "true"
+              # renders unquoted as a YAML number/bool, and the API server then
+              # rejects the whole manifest with "cannot unmarshal number into
+              # Go struct field EnvVar.value of type string". Every chart in
+              # this repo quotes here.
+              value: {{ tpl $value.value $ | quote }}
             {{- else if $value.valueFrom }}
             {{- if $value.valueFrom.secretKeyRef }}
             - name: {{ $value.name }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ tpl $value.valueFrom.secretKeyRef.name $ }}
-                  key: {{ tpl $value.valueFrom.secretKeyRef.key $ }}
+                  name: {{ tpl $value.valueFrom.secretKeyRef.name $ | quote }}
+                  key: {{ tpl $value.valueFrom.secretKeyRef.key $ | quote }}
             {{- else if $value.valueFrom.configMapKeyRef }}
             - name: {{ $value.name }}
               valueFrom:
                 configMapKeyRef:
-                  name: {{ tpl $value.valueFrom.configMapKeyRef.name $ }}
-                  key: {{ tpl $value.valueFrom.configMapKeyRef.key $ }}
+                  name: {{ tpl $value.valueFrom.configMapKeyRef.name $ | quote }}
+                  key: {{ tpl $value.valueFrom.configMapKeyRef.key $ | quote }}
             {{- end }}
             {{- end }}
             {{- end }}

--- a/template-chart/values.yaml
+++ b/template-chart/values.yaml
@@ -50,6 +50,15 @@ xxx:
       runAsGroup: 1000
       fsGroup: 1000
       fsGroupChangePolicy: Always
+      # RuntimeDefault applies the container runtime's default seccomp filter,
+      # which blocks the syscalls a normal workload never makes. It sits in the
+      # pod context on purpose: from here it covers every container in the pod
+      # including init containers, while a container-level seccompProfile would
+      # have to be repeated for each one (and silently missed on the next one
+      # added). A container that genuinely needs a different filter can still
+      # override it under securityContext.container, which wins over this value.
+      seccompProfile:
+        type: RuntimeDefault
     container:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true
@@ -59,7 +68,29 @@ xxx:
           - ALL
         add: []
   ports:
-    - containerPort: 80
+    # An unprivileged port on purpose (AVD-KSV-0117 flags containerPort < 1024).
+    #
+    # Note what the reason is NOT: on current Kubernetes a non-root container
+    # can bind port 80 just fine. The kubelet sets
+    # net.ipv4.ip_unprivileged_port_start=0 in the pod network namespace, so
+    # the classic "ports below 1024 need NET_BIND_SERVICE" rule does not apply
+    # inside a pod. Measured in k3d (k3s v1.35.5): the sysctl reads 0, and a
+    # container running as runAsUser 20000 with capabilities.drop: [ALL] binds
+    # port 80 successfully. Anyone who "fixes" this back to 80 after testing it
+    # once will find that it works - which is exactly why the reason is written
+    # down here.
+    #
+    # The reason to stay above 1024 is that this is a runtime default, not a
+    # guarantee: a cluster that restores ip_unprivileged_port_start=1024 (node
+    # sysctl or a hardened distribution) breaks every workload that copied the
+    # 80, and the failure then appears in the copied chart, not here. Every
+    # real chart in this repo listens above 1024 (3000, 8080, 8123, 9998, ...);
+    # the one exception is samba, which needs 139/445 and adds NET_BIND_SERVICE
+    # with a documented justification.
+    #
+    # containerPort is declarative - it does not force the application onto the
+    # port. Point the application at the same port when copying this template.
+    - containerPort: 8080
       protocol: TCP
       name: http
   env:


### PR DESCRIPTION
Five changes to `template-chart`, the scaffold every future chart is copied from. Four were assigned; the fifth turned up while verifying them, and one of the four turned out to be right **for a different reason than the one it was raised with**.

## 1. `seccompProfile: RuntimeDefault` (pod context)

Same as the rest of the series for #84. It sits in the **pod context** because from there it covers init containers and any container added later without being repeated; a container that genuinely needs a different filter can still override it under `securityContext.container`, which wins.

This PR gets to demonstrate that argument directly rather than argue it. An **ephemeral container attached to the already-running pod** — one with no `securityContext` of its own, added long after the pod was created — reports:

```
NoNewPrivs:       0
Seccomp:          2
Seccomp_filters:  1
```

`Seccomp: 2` is `SECCOMP_MODE_FILTER`: the profile reached a container that did not exist when the pod was written. `NoNewPrivs: 0` in the same output is the counterpart — that one is set per container, so the late arrival did **not** get it. Pod-level covers, container-level does not.

## 2. `containerPort: 80` → `8080` — right change, wrong reason

This clears **AVD-KSV-0117** (`containerPort` less than 1024), which is a **policy** check about privileged ports.

The reason this was raised with — that a container running as uid 20000 without `NET_BIND_SERVICE` cannot bind port 80 and fails with `EACCES` — **does not hold on current Kubernetes**, and I could not write it into the template in good conscience. Measured in k3d (k3s v1.35.5) with the template's exact security context (`runAsUser: 20000`, `capabilities.drop: [ALL]`, no `add`):

```
port 80:   BIND OK
port 8080: BIND OK
```

Because the kubelet sets `net.ipv4.ip_unprivileged_port_start=0` in the pod network namespace — read from inside the pod, it is `0`. The classic "ports below 1024 need `NET_BIND_SERVICE`" rule does not apply inside a pod.

This matters more than a footnote. `template-chart` is copied into every new chart, and §12 of the README is titled *values that must not lie*. A comment asserting `EACCES` would be a false statement propagated into every future chart — and the first person to test it would find that port 80 works and conclude the comment was wrong about everything.

So the change stands, with the **real** reason recorded in `values.yaml`: the permissive sysctl is a **runtime default, not a guarantee**. A cluster that restores `ip_unprivileged_port_start=1024` — node sysctl, hardened distribution — breaks every workload that copied the 80, and the breakage shows up in the copied chart rather than here. Every real chart in this repo already listens above 1024 (3000, 8080, 8123, 9998, ...); samba is the sole exception and adds `NET_BIND_SERVICE` with a documented justification.

The blast radius of the change is nil, verified at the rendering: probes address the port by **name** (`port: http`, all three), the Service uses `targetPort: http`, and the Service's own `port: 80` is client-side and untouched.

## 3. ConfigMap placeholder key

`key: "value"` → `example-setting: "value"`, clearing **AVD-KSV-01010** (`stores sensitive contents in key(s) '{"key"}'`). A scanner artifact, but one every copy inherited.

## 4. Fully qualified image placeholder

`registry/image:` → `ghcr.io/ORG/IMAGE:`. The unqualified form resolves to Docker Hub and is what produced the repo's unqualified images; the scaffold now teaches the shape whose absence caused the problem. `ci/excluded-charts.txt` names the placeholder in its exclusion reason, so it moved with it.

## 5. Found while verifying: `env` values were not quoted

Not on the list, and not visible in a render — it only appears when the scaffold is actually **installed**:

```
Deployment in version "v1" cannot be handled as a Deployment: json: cannot unmarshal
number into Go struct field EnvVar.spec.template.spec.containers.env.value of type string
```

The template rendered `value: {{ tpl $value.value $ }}` without `| quote`, so an env value like `"8080"`, `"true"` or a bare version number renders as a YAML number/bool and the API server rejects **the entire manifest**. Every real chart in the repo (`cyberchef`, `apache-tika`, `gotenberg`, ...) already quotes here — only the template, the thing they are all copied from, did not. Fixed in both `xxx.deployment.yaml` and `xxx.sfs.yaml`, along with the `secretKeyRef`/`configMapKeyRef` names and keys, matching the existing charts exactly.

## Verification

**Trivy on the rendered scaffold** — measured on both sides (before = rendered from `origin/main`):

| check | before | after |
|---|---|---|
| KSV-0030 (seccomp) | 2 | **0** |
| KSV-0104 (seccomp) | 2 | **0** |
| KSV-0117 (privileged port) | 2 | **0** |
| KSV-01010 (ConfigMap key) | 1 | **0** |
| KSV-0011 (no CPU limit) | 2 | 2 — repo convention (#84) |
| KSV-0021 (`runAsGroup` > 10000) | 2 | 2 — see note below |
| KSV-0110 (default namespace) | 2 | 2 — render artifact, no namespace given |
| KSV-0125 (trusted registries) | 2 | 2 — policy decision (#84) |

Seven findings cleared; every remaining MEDIUM is `KSV-0125`.

**`helm lint --strict template-chart`** — 0 findings.

**Instantiated and installed, not just rendered.** The scaffold was copied and de-placeholdered exactly as README's "Creating a new chart" prescribes (file names, `Chart.yaml`, values keys, `.Values.*` references, helper prefixes), pointed at a real image, and installed into a throwaway k3d cluster:

- Workload becomes **Ready**, 0 restarts, `pod=RuntimeDefault`, `uid=20000`, `containerPort=8080` on the live object.
- `GET /` through the Service → **HTTP 200**, and the app answers on 8080 — so `port: 80` → `targetPort: http` → `containerPort: 8080` resolves correctly end to end, and all three probes pass against the renamed port.
- The `values.schema.json` did its job during this: passing the env value as a number was rejected at install time with `at '/whoamidemo/env/0/value': got number, want string` — #68 working as designed.

Cluster created with `--kubeconfig-switch-context=false`, every call with an explicit `--context`, deleted afterwards; the global context was never used or changed.

**Note, not a change — `KSV-0021` still fires.** The scaffold's `runAsUser` is 20000, comfortably above the 10000 line, but `runAsGroup` and `fsGroup` are `1000`, so the **group** check still flags every new chart. Raising them in the template would be free (no existing volume data to strand, unlike the deployed charts that motivated "document rather than change"). I have deliberately **not** done it here — it is a decision, not a fix, and it belongs with the UID/GID discussion on #84 rather than being slipped into a template PR.

## Version

**Major** (`3.0.0+upxxx` → `4.0.0+upxxx`): the port change is a breaking values change and the seccomp profile changes runtime behavior. `template-chart` is in `ci/excluded-charts.txt` and is never published, so no publish round and no cluster-side work follows from this.

Refs #84
