### PR TITLE
renovate: automerge minor updates, make the install-test blocking

### DIFF
--- a/.github/workflows/validate-charts.yml
+++ b/.github/workflows/validate-charts.yml
@@ -132,10 +132,10 @@ jobs:
     needs: [detect-changed-charts, build-chart]
     if: needs.detect-changed-charts.outputs.any-chart-changed == 'true'
     runs-on: ubuntu-latest
-    # Stabilization phase (issue #22): the job reports failures but does not
-    # block the PR. Promote to a required check (drop continue-on-error) once
-    # it has proven stable across several chart PRs.
-    continue-on-error: true
+    # Blocking since Renovate automerges patch/minor updates: a chart that no
+    # longer starts must stop the PR before it reaches main and publishes. This
+    # ends the stabilization phase of issue #22 - the job reported failures
+    # without blocking while it proved itself across several chart PRs.
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Fixtures live at the **repo root** under `ci/` (deliberately *not* inside the ch
 - `ci/<chart>/settings.env` — optional overrides (e.g. `INSTALL_TIMEOUT` for slow starters)
 - `ci/excluded-charts.txt` — charts that cannot run in CI, each with a justification. Currently: `satisfactory` (multi-GB image + 10GB+ Steam download), `template-chart` (scaffold with placeholder image)
 
-Fixture images avoid Docker Hub where possible (`public.ecr.aws`/`ghcr.io`) to dodge runner rate limits. The job currently runs with `continue-on-error: true` (stabilization phase); it will be promoted to a required check once it has proven stable across several chart PRs. When adding a new chart, add its `ci/<chart>/` fixtures (or an entry in `ci/excluded-charts.txt`) — the install-test fails if both are missing. The script also runs locally against any existing cluster: `k3d cluster create t && ci/run-install-test.sh <chart> && k3d cluster delete t`.
+Fixture images avoid Docker Hub where possible (`public.ecr.aws`/`ghcr.io`) to dodge runner rate limits. The job **blocks the PR** on failure — the stabilization phase of #22 ended when Renovate started automerging patch/minor updates, since a chart that no longer starts must not reach `main` and publish unattended. When adding a new chart, add its `ci/<chart>/` fixtures (or an entry in `ci/excluded-charts.txt`) — the install-test fails if both are missing. The script also runs locally against any existing cluster: `k3d cluster create t && ci/run-install-test.sh <chart> && k3d cluster delete t`.
 
 ## Dependency updates (Renovate)
 
@@ -90,9 +90,11 @@ Everything is derived from the base commit, so the script is idempotent across t
 >
 > Without that entry Renovate skips the task without an error and every chart PR stays red on the version check.
 
+If the dependency dashboard reports `Failed to look up github-releases package …: no-result` for third-party repos, that is the instance's GitHub credentials, not this config: a GitHub App installation token is not a good fit for looking up repos the app is not installed on. Give the instance a separate read-only PAT as `GITHUB_COM_TOKEN` for github.com datasource lookups.
+
 ### PR policy
 
-- **Automerge** for `patch` and `digest` updates, after a `minimumReleaseAge` of 3 days and only once the PR pipeline is green. Renovate merges itself rather than using GitHub auto-merge, which would merge immediately as long as `validate-charts` is not a required check. Everything else is merged by hand.
+- **Automerge** for `patch`, `minor` and `digest` updates, after a `minimumReleaseAge` of 3 days and only once the PR pipeline is green — install-test included, which is why that job no longer runs with `continue-on-error`. Minor is in scope because the sidecar images barely move in patch steps (`alpine 3.22` → `3.24`, `nginx 1.30.4` → `1.31.4` are both minor), so a patch-only rule would practically never fire. Renovate merges itself rather than using GitHub auto-merge, which would merge immediately as long as `main` has no required status checks. Majors are merged by hand.
 - **Majors** arrive one line at a time (`separateMultipleMajor`): a v1 → v3 jump produces a PR for the latest v2 first and then one for v3 — the stepwise procedure the versioning section requires.
 - `prConcurrentLimit: 10` / `prHourlyLimit: 4` keep the k3d install-tests from all starting at once.
 - The manually dispatched `change-app-version.yml` still exists for one-off bumps, but the normal path for app updates is now a Renovate PR.

--- a/renovate.json5
+++ b/renovate.json5
@@ -71,8 +71,13 @@
       enabled: false,
     },
     {
-      description: "Patch and digest updates merge themselves once the PR pipeline is green.",
-      matchUpdateTypes: ["patch", "digest"],
+      description: [
+        "Patch, minor and digest updates merge themselves once the PR pipeline is green.",
+        "Minor is included because the sidecar images barely move in patch steps —",
+        "alpine 3.22 -> 3.24 and nginx 1.30.4 -> 1.31.4 are both minor, so a patch-only",
+        "rule would practically never fire. Majors stay manual.",
+      ],
+      matchUpdateTypes: ["patch", "minor", "digest"],
       automerge: true,
       automergeType: "pr",
       // Renovate waits for the checks itself instead of handing the PR to


### PR DESCRIPTION
Follow-up to #143. Automerge never fired on #138 and #139 — not because it was switched off, but because both are **minor** updates (`alpine 3.22` → `3.24`, `nginx 1.30.4` → `1.31.4`) while the rule only covered `patch` and `digest`. Sidecar images barely move in patch steps, so a patch-only rule would practically never fire on exactly the updates it was meant for.

## Changes

- `renovate.json5`: automerge now covers `patch`, `minor` and `digest`. Majors stay manual, one line at a time.
- `validate-charts.yml`: `continue-on-error` removed from the install-test job. Automerging a chart update publishes it, so a chart that no longer starts has to stop the PR rather than report into the void. This ends the stabilization phase of #22.
- README: PR policy and install-test description updated, plus a note on the dashboard's lookup warning (see below).

## Note on the dependency dashboard warning

The `Failed to look up … aquasecurity/trivy` / `aquasecurity/setup-trivy` entries on #144 are **not** caused by this repo's config:

- Both repos exist under exactly those names and `aquasecurity/trivy`'s latest release is `v0.74.0`, i.e. the pinned version.
- A local `renovate --platform=local --dry-run=lookup` with a real token resolves both cleanly (`sourceUrl` populated, no failure).
- `aquasecurity/setup-trivy` comes from the built-in `github-actions` manager, not from any custom manager here — so the failure hits a dependency this repo never configured.

That points at the instance's GitHub credentials: a GitHub App installation token is a poor fit for looking up repos the app is not installed on. Giving the instance a read-only PAT as `GITHUB_COM_TOKEN` for github.com datasource lookups is the documented remedy; it may equally have been transient, in which case the warning clears on the next run. Documented in the README so the next person does not go looking in the config.

## What this means for the open PRs

Once this is merged, #138 and #139 automerge on Renovate's next run — provided their install-test now passes for real, since that job is blocking from here on. Worth watching: those are the first two chart PRs where an install-test failure actually stops something.

## Verification

- `renovate-config-validator` → *Config validated successfully*
- The bump hook is confirmed working in production: #138 carries `3.0.0+up2026.8.2.java21` → `3.0.1+…` and #139 `7.0.0+upv1.159.0` → `7.0.1+…`, both correctly patch-level since only a sidecar image moved.
- Renovate's own commits are GitHub-verified, so the signed-commit requirement does not block automerge.
