### PR TITLE
rss-bridge: app update 2025-06-03 -> 2025-08-05

### DIFF
--- a/rss-bridge/Chart.yaml
+++ b/rss-bridge/Chart.yaml
@@ -5,8 +5,8 @@ icon: https://raw.githubusercontent.com/RSS-Bridge/rss-bridge/master/static/logo
 
 type: application
 
-version: 1.0.0+up2025.06.03
-appVersion: "2025-06-03"
+version: 1.0.1+up2025.08.05
+appVersion: "2025-08-05"
 
 maintainers:
   - name: jklein

--- a/rss-bridge/values.yaml
+++ b/rss-bridge/values.yaml
@@ -140,9 +140,11 @@ rssBridge:
     limitFactor: 3
     requests:
       cpu: 0.1
-      # Measured with the shipped image: about 59 MiB resident while idle and
-      # roughly 89 MiB after serving feeds, so the previous 20Mi request was
-      # a third of what the workload actually occupies around the clock.
+      # Measured with the shipped image: about 21 MiB resident at startup and
+      # roughly 64 MiB after serving feeds, so the 20Mi the original manifest
+      # requested was a third of what the workload occupies around the clock.
+      # (Re-measured on the 2025-08-05 image; the 2025-06-03 image came out
+      # marginally higher at 24 MiB / 71 MiB under the identical procedure.)
       memory: 128Mi
       # The previous manifest requested 2Gi of ephemeral storage - identical to
       # its limit - and thereby reserved two gigabytes of node scheduling
@@ -164,11 +166,12 @@ rssBridge:
       # Set explicitly rather than left to limitFactor x request.
       #
       # memory: the manifest this chart replaces capped the container at
-      # 100Mi, but five concurrent feed fetches were measured peaking at
-      # 119 MiB - the old limit was already below the real peak, and php-fpm
-      # is configured for up to five workers with a 128M PHP memory_limit
-      # each. 512Mi covers the measured peak with room to spare and still
-      # bounds a runaway bridge.
+      # 100Mi, but a warm container serving five concurrent feed fetches was
+      # measured peaking at 119 MiB - the old limit was already below the real
+      # peak. php-fpm is configured for up to five workers with a 128M PHP
+      # memory_limit each, so the theoretical ceiling is far higher still.
+      # 512Mi covers the measured peak with room to spare and still bounds a
+      # runaway bridge.
       memory: 512Mi
       # Unchanged from the previous manifest on purpose: a large cap costs
       # nothing (it reserves no capacity) and guarantees this change cannot


### PR DESCRIPTION
App update for the chart created in #128, which deliberately left it out so the takeover would not be mixed with a version jump.

Fixes #135

## The jump

`2025-06-03` → `2025-08-05`. **One step** — `2025-08-05` is the immediate successor, with no publication in between (checked against the project's release list, not assumed):

```
2025-08-05  published 2025-08-05   <- target, newest release
2025-06-03  published 2025-06-03   <- current
2025-01-26 / 2025-01-02 / 2024-02-02
```

Tag present on Docker Hub for `linux/amd64` and `linux/arm64` (also `arm/v7`).

## Why we stay on the dated release tag

The newest *release* is itself over twelve months old, and the project now pushes `latest` and commit-based `sha-*` tags continuously from the main branch. **We stay on the release tag anyway.** A `sha-*` tag is not more *released* than the release, only newer, and `latest` is rolling — both conflict with this repo's convention of reproducible, pinned tags (`appVersion` is the exact image tag). The price is that the chart trails development; that is the deliberate trade, recorded here so the next round does not relitigate it.

## Changelog review — checked against the shipped source, not the release notes

Both images were extracted and diffed directly, which answers several of these with certainty rather than inference.

**1. `whitelist.txt` format — unchanged.** `lib/Configuration.php` is byte-identical between the two images apart from its `VERSION` constant. The parsing the chart depends on is therefore untouched: `trim()` the file, split on newline, `array_filter(array_map('trim', …))`, and `*` as the wildcard. This was the most dangerous item — a changed format would mean no or wrong bridges behind a healthy pod — and it is the one the diff settles outright.

**2. The five production bridges — all present, none renamed.**

| Bridge | Status |
|---|---|
| `Youtube` | byte-identical |
| `TheHackerNews` | byte-identical |
| `ARDMediathek` | byte-identical |
| `Reddit` | byte-identical |
| `Heise` | **changed — content only** |

Bridge inventory went 497 → 502. Upstream removed exactly three — `AskfmBridge`, `DansTonChatBridge`, `FirstLookMediaTechBridge` — **none of them ours**.

The Heise change is a three-line content edit: paywalled `heise+` items without a session cookie now get their URI rewritten to an `archive.is/…` link, and two more selectors (`.notice-banner__text`, `.notice-banner__link`) are stripped from article content. No parameter, no name, no behaviour the chart configures. Worth knowing on the cluster side because item links in the Heise feed change for paywalled articles.

**3. `RSSBRIDGE_*` environment mapping — unchanged.** Same file as point 1, so the `RSSBRIDGE_<section>_<key>` mapping is byte-identical. Nothing renamed, nothing dropped.

**4. Write paths — re-derived empirically, not inferred.** This chart is the reason to distrust a diff here: PHP's opcache creates its lock file in `/tmp` and unlinks it immediately, so it appears in **no** filesystem comparison. The method from #128 was repeated on the new image:

- Ran it with a writable rootfs, exercised all five production bridges plus `/`, `list` and `detect` (all HTTP 200), read the diff layer → `/app/cache`, `/run`, `/run/php`, `/var/lib/nginx`. `/tmp` again invisible, as expected.
- Ran it **fully hardened** with exactly the chart's five mounts → starts, `/?action=health` 200.
- **Control run without `/tmp`** → still dies at startup with `Fatal Error Unable to create lock file: Read-only file system (30)`.

So the set is unchanged: no path added, and none became unnecessary. Supporting evidence: `docker-entrypoint.sh` is byte-identical, and `nginx.conf`, `sites-enabled/default`, the php-fpm pool and `php-fpm.conf` are all byte-identical too.

**5. Health endpoint — intact.** `actions/` is identical between the images, so `HealthAction` and `/?action=health` are unchanged. `lib/RssBridge.php` differs only by moving `BasicAuthMiddleware` ahead of the cache middleware (upstream fix "don't cache basic auth response"); the chart does not enable authentication, so it has no effect here.

**6. PHP version and resource demand — no change needed.** PHP 8.2.28 → 8.2.29 (patch); nginx 1.22.1 and Debian 12 unchanged. The PHP directory is still `8.2`, so the `/run/php/php8.2-fpm.sock` path the chart mounts still applies — a PHP minor bump would have broken that mount silently, which is why it is called out.

Measured with an identical fresh-start procedure on both images (five concurrent real feed fetches):

| | idle | peak under 5 concurrent fetches | cache after all five bridges |
|---|---|---|---|
| `2025-06-03` | 24.1 MiB | 71.1 MiB | 2 249 772 B / 17 entries |
| `2025-08-05` | 20.8 MiB | **64.5 MiB** | 2 249 771 B / 17 entries |

The new image is marginally lighter. Requests and limits stay at 128Mi / 512Mi and 64Mi / 2Gi.

*Correction to a number from #128:* the 119.4 MiB recorded there came from an already-warm container, not a fresh start, so it is not comparable to the table above. The values.yaml comments are updated to say so — the 512Mi limit rationale is unaffected, since the binding argument is php-fpm's five workers at a 128M PHP `memory_limit` each.

## Verification

`helm lint --strict` → 0 findings. `helm package` → `rss-bridge-1.0.1+up2025.08.05.tgz`. `ci/run-trivy-config.sh rss-bridge` → `0 to act on, 5 excepted`. `ci/run-install-test.sh rss-bridge` against a throwaway k3d cluster → `OK: chart 'rss-bridge' installed and all workloads are Ready.`

**"Pod is Ready" is not the proof**, and this chart is why: a failed nginx bind leaves a `Running` container with no web server, and an unwritable `/app/cache` throws on every *feed* request while `/?action=health` keeps answering 200. So feeds were fetched from inside the hardened pod and checked for **actual `<entry>` elements**, not status codes — RSS-Bridge renders errors *as* a feed with HTTP 200, so a status check alone is a false pass. That trap fired immediately: a bare `?bridge=Youtube` returns HTTP 200 carrying `Required parameter(s) missing`. With the parameters each bridge requires:

| Bridge | HTTP | Entries | First entry |
|---|---|---|---|
| Youtube | 200 | 15 | "I put the NEWEST CPU in the OLDEST Motherb…" |
| TheHackerNews | 200 | 5 | "TikTok Agrees to $400 Million Settlement…" |
| ARDMediathek | 200 | 29 | "Wem gehört das Ackerland? Der Preiskampf um…" |
| Heise | 200 | 5 | "Top 10: Bestes Tablet im Test – Samsung vor A…" |
| Reddit | **429** | 0 | — |

**Reddit returns 429 — and that is not this update.** The identical request against the **old** image from the same network returns 429 as well; all four others return identical entry counts on both images (15 / 5 / 29 / 5). Reddit is rate-limiting this test network's egress IP. `RedditBridge.php` is byte-identical between the images and does reach Reddit; its `frontend` parameter only rewrites item URIs, the fetch always goes to `old.reddit.com/search.json`, so it cannot route around the limit. The production cluster has been serving this bridge for over a year from a different egress address.

**Whitelist demonstrably enforced on the new image:** with the five production bridges configured, the running instance offers exactly `bridge-{ARDMediathek,Heise,Reddit,TheHackerNews,Youtube}Bridge` and a 30 362-byte front page. Upgraded to a two-entry whitelist, the pod is replaced (checksum/config still rolls it) and the instance then offers exactly `bridge-HeiseBridge` and `bridge-TheHackerNewsBridge`, front page 8 058 bytes.

Hardening re-confirmed in-cluster on the new image: `uid=33(www-data)`, root filesystem read-only, `ip_unprivileged_port_start` pinned at 0, image resolved to `docker.io/rssbridge/rss-bridge@sha256:569f01f3…`.

## Version

`1.0.1+up2025.08.05` — patch. The review found no change to the values surface and no behaviour the chart exposes, so nothing warrants a higher bump. The only chart edits are `Chart.yaml` and comment text in `values.yaml`.
