### PR TITLE
Acht Charts: seccompProfile RuntimeDefault im Pod-Context und qualifizierte Images

### DIFF
--- a/calibre-web-automated/Chart.yaml
+++ b/calibre-web-automated/Chart.yaml
@@ -5,7 +5,7 @@ name: calibre-web-automated
 description: A Helm chart to deploy calibere-web-automated
 icon: https://raw.githubusercontent.com/crocodilestick/Calibre-Web-Automated/main/README_images/cwa-logo-round-dark.png
 
-version: 5.0.0+upv4.0.6
+version: 6.0.0+upv4.0.6
 appVersion: v4.0.6
 
 maintainers:

--- a/calibre-web-automated/templates/_helpers.tpl
+++ b/calibre-web-automated/templates/_helpers.tpl
@@ -230,7 +230,8 @@ default probe needs no further context.
 {{- $given := (fromYaml (include "calibre-web-automated.subBlock" (dict "block" . "key" "pod" "path" "cwa.securityContext"))).value -}}
 {{- $defaults := dict
       "fsGroup" 1000
-      "fsGroupChangePolicy" "Always" -}}
+      "fsGroupChangePolicy" "Always"
+      "seccompProfile" (dict "type" "RuntimeDefault") -}}
 {{- include "calibre-web-automated.defaultedDict" (dict "defaults" $defaults "given" $given "path" "cwa.securityContext.pod") -}}
 {{- end -}}
 

--- a/calibre-web-automated/values.yaml
+++ b/calibre-web-automated/values.yaml
@@ -65,6 +65,20 @@ cwa:
     pod:
       fsGroup: 1000
       fsGroupChangePolicy: Always
+      # RuntimeDefault applies the container runtime's default seccomp filter,
+      # which blocks the syscalls a normal workload never makes. It sits in the
+      # pod context on purpose: from here it covers every container in the pod
+      # including init containers, while a container-level seccompProfile would
+      # have to be repeated for each one (and silently missed on the next one
+      # added). A container that genuinely needs a different filter can still
+      # override it under securityContext.container, which wins over this value.
+      #
+      # It is orthogonal to the readOnlyRootFilesystem: false deviation above:
+      # the filter restricts syscalls, not mount flags, so the s6 init keeps
+      # its writable root filesystem and the PUID/PGID remapping to uid 1000
+      # stays active. Verified against v4.0.6 under the filter.
+      seccompProfile:
+        type: RuntimeDefault
     container:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: false

--- a/minecraft-router/Chart.yaml
+++ b/minecraft-router/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://avatars.githubusercontent.com/u/988985
 
 type: application
 
-version: 3.0.0+up1.46.4
+version: 4.0.0+up1.46.4
 appVersion: "1.46.4"
 
 maintainers:

--- a/minecraft-router/templates/_helpers.tpl
+++ b/minecraft-router/templates/_helpers.tpl
@@ -224,7 +224,8 @@ the base image.
       "runAsUser" 10000
       "runAsGroup" 10000
       "fsGroup" 10000
-      "fsGroupChangePolicy" "Always" -}}
+      "fsGroupChangePolicy" "Always"
+      "seccompProfile" (dict "type" "RuntimeDefault") -}}
 {{- include "minecraft-router.defaultedDict" (dict "defaults" $defaults "given" $given "path" "server.securityContext.pod") -}}
 {{- end -}}
 

--- a/minecraft-router/templates/minecraft-router.deployment.yaml
+++ b/minecraft-router/templates/minecraft-router.deployment.yaml
@@ -27,7 +27,7 @@ spec:
         {{- include "minecraft-router.podSecurityContext" .Values.server.securityContext | nindent 8 }}
       containers:
         - name: {{ .Release.Name }}-{{ .Chart.Name }}-deployment
-          image: "itzg/mc-router:{{ .Chart.AppVersion }}"
+          image: "docker.io/itzg/mc-router:{{ .Chart.AppVersion }}"
           imagePullPolicy: IfNotPresent
           args:
             - "--port"

--- a/minecraft-router/values.yaml
+++ b/minecraft-router/values.yaml
@@ -108,6 +108,15 @@ server:
       # Keeps the mounted routing-config ConfigMap readable for that gid.
       fsGroup: 10000
       fsGroupChangePolicy: Always
+      # RuntimeDefault applies the container runtime's default seccomp filter,
+      # which blocks the syscalls a normal workload never makes. It sits in the
+      # pod context on purpose: from here it covers every container in the pod
+      # including init containers, while a container-level seccompProfile would
+      # have to be repeated for each one (and silently missed on the next one
+      # added). A container that genuinely needs a different filter can still
+      # override it under securityContext.container, which wins over this value.
+      seccompProfile:
+        type: RuntimeDefault
     container:
       allowPrivilegeEscalation: false
       # No deviation needed: the image ships nothing but the static binary and

--- a/outline/Chart.yaml
+++ b/outline/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://raw.githubusercontent.com/outline/outline/main/public/images/icon-
 
 type: application
 
-version: 6.0.0+up1.9.2
+version: 7.0.0+up1.9.2
 appVersion: 1.9.2
 
 maintainers:

--- a/outline/templates/_helpers.tpl
+++ b/outline/templates/_helpers.tpl
@@ -217,7 +217,8 @@ there is no dependency-free alternative to fall back to.
       "runAsUser" 1001
       "runAsGroup" 1001
       "fsGroup" 1001
-      "fsGroupChangePolicy" "Always" -}}
+      "fsGroupChangePolicy" "Always"
+      "seccompProfile" (dict "type" "RuntimeDefault") -}}
 {{- include "outline.defaultedDict" (dict "defaults" $defaults "given" $given "path" "outline.securityContext.pod") -}}
 {{- end -}}
 

--- a/outline/templates/outline.sfs.yaml
+++ b/outline/templates/outline.sfs.yaml
@@ -21,7 +21,7 @@ spec:
         {{- include "outline.podSecurityContext" .Values.outline.securityContext | nindent 8 }}
       containers:
         - name: {{ .Release.Name }}-{{ .Chart.Name }}-sfs
-          image: "outlinewiki/outline:{{ .Chart.AppVersion }}"
+          image: "docker.io/outlinewiki/outline:{{ .Chart.AppVersion }}"
           imagePullPolicy: IfNotPresent
           env:
             - name: PORT

--- a/outline/values.yaml
+++ b/outline/values.yaml
@@ -30,6 +30,15 @@ outline:
       runAsGroup: 1001
       fsGroup: 1001
       fsGroupChangePolicy: Always
+      # RuntimeDefault applies the container runtime's default seccomp filter,
+      # which blocks the syscalls a normal workload never makes. It sits in the
+      # pod context on purpose: from here it covers every container in the pod
+      # including init containers, while a container-level seccompProfile would
+      # have to be repeated for each one (and silently missed on the next one
+      # added). A container that genuinely needs a different filter can still
+      # override it under securityContext.container, which wins over this value.
+      seccompProfile:
+        type: RuntimeDefault
     container:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true

--- a/patchmon/Chart.yaml
+++ b/patchmon/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://raw.githubusercontent.com/PatchMon/PatchMon/main/frontend/public/a
 
 type: application
 
-version: 6.1.0+up2.1.3
+version: 7.0.0+up2.1.3
 appVersion: "2.1.3"
 
 maintainers:

--- a/patchmon/templates/_helpers.tpl
+++ b/patchmon/templates/_helpers.tpl
@@ -217,7 +217,8 @@ helpers take dict "given" <block|nil> "root" $.
 {{- $defaults := dict
       "runAsNonRoot" true
       "runAsUser" 65532
-      "runAsGroup" 65532 -}}
+      "runAsGroup" 65532
+      "seccompProfile" (dict "type" "RuntimeDefault") -}}
 {{- include "patchmon.defaultedDict" (dict "defaults" $defaults "given" $given "path" "patchmon.server.securityContext.pod") -}}
 {{- end -}}
 

--- a/patchmon/values.yaml
+++ b/patchmon/values.yaml
@@ -22,6 +22,17 @@ patchmon:
         runAsNonRoot: true
         runAsUser: 65532
         runAsGroup: 65532
+        # RuntimeDefault applies the container runtime's default seccomp
+        # filter, which blocks the syscalls a normal workload never makes. It
+        # sits in the pod context on purpose: from here it covers every
+        # container in the pod - the server and the optional guacd sidecar
+        # alike - including init containers, while a container-level
+        # seccompProfile would have to be repeated for each one (and silently
+        # missed on the next one added). A container that genuinely needs a
+        # different filter can still override it under
+        # securityContext.container, which wins over this value.
+        seccompProfile:
+          type: RuntimeDefault
       container:
         allowPrivilegeEscalation: false
         readOnlyRootFilesystem: true
@@ -88,7 +99,7 @@ patchmon:
     enabled: false
     # guacd is an independent upstream application, so its image is not tied
     # to the chart's appVersion. Pinned to the version upstream ships with.
-    image: guacamole/guacd:1.6.0
+    image: docker.io/guacamole/guacd:1.6.0
     # The image runs as its own unprivileged user (uid 1000); it only needs a
     # writable /tmp, which the chart provides as an emptyDir.
     securityContext:

--- a/satisfactory/Chart.yaml
+++ b/satisfactory/Chart.yaml
@@ -3,7 +3,7 @@ name: satisfactory
 description: A Helm chart to deploy a Satisfactory Gameserver on Kubernetes
 icon: https://raw.githubusercontent.com/wolveix/satisfactory-server/main/.github/logo.png
 type: application
-version: 5.0.0+upv1.9.10
+version: 6.0.0+upv1.9.10
 appVersion: "v1.9.10"
 maintainers:
   - name: jklein

--- a/satisfactory/templates/_helpers.tpl
+++ b/satisfactory/templates/_helpers.tpl
@@ -224,7 +224,8 @@ Probe specifics that a rebuilt default must not lose:
       "runAsUser" 1000
       "runAsGroup" 1000
       "fsGroup" 1000
-      "fsGroupChangePolicy" "OnRootMismatch" -}}
+      "fsGroupChangePolicy" "OnRootMismatch"
+      "seccompProfile" (dict "type" "RuntimeDefault") -}}
 {{- include "satisfactory.defaultedDict" (dict "defaults" $defaults "given" $given "path" "securityContext.pod") -}}
 {{- end -}}
 

--- a/satisfactory/values.yaml
+++ b/satisfactory/values.yaml
@@ -97,6 +97,15 @@ securityContext:
     # entrypoint.
     fsGroup: 1000
     fsGroupChangePolicy: OnRootMismatch
+    # RuntimeDefault applies the container runtime's default seccomp filter,
+    # which blocks the syscalls a normal workload never makes. It sits in the
+    # pod context on purpose: from here it covers every container in the pod
+    # including init containers, while a container-level seccompProfile would
+    # have to be repeated for each one (and silently missed on the next one
+    # added). A container that genuinely needs a different filter can still
+    # override it under securityContext.container, which wins over this value.
+    seccompProfile:
+      type: RuntimeDefault
   container:
     allowPrivilegeEscalation: false
     # Works because the chart mounts emptyDirs at /tmp and the steam user's

--- a/urlaubsverwaltung/Chart.yaml
+++ b/urlaubsverwaltung/Chart.yaml
@@ -4,5 +4,5 @@ description: A Helm chart to deploy urlaubsverwaltung on Kubernetes
 icon: https://raw.githubusercontent.com/urlaubsverwaltung/urlaubsverwaltung/main/src/main/resources/static/favicons/apple-touch-icon.png
 type: application
 
-version: 7.0.0+up6.7.0
+version: 8.0.0+up6.7.0
 appVersion: 6.7.0

--- a/urlaubsverwaltung/templates/_helpers.tpl
+++ b/urlaubsverwaltung/templates/_helpers.tpl
@@ -213,7 +213,8 @@ is only the fallback for the case where an override has erased the block.
 {{- $defaults := dict
       "runAsNonRoot" true
       "runAsUser" 1002
-      "runAsGroup" 1001 -}}
+      "runAsGroup" 1001
+      "seccompProfile" (dict "type" "RuntimeDefault") -}}
 {{- include "urlaubsverwaltung.defaultedDict" (dict "defaults" $defaults "given" $given "path" "urlaubsverwaltung.securityContext.pod") -}}
 {{- end -}}
 

--- a/urlaubsverwaltung/templates/urlaubsverwaltung.deployment.yaml
+++ b/urlaubsverwaltung/templates/urlaubsverwaltung.deployment.yaml
@@ -20,7 +20,7 @@ spec:
         {{- include "urlaubsverwaltung.podSecurityContext" .Values.urlaubsverwaltung.securityContext | nindent 8 }}
       containers:
         - name: {{ .Release.Name }}-{{ .Chart.Name }}-deployment
-          image: "urlaubsverwaltung/urlaubsverwaltung:{{ .Chart.AppVersion }}"
+          image: "docker.io/urlaubsverwaltung/urlaubsverwaltung:{{ .Chart.AppVersion }}"
           imagePullPolicy: IfNotPresent
           securityContext:
             {{- include "urlaubsverwaltung.containerSecurityContext" .Values.urlaubsverwaltung.securityContext | nindent 12 }}

--- a/urlaubsverwaltung/values.yaml
+++ b/urlaubsverwaltung/values.yaml
@@ -29,6 +29,15 @@ urlaubsverwaltung:
       runAsNonRoot: true
       runAsUser: 1002
       runAsGroup: 1001
+      # RuntimeDefault applies the container runtime's default seccomp filter,
+      # which blocks the syscalls a normal workload never makes. It sits in the
+      # pod context on purpose: from here it covers every container in the pod
+      # including init containers, while a container-level seccompProfile would
+      # have to be repeated for each one (and silently missed on the next one
+      # added). A container that genuinely needs a different filter can still
+      # override it under securityContext.container, which wins over this value.
+      seccompProfile:
+        type: RuntimeDefault
     container:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true

--- a/voucher-vault/Chart.yaml
+++ b/voucher-vault/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://raw.githubusercontent.com/l4rm4nd/VoucherVault/main/myapp/static/a
 
 type: application
 
-version: 5.0.0+up1.30.1
+version: 6.0.0+up1.30.1
 appVersion: "1.30.1"
 
 maintainers:

--- a/voucher-vault/templates/_helpers.tpl
+++ b/voucher-vault/templates/_helpers.tpl
@@ -217,7 +217,8 @@ header, otherwise the pod never becomes ready.
       "runAsUser" 33
       "runAsGroup" 33
       "fsGroup" 33
-      "fsGroupChangePolicy" "Always" -}}
+      "fsGroupChangePolicy" "Always"
+      "seccompProfile" (dict "type" "RuntimeDefault") -}}
 {{- include "voucher-vault.defaultedDict" (dict "defaults" $defaults "given" $given "path" "voucherVault.securityContext.pod") -}}
 {{- end -}}
 

--- a/voucher-vault/templates/voucher-vault.sfs.yaml
+++ b/voucher-vault/templates/voucher-vault.sfs.yaml
@@ -27,7 +27,7 @@ spec:
         # entrypoint's collectstatic only adds what is missing, e.g. the
         # Django admin static files). See securityContext in values.yaml.
         - name: init-static
-          image: "l4rm4nd/vouchervault:{{ .Chart.AppVersion }}"
+          image: "docker.io/l4rm4nd/vouchervault:{{ .Chart.AppVersion }}"
           imagePullPolicy: IfNotPresent
           # Copies the children (not ".") so cp never tries to set metadata
           # on the mountpoint itself, which the non-root uid may not own.
@@ -48,7 +48,7 @@ spec:
               ephemeral-storage: 10Mi
       containers:
         - name: {{ .Release.Name }}-{{ .Chart.Name }}-sfs
-          image: "l4rm4nd/vouchervault:{{ .Chart.AppVersion }}"
+          image: "docker.io/l4rm4nd/vouchervault:{{ .Chart.AppVersion }}"
           imagePullPolicy: IfNotPresent
           env:
             {{- range $value := .Values.voucherVault.env }}

--- a/voucher-vault/values.yaml
+++ b/voucher-vault/values.yaml
@@ -74,6 +74,15 @@ voucherVault:
       runAsGroup: 33
       fsGroup: 33
       fsGroupChangePolicy: Always
+      # RuntimeDefault applies the container runtime's default seccomp filter,
+      # which blocks the syscalls a normal workload never makes. It sits in the
+      # pod context on purpose: from here it covers every container in the pod
+      # including init containers, while a container-level seccompProfile would
+      # have to be repeated for each one (and silently missed on the next one
+      # added). A container that genuinely needs a different filter can still
+      # override it under securityContext.container, which wins over this value.
+      seccompProfile:
+        type: RuntimeDefault
     container:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true

--- a/zipline/Chart.yaml
+++ b/zipline/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 6.0.0+up4.7.0
+version: 7.0.0+up4.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/zipline/templates/_helpers.tpl
+++ b/zipline/templates/_helpers.tpl
@@ -218,7 +218,8 @@ a database outage must not restart the pod.
       "runAsUser" 1000
       "runAsGroup" 1000
       "fsGroup" 1000
-      "fsGroupChangePolicy" "Always" -}}
+      "fsGroupChangePolicy" "Always"
+      "seccompProfile" (dict "type" "RuntimeDefault") -}}
 {{- include "zipline.defaultedDict" (dict "defaults" $defaults "given" $given "path" "zipline.securityContext.pod") -}}
 {{- end -}}
 

--- a/zipline/values.yaml
+++ b/zipline/values.yaml
@@ -26,6 +26,15 @@ zipline:
       runAsGroup: 1000
       fsGroup: 1000
       fsGroupChangePolicy: Always
+      # RuntimeDefault applies the container runtime's default seccomp filter,
+      # which blocks the syscalls a normal workload never makes. It sits in the
+      # pod context on purpose: from here it covers every container in the pod
+      # including init containers, while a container-level seccompProfile would
+      # have to be repeated for each one (and silently missed on the next one
+      # added). A container that genuinely needs a different filter can still
+      # override it under securityContext.container, which wins over this value.
+      seccompProfile:
+        type: RuntimeDefault
     container:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true


### PR DESCRIPTION
Stufe 1 des freigegebenen Plans zu #84: acht Charts bekommen `seccompProfile: RuntimeDefault` im **Pod**-Security-Context, fünf davon zusätzlich den `docker.io/`-Präfix für ihre bislang unqualifizierten Images. Jedes Chart erhält einen Major-Bump, `appVersion` bleibt unverändert.

Das `seccompProfile` steht im Pod- und nicht im Container-Context, weil es von dort Init-Container und später ergänzte Container abdeckt, ohne wiederholt zu werden; ein Container, der einen anderen Filter braucht, kann ihn unter `securityContext.container` überschreiben.

## Was je Chart geändert wurde

| Chart | neue Version | seccomp | `docker.io/`-Präfix |
|---|---|---|---|
| `minecraft-router` | `4.0.0+up1.46.4` | ja | `itzg/mc-router` (Template) |
| `outline` | `7.0.0+up1.9.2` | ja | `outlinewiki/outline` (Template) |
| `urlaubsverwaltung` | `8.0.0+up6.7.0` | ja | `urlaubsverwaltung/urlaubsverwaltung` (Template) |
| `zipline` | `7.0.0+up4.7.0` | ja | — (bereits `ghcr.io`) |
| `voucher-vault` | `6.0.0+up1.30.1` | ja | `l4rm4nd/vouchervault`, **beide** Vorkommen (App + Init-Container) |
| `satisfactory` | `6.0.0+upv1.9.10` | ja | — (bereits `ghcr.io`) |
| `patchmon` | `7.0.0+up2.1.3` | ja | `guacamole/guacd:1.6.0` (`values.yaml`) |
| `calibre-web-automated` | `6.0.0+upv4.0.6` | ja | — (bereits `ghcr.io`) |

## Funktionsnachweis je Chart

Belegt in einem throwaway k3d-Cluster gegen echte Anwendungsarbeit — ein laufender Pod beweist hier nichts. Zusätzlich je Container `Seccomp: 2` (Filter aktiv) aus `/proc/<pid>/status` gelesen.

- **`minecraft-router`** — Ein Minecraft-Handshake auf eine gemappte Domain läuft durch den Router zu einem Backend, dessen Status-Payload beim Client ankommt (`SECCOMP-PROOF-BACKEND`, 123 Bytes). Der Router hat zuvor seine Routing-ConfigMap gelesen und beide Mappings angelegt. `Seccomp: 2` auf `mc-router`.
- **`outline`** — Alle Migrationen angewendet (45 Tabellen in Postgres), OIDC-Discovery gegen den Issuer erfolgreich, `/_health` (prüft Postgres **und** Redis) liefert `OK`, `/` liefert 200 mit 14 138 Bytes und `<title>Outline</title>`. `Seccomp: 2` auf dem node-Prozess.
- **`urlaubsverwaltung`** — Liquibase wendet 79 Changesets an (35 Tabellen), die App legt Settings, 16 Urlaubsarten und Krankmeldungstypen an, `/login` liefert 200 mit `<title>Please sign in</title>`. `Seccomp: 2` auf dem java-Prozess.
- **`zipline`** — 27 Prisma-Migrationen (17 Tabellen), danach ein vollständiger Rundlauf: ersten Benutzer angelegt, Login, Token gelesen, Datei hochgeladen, byte-genau wieder heruntergeladen (`SECCOMP-PROOF-PAYLOAD-ZIPLINE-8421`, HTTP 200) und auf dem PVC als `proof.txt` wiedergefunden. `Seccomp: 2`.
- **`voucher-vault`** — Der Init-Container terminiert mit Exit 0 und sein `collectstatic`-Ergebnis wird tatsächlich ausgeliefert (`/static/admin/css/base.css`, 200, 22 120 Bytes). Django hat seine 22 Tabellen, uWSGI liefert 200 mit `<title>VoucherVault</title>`. `Seccomp: 2`.
- **`patchmon`** — **Beide** Container laufen unter dem Pod-Profil und melden beide `Seccomp: 2`. Der Server wendet 47 Migrationen an (44 Tabellen), verbindet Postgres und Redis, Queue und Scheduler laufen, ein Hintergrund-Task (`ssg-update-check`) läuft durch, `/` liefert 200 mit `<title>PatchMon - Linux Patch Management Dashboard</title>`. guacd beantwortet eine echte Guacamole-Instruktion `6.select,3.rdp;` mit seiner vollständigen `args`-Liste — das RDP-Client-Plugin ist also geladen — und zwar über genau den Pfad `127.0.0.1:4822`, den das Chart verdrahtet.
- **`calibre-web-automated`** — Die dokumentierte Ausnahme `readOnlyRootFilesystem: false` bleibt unberührt: `id abc` ist weiterhin **uid 1000** (nicht die 911, auf die das Image im Read-only-Modus zurückfällt), `/config` samt `app.db` und die Calibre-`metadata.db` (413 KB) gehören 1000:1000, der Anwendungsprozess läuft als uid 1000 und die s6-Supervisoren bleiben root — genau wie dokumentiert. **Beide** melden `Seccomp: 2`, der Filter wird also über den root→uid-1000-Wechsel vererbt. Die Login-Seite liefert 200 mit `<title>Calibre-Web Automated | Login</title>`, `calibredb` (calibre 9.1) läuft und fügt ein Buch hinzu.
- **`satisfactory`** — **Hier fehlt der Anwendungsnachweis, und ich behaupte ihn nicht.** Das Image ist mehrere GB groß und lädt beim ersten Start 10 GB+ Spieldaten über Steam nach; genau deshalb steht das Chart in `ci/excluded-charts.txt`. Belegt ist nur: der gerenderte Pod-Security-Context wird serverseitig akzeptiert (`helm install --dry-run=server`), und derselbe Block verbatim auf ein Ersatz-Image angewandt liefert `Seccomp: 2` bei uid/gid 1000. Ob der Spielserver selbst unter dem Filter arbeitet, ist damit **nicht** gezeigt.

### Kontrollexperiment bei calibre-web-automated

`calibredb add` gibt beim Hinzufügen einen `BrokenPipeError` aus seinem IPC-Worker aus — das Buch wird trotzdem angelegt (`Added book ids: 3`, Dateien liegen als `metadata.opf` und `.txt` auf dem Volume). Um das nicht wegzuerklären, habe ich denselben Aufruf in einem Kontroll-Pod auf demselben Image mit `seccompProfile: Unconfined` wiederholt: dort meldet `/proc/1/status` `Seccomp: 0` und derselbe Aufruf wirft dieselbe Klasse Traceback aus derselben calibre-IPC-Maschinerie. Der Filter ist also nicht die Ursache.

## Trivy

`ci/run-trivy-config.sh` meldet für alle acht Charts **„0 to act on"**. Zur Gegenprobe: das in dieser Stufe unangetastete `samba` zeigt weiterhin `KSV-0104` und `KSV-0030` — die Befunde sind also tatsächlich durch diese Charts geschlossen worden und nicht durch eine Änderung an der Ignore-Liste. `ci/trivy/trivyignore.yaml` enthielt ohnehin keine seccomp-Einträge und bleibt unverändert.

## `values.schema.json`

Geprüft, nicht angenommen: In allen acht Schemata ist `securityContext.pod` als `type: ["object", "null"]` **ohne** `properties`/`additionalProperties`-Einschränkung modelliert („kept open because the chart does not interpret the individual fields"). Der neue Schlüssel validiert damit unverändert — kein Schema musste nachgezogen werden, was auch zu den bereits erledigten Charts passt, die ihre Schemata ebenfalls nicht angefasst haben.

Die Null-Absicherung aus #99 hält weiterhin: `--set <chart>.securityContext=null` und `--set <chart>.securityContext.pod=null` fallen beide auf die Defaults inklusive des neuen Schlüssels zurück; ein explizites Überschreiben (`seccompProfile.type=Unconfined`) gewinnt wie vorgesehen.

## Renovate-Auflage

**Erfüllt, und zwar gegen die präfigierte Form.** Lookup mit Renovate 44.40.1 (`--platform=local --dry-run=lookup`, im offiziellen Container, weil die lokale npx-Installation ohne `re2` falsche Regex-Fehler produziert) gegen den Arbeitsbaum **mit** bereits gesetztem Präfix:

```
"depName":     "docker.io/guacamole/guacd",
"packageName": "docker.io/guacamole/guacd",
"registryUrl": "https://index.docker.io",
"lookupName":  "guacamole/guacd",
"currentValue": "1.6.0",
"currentVersion": "1.6.0",
"currentVersionTimestamp": "2025-06-23T01:28:50.423Z",
"warnings": []
```

Renovate löst den Präfix korrekt auf, streift ihn für die Registry-Abfrage ab, findet die Version samt echtem Release-Zeitstempel und meldet keine Warnung. `updates: []` heißt hier „1.6.0 ist weiterhin die neueste", nicht „Lookup fehlgeschlagen" — der Zeitstempel belegt, dass die Abfrage durchlief. Über alle 23 Dependencies hinweg gibt es keine nicht-leere `warnings`-Liste; die einzigen `skipReason`-Einträge sind `github-token-required` bei GitHub-Actions und damit unabhängig von dieser Änderung.

Die übrigen vier präfigierten Referenzen liegen in **Templates**, die Renovate nie liest. Sie werden über die `customManagers` anhand `appVersion:` in `Chart.yaml` verfolgt, mit in `renovate.json5` fest hinterlegtem `depNameTemplate` — der Lookup bestätigt das: sie erscheinen dort weiterhin unpräfigiert als `itzg/mc-router`, `outlinewiki/outline`, `urlaubsverwaltung/urlaubsverwaltung` und `l4rm4nd/vouchervault`. Diese Änderung ist für sie unsichtbar.

## Risiko des Zuschnitts

Ausdrücklich benannt und vom Plan so gewollt: Das ist ein Sammel-PR über acht Charts. **Ein fehlschlagender Install-Test blockiert die übrigen sieben mit.** Der Gegenwert sind 8 statt 16 Veröffentlichungen und ebenso viele eingesparte Hochzieh-Runden auf der Cluster-Seite. `satisfactory` ist vom Install-Test ausgenommen und trägt deshalb nicht zum Risiko bei — aber eben auch nicht zum Nachweis.

## README

Unverändert, entsprechend dem Vorgehen der bereits erledigten Charts: weder die Chart-Commits dieser Serie noch der `template-chart`-Commit `00ea301`, der die Konvention gesetzt hat, haben die README angefasst. Diese Änderung ist chart-lokales Laufzeitverhalten, keine repo-weite Verhaltensänderung.

Refs #84 — das Issue bleibt offen, Stufen 2–4 folgen.
