### PR TITLE
rallly: seccompProfile RuntimeDefault in the pod context

### DIFF
--- a/rallly/Chart.yaml
+++ b/rallly/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://raw.githubusercontent.com/lukevella/rallly/main/apps/landing/publi
 
 type: application
 
-version: 7.0.0+up4.12.3
+version: 8.0.0+up4.12.3
 appVersion: "4.12.3"
 
 maintainers:

--- a/rallly/templates/_helpers.tpl
+++ b/rallly/templates/_helpers.tpl
@@ -220,7 +220,8 @@ AVD-KSV-0022 for the older deployed chart version (#84).
       "runAsUser" 20000
       "runAsGroup" 1000
       "fsGroup" 1000
-      "fsGroupChangePolicy" "Always" -}}
+      "fsGroupChangePolicy" "Always"
+      "seccompProfile" (dict "type" "RuntimeDefault") -}}
 {{- include "rallly.defaultedDict" (dict "defaults" $defaults "given" $given "path" "rallly.securityContext.pod") -}}
 {{- end -}}
 

--- a/rallly/values.yaml
+++ b/rallly/values.yaml
@@ -62,6 +62,15 @@ rallly:
       runAsGroup: 1000
       fsGroup: 1000
       fsGroupChangePolicy: Always
+      # RuntimeDefault applies the container runtime's default seccomp filter,
+      # which blocks the syscalls a normal workload never makes. It sits in the
+      # pod context on purpose: from here it covers every container in the pod
+      # including init containers, while a container-level seccompProfile would
+      # have to be repeated for each one (and silently missed on the next one
+      # added). A container that genuinely needs a different filter can still
+      # override it under securityContext.container, which wins over this value.
+      seccompProfile:
+        type: RuntimeDefault
     container:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true


### PR DESCRIPTION
Adds `seccompProfile: RuntimeDefault` to rallly — fourth chart of the seccomp series for #84.

## Where the value goes, and why (unchanged across the series)

`seccompProfile` can sit in the pod context or the container context, and the container value overrides the pod value. This series puts it in the **pod context** everywhere — decided by measurement, not preference.

`AVD-KSV-0104` fires **once per container**, and a chart's init container may carry its own hardcoded `securityContext` that exists for an unrelated reason (paperless-ngx runs one as root with `CHOWN` to hand over `/run`). On container level the profile would have to be written into each of them by hand and would be silently missed on the next container added. From the pod context one line covers all of them, and a container that genuinely needs a different filter can still override it under `securityContext.container`.

#133 turned that argument into a measurement: an **ephemeral container attached to an already-running pod**, with no `securityContext` of its own, reported `Seccomp: 2` (inherited from the pod context) alongside `NoNewPrivs: 0` (container-level, so not inherited). Pod-level covers late arrivals; container-level does not.

## Why the test targets the database, not the landing page

rallly is a Next.js app whose whole function is backed by Postgres. A static page answering 200 would prove almost nothing — the interesting question is whether the app can still open a TCP connection to the database, authenticate, and run its schema work under the filter. So the check was aimed there:

- Startup log: **`All migrations have been successfully applied.`**
- In Postgres afterwards: **141 rows** in `_prisma_migrations` with `finished_at` set, and **31 tables** in the `public` schema — `polls`, `votes`, `participants`, `users`, `spaces`, `sessions`, … i.e. the app's entire data model, created by the app process itself under the filter.

That is real network I/O plus DDL and transaction commits from inside the filtered container, not a health endpoint returning a constant.

On top of that, the server-rendered HTTP surface answers: `GET /` → **HTTP 200**, 76136 bytes, `<title>Home</title>`, and `/login`, `/new`, `/manifest.json` all answer 200 as well. (Next.js serves its app shell for client-routed paths, so I am not reading those individual 200s as per-route backend proof — the database evidence above is what carries the claim.)

## Verification

**Rendering and lint**

- `helm lint --strict rallly` — 0 findings.
- The rendered pod spec carries `seccompProfile: {type: RuntimeDefault}` in the pod context.
- Trivy, measured on both sides against the CI values. Before (rendered from `origin/main`): `KSV-0030` and `KSV-0104` present. After: **both gone**.

**Null-safety (#99)** — rallly keeps its own copy of the pod defaults in `_helpers.tpl`, so the fallback had to move with `values.yaml`. It did: `helm template --set rallly.securityContext=null` still renders `RuntimeDefault`.

**k3d** (throwaway cluster `seccomp-rallly`, `--kubeconfig-switch-context=false`, every call with an explicit `--context`, deleted afterwards; the global context was never used or changed)

- App pod `1/1 Running`, **0 restarts**, `pod=RuntimeDefault` on the live object.
- **The kernel actually applied it**:

  ```
  NoNewPrivs:       1
  Seccomp:          2
  Seccomp_filters:  1
  ```

  `Seccomp: 2` is `SECCOMP_MODE_FILTER` with one filter loaded — the difference between "the field is in the manifest" and "the filter is enforced".

**CI install-test** — ran `ci/run-install-test.sh rallly` verbatim against the k3d cluster (isolated `KUBECONFIG`, no `SKIP` path), including the throwaway Postgres and dex fixtures: real install, `OK: chart 'rallly' installed and all workloads are Ready.`

## Version

**Major** (`7.0.0+up4.12.3` → `8.0.0+up4.12.3`): runtime behavior changes. The value stays user-configurable at `rallly.securityContext.pod`.

Refs #84
