### PR TITLE
minecraft-server: Null-Absicherung für Härtung, Probes und Resources

### DIFF
--- a/minecraft-server/Chart.yaml
+++ b/minecraft-server/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # continuously, so a pod restart could pull a different image than the last one
 # without anything being recorded anywhere. The dated tags are immutable, so the
 # image is now pinned by the chart version like every other chart in this repo.
-version: 3.0.1+up2026.8.2.java21
+version: 4.0.0+up2026.8.2.java21
 appVersion: "2026.8.2-java21"
 
 maintainers:

--- a/minecraft-server/templates/_helpers.tpl
+++ b/minecraft-server/templates/_helpers.tpl
@@ -95,10 +95,19 @@ the heap instead, which keeps the two from drifting apart; an explicitly set
 request always wins. The limit follows from the request via the limitFactor
 rule in "minecraft-server.resources".
 
+Since chart 4.0.0 the values block first goes through "defaultedDict" (issue
+#99), so an erased "server.resources:" falls back to the chart's requests and
+computed limits instead of rendering a container without any resource
+accounting. The fallback deliberately leaves the memory request unset, exactly
+as values.yaml does, so the derivation from the JVM heap below still applies.
+
 Input: the root context.
 */}}
 {{- define "minecraft-server.serverResources" -}}
-{{- $resources := deepCopy (.Values.server.resources | default dict) -}}
+{{- $defaults := dict
+      "limitFactor" 3
+      "requests" (dict "cpu" "2" "ephemeral-storage" "100Mi") -}}
+{{- $resources := fromYaml (include "minecraft-server.defaultedDict" (dict "defaults" $defaults "given" .Values.server.resources "path" "server.resources")) -}}
 {{- $requests := deepCopy ($resources.requests | default dict) -}}
 {{- if kindIs "invalid" $requests.memory -}}
 {{- $_ := set $requests "memory" (printf "%vGi" .Values.minecraft.resources.memory) -}}
@@ -155,4 +164,169 @@ last one silently won. Fail loudly instead.
 {{- if and .Values.curseforgeServerpack.enabled (not .Values.curseforgeServerpack.downloadUrl) -}}
 {{- fail "minecraft-server: curseforgeServerpack.enabled is true but curseforgeServerpack.downloadUrl is not set - the init container would download an empty URL" -}}
 {{- end -}}
+{{- end -}}
+
+{{/*
+Merge a user-supplied values sub-tree onto a dict of chart defaults so that a
+null / empty override falls back to the defaults instead of erasing them.
+
+Input: dict "defaults" <dict> "given" <dict|nil> "path" <string, optional
+values path used in error messages>. Output: YAML of the merged dict (consume
+it with fromYaml).
+
+Why this exists (issue #99): Helm merges values maps recursively, but an
+override key written without children — e.g. a leftover
+
+  securityContext:
+
+after deleting its last remaining sub-key — is YAML null. Where the chart
+defines a default, Helm treats that null as a deletion of the default; the
+template then renders "securityContext: null": no readOnlyRootFilesystem, no
+dropped capabilities, no allowPrivilegeEscalation: false. The workload starts
+and reports healthy while being unhardened, so nothing points at the mistake.
+The same shape erases a probe (it disappears) or the resources block (no
+requests, no computed limits). This helper defines the opposite semantics: an
+empty block means "chart defaults apply".
+
+Rules:
+  - a nil "given" is treated as an empty dict (all defaults apply).
+  - a key whose override value is null keeps the default (nulls never delete).
+  - a key present in both as a map is merged recursively, so a partially
+    filled block only overrides the keys it actually sets.
+  - a scalar override for a key the defaults define as a map is rejected with
+    a message naming the values path, instead of failing later with a template
+    field error.
+  - any other set value wins as given, including an explicit false or 0 —
+    Helm's "default" and sprig's "mergeOverwrite" would both swallow those
+    zero values, hence the explicit kindIs "invalid" nil check.
+  - keys only present in the override are passed through unchanged.
+
+NOTE: like the helpers above, this is duplicated into every chart's
+templates/_helpers.tpl with the chart's name as define prefix, because charts
+in this repo deliberately have no dependencies. The reference implementation
+lives in template-chart.
+*/}}
+{{- define "minecraft-server.defaultedDict" -}}
+{{- $defaults := .defaults | default dict -}}
+{{- $given := .given -}}
+{{- $path := .path | default "value" -}}
+{{- if kindIs "invalid" $given -}}
+{{- $given = dict -}}
+{{- end -}}
+{{- if not (kindIs "map" $given) -}}
+{{- fail (printf "%s must be a mapping or null, got %s (%v)" $path (kindOf $given) $given) -}}
+{{- end -}}
+{{- $out := deepCopy $defaults -}}
+{{- range $key, $value := $given -}}
+{{- if not (kindIs "invalid" $value) -}}
+{{- $default := index $defaults $key -}}
+{{- if and (kindIs "map" $value) (kindIs "map" $default) -}}
+{{- $_ := set $out $key (fromYaml (include "minecraft-server.defaultedDict" (dict "defaults" $default "given" $value "path" (printf "%s.%s" $path $key)))) -}}
+{{- else if kindIs "map" $default -}}
+{{- fail (printf "%s.%s must be a mapping or null, got %s (%v)" $path $key (kindOf $value) $value) -}}
+{{- else -}}
+{{- $_ := set $out $key $value -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- toYaml $out -}}
+{{- end -}}
+
+{{/*
+Pick one sub-block out of a values block that may itself be null.
+
+Input: dict "block" <dict|nil> "key" <string> "path" <string>.
+Returns YAML of dict "value" <the sub-block, may be nil>, after rejecting a
+non-mapping block with a message that names the values path. Needed because
+".Values.securityContext" can itself be erased, and indexing into nil inside a
+template is not an error but silently yields nothing.
+*/}}
+{{- define "minecraft-server.subBlock" -}}
+{{- $block := .block -}}
+{{- if kindIs "invalid" $block -}}
+{{- $block = dict -}}
+{{- end -}}
+{{- if not (kindIs "map" $block) -}}
+{{- fail (printf "%s must be a mapping or null, got %s (%v)" .path (kindOf $block) $block) -}}
+{{- end -}}
+{{- toYaml (dict "value" (index $block .key)) -}}
+{{- end -}}
+
+{{/*
+The effective security contexts and probes (issue #99); the resources block is
+covered by "minecraft-server.serverResources" above.
+
+The defaults below MUST stay in sync with the corresponding blocks in
+values.yaml, which stays the documented, user-facing place for them; this copy
+is only the fallback for the case where an override has erased the block. The
+sync is not left to discipline: rendering with every one of these blocks set to
+null is byte-identical to rendering the defaults, so a drift shows up.
+
+This chart's deviations from the repo baseline, which a "cleaned up" standard
+fallback would silently undo:
+
+  - uid/gid are pinned to 1000, the image's "minecraft" user. The image's
+    entrypoint normally starts as root and drops to that user via gosu;
+    starting as the user directly takes the non-root branch, which skips the
+    recursive chown of /data and the write to /etc/nsswitch.conf that would
+    fail on a read-only root filesystem. It is also the uid that owns the
+    existing world data on the PVC.
+  - fsGroupChangePolicy is OnRootMismatch, not Always: a recursive chown of a
+    32Gi world on every pod start costs minutes.
+  - the capabilities block carries an explicit empty "add" list alongside
+    "drop: [ALL]", matching values.yaml.
+  - all three probes run the image's own mc-health script as an EXEC probe -
+    a real Minecraft server-list ping via mc-monitor against SERVER_PORT.
+    There is no HTTP endpoint to fall back to, so a probe default rebuilt as
+    an httpGet would leave this workload with no working probe at all.
+  - the startup budget is 15s x 80 = 20 minutes, because on a fresh volume the
+    image downloads the server jar and, for FTB/CurseForge modpacks, the whole
+    modpack before the world even starts loading.
+*/}}
+{{- define "minecraft-server.podSecurityContext" -}}
+{{- $given := (fromYaml (include "minecraft-server.subBlock" (dict "block" . "key" "pod" "path" "securityContext"))).value -}}
+{{- $defaults := dict
+      "runAsNonRoot" true
+      "runAsUser" 1000
+      "runAsGroup" 1000
+      "fsGroup" 1000
+      "fsGroupChangePolicy" "OnRootMismatch" -}}
+{{- include "minecraft-server.defaultedDict" (dict "defaults" $defaults "given" $given "path" "securityContext.pod") -}}
+{{- end -}}
+
+{{- define "minecraft-server.containerSecurityContext" -}}
+{{- $given := (fromYaml (include "minecraft-server.subBlock" (dict "block" . "key" "container" "path" "securityContext"))).value -}}
+{{- $defaults := dict
+      "allowPrivilegeEscalation" false
+      "readOnlyRootFilesystem" true
+      "runAsNonRoot" true
+      "capabilities" (dict "drop" (list "ALL") "add" (list)) -}}
+{{- include "minecraft-server.defaultedDict" (dict "defaults" $defaults "given" $given "path" "securityContext.container") -}}
+{{- end -}}
+
+{{- define "minecraft-server.livenessProbe" -}}
+{{- $defaults := dict
+      "exec" (dict "command" (list "mc-health"))
+      "periodSeconds" 30
+      "timeoutSeconds" 10
+      "failureThreshold" 3 -}}
+{{- include "minecraft-server.defaultedDict" (dict "defaults" $defaults "given" . "path" "livenessProbe") -}}
+{{- end -}}
+
+{{- define "minecraft-server.readinessProbe" -}}
+{{- $defaults := dict
+      "exec" (dict "command" (list "mc-health"))
+      "periodSeconds" 15
+      "timeoutSeconds" 10
+      "failureThreshold" 3 -}}
+{{- include "minecraft-server.defaultedDict" (dict "defaults" $defaults "given" . "path" "readinessProbe") -}}
+{{- end -}}
+
+{{- define "minecraft-server.startupProbe" -}}
+{{- $defaults := dict
+      "exec" (dict "command" (list "mc-health"))
+      "periodSeconds" 15
+      "timeoutSeconds" 10
+      "failureThreshold" 80 -}}
+{{- include "minecraft-server.defaultedDict" (dict "defaults" $defaults "given" . "path" "startupProbe") -}}
 {{- end -}}

--- a/minecraft-server/templates/minecraft-server.configmap.yaml
+++ b/minecraft-server/templates/minecraft-server.configmap.yaml
@@ -1,3 +1,11 @@
+{{/*
+The chown at the end of init.sh used to be a hardcoded 1000:1000 while the uid
+it has to match was overridable through securityContext.pod - so an override
+made the two disagree in silence. Both now read the same null-safe helper, and
+with the chart defaults the rendered script is unchanged (1000:1000), so this
+does not move checksum/config and does not roll existing pods.
+*/}}
+{{- $podCtx := fromYaml (include "minecraft-server.podSecurityContext" .Values.securityContext) -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -40,7 +48,7 @@ data:
       # not be fatal: an unprivileged process cannot chown foreign files, and
       # with "set -e" a failure here would keep the whole pod from starting.
       echo "change owner of files"
-      chown -R 1000:1000 $SERVERPACK_DIR || echo "chown skipped (not permitted); continuing"
+      chown -R {{ $podCtx.runAsUser }}:{{ $podCtx.runAsGroup }} $SERVERPACK_DIR || echo "chown skipped (not permitted); continuing"
 
       echo "successfully migrated server"
 

--- a/minecraft-server/templates/minecraft-server.sfs.yaml
+++ b/minecraft-server/templates/minecraft-server.sfs.yaml
@@ -35,14 +35,14 @@ spec:
     spec:
       automountServiceAccountToken: false
       securityContext:
-        {{- toYaml .Values.securityContext.pod | nindent 8 }}
+        {{- include "minecraft-server.podSecurityContext" .Values.securityContext | nindent 8 }}
       {{- if .Values.curseforgeServerpack.enabled }}
       initContainers:
         - name: download-serverpack
           image: {{ .Values.server.initImage }}
           command: [ 'sh', '/init/init.sh' ]
           securityContext:
-            {{- toYaml .Values.securityContext.container | nindent 12 }}
+            {{- include "minecraft-server.containerSecurityContext" .Values.securityContext | nindent 12 }}
           volumeMounts:
             - name: "mc-volume"
               mountPath: /modpacks
@@ -61,7 +61,7 @@ spec:
           image: "itzg/minecraft-server:{{ .Chart.AppVersion }}"
           imagePullPolicy: IfNotPresent
           securityContext:
-            {{- toYaml .Values.securityContext.container | nindent 12 }}
+            {{- include "minecraft-server.containerSecurityContext" .Values.securityContext | nindent 12 }}
           ports:
             - name: mc-port
               containerPort: {{ .Values.server.port }}
@@ -205,11 +205,11 @@ spec:
             {{- end }}
             {{- end }}
           livenessProbe:
-            {{- toYaml .Values.livenessProbe | nindent 12 }}
+            {{- include "minecraft-server.livenessProbe" .Values.livenessProbe | nindent 12 }}
           readinessProbe:
-            {{- toYaml .Values.readinessProbe | nindent 12 }}
+            {{- include "minecraft-server.readinessProbe" .Values.readinessProbe | nindent 12 }}
           startupProbe:
-            {{- toYaml .Values.startupProbe | nindent 12 }}
+            {{- include "minecraft-server.startupProbe" .Values.startupProbe | nindent 12 }}
           resources:
             {{- include "minecraft-server.serverResources" . | nindent 12 }}
           volumeMounts:

--- a/minecraft-server/values.schema.json
+++ b/minecraft-server/values.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "minecraft-server values",
-  "description": "Strict values schema (issue #68 pilot). additionalProperties is false on every chart-owned object level, so a key that the chart does not read is rejected at render time instead of being silently ignored. The only objects that stay open are the ones passed verbatim into the Kubernetes pod spec (probes, security contexts, global) - the chart does not interpret their contents, so it cannot judge which keys are meaningful.",
+  "description": "Strict values schema (issue #68 pilot). additionalProperties is false on every chart-owned object level, so a key that the chart does not read is rejected at render time instead of being silently ignored. The only objects that stay open are the ones passed verbatim into the Kubernetes pod spec (probes, security contexts, global) - the chart does not interpret their contents, so it cannot judge which keys are meaningful. The hardening, probe and resources blocks additionally accept null, because an erased block falls back to the chart defaults (issue #99). Both halves are needed and cover different cases: for a key WITH a chart default Helm's coalescing deletes the null before validation ever sees it, and only the defaultedDict fallback in _helpers.tpl catches that; for a key WITHOUT one (e.g. server.resources.limits) the null survives into validation, where a strict \"object\" would abort the render. Everything else stays strictly typed.",
   "type": "object",
   "additionalProperties": false,
   "properties": {
@@ -75,7 +75,8 @@
           "type": "string"
         },
         "resources": {
-          "type": "object",
+          "description": "May be null / empty: the chart then falls back to its default requests and computed limits (issue #99) instead of rendering the server container without resource accounting. The memory request stays deliberately unset in that fallback, as in values.yaml, so it keeps being derived from the JVM heap (minecraft.resources.memory).",
+          "type": ["object", "null"],
           "additionalProperties": false,
           "properties": {
             "limitFactor": {
@@ -130,16 +131,17 @@
       "$ref": "#/definitions/probe"
     },
     "securityContext": {
-      "type": "object",
+      "description": "May be null / empty at any level: the chart then falls back to its hardening defaults (issue #99) instead of rendering an unhardened workload. The pod context is consumed twice - as the pod's securityContext and by the serverpack init script, which chowns the migrated files to runAsUser:runAsGroup; both reads go through the same helper.",
+      "type": ["object", "null"],
       "additionalProperties": false,
       "properties": {
         "pod": {
-          "description": "Rendered verbatim as the pod's securityContext; kept open because the chart does not interpret it.",
-          "type": "object"
+          "description": "Merged onto the chart's pod hardening defaults and rendered as the pod's securityContext; kept open because the chart does not interpret the individual fields.",
+          "type": ["object", "null"]
         },
         "container": {
-          "description": "Rendered verbatim as the container's securityContext; kept open because the chart does not interpret it.",
-          "type": "object"
+          "description": "Merged onto the chart's container hardening defaults and rendered as the securityContext of the server container and the serverpack init container; kept open because the chart does not interpret the individual fields.",
+          "type": ["object", "null"]
         }
       }
     },
@@ -283,7 +285,7 @@
   },
   "definitions": {
     "resourceList": {
-      "type": "object",
+      "type": ["object", "null"],
       "additionalProperties": false,
       "properties": {
         "cpu": {
@@ -314,8 +316,8 @@
       }
     },
     "probe": {
-      "description": "Rendered verbatim as a container probe; kept open because the chart does not interpret it.",
-      "type": "object"
+      "description": "Merged onto the chart's probe defaults and rendered as a container probe; kept open because the chart does not interpret the individual fields. May be null / empty, which means the defaults apply (issue #99) rather than the probe disappearing. The defaults carry the probe's context, not just its timings: all three run the image's mc-health script as an exec probe, which is the only health check this image offers.",
+      "type": ["object", "null"]
     }
   }
 }


### PR DESCRIPTION
Schliesst die letzte gemessene Lücke aus #99 — `minecraft-server` war das einzige der 21 Charts, bei dem ein genullter Security-Kontext die Härtung lautlos entfernt hat.

Gemessen auf `3.0.1` gegen `ci/minecraft-server/test-values.yaml`:

```
--set securityContext.pod=null --set securityContext.container=null
→ helm exit 0, kein Schemafehler
→ securityContext: null   für Pod UND Container
```

Kein `runAsNonRoot`, kein `readOnlyRootFilesystem`, keine gedroppten Capabilities — in einem Chart mit PVC. Ursache: kein `defaultedDict`-Helfer, `toYaml` direkt auf `.Values.securityContext.pod`, und `securityContext.pod` im Schema als striktes `"object"` ohne `required`. Bittere Stelle: Die README führt dieses Chart als **Piloten** für #68 — es hat sein Schema früh bekommen und ist deshalb von der späteren Null-Absicherung nie erfasst worden.

## Was drin ist

**Beide Hälften**, weil sie Verschiedenes abdecken. Bei einem Schlüssel **mit** Chart-Default entfernt Helms Coalescing das `null` **vor** der Validierung — dagegen hilft nur die Fallback-Tabelle. Bei einem Schlüssel **ohne** Default (`server.resources.limits`) überlebt das `null` und brach am strikten `"object"` ab — dagegen hilft nur die Weitung auf `["object","null"]`.

Die Fallback-Tabelle bildet **die Defaults dieses Charts** ab, Abweichungen eingeschlossen:

- **uid/gid 1000**, der `minecraft`-User des Images. Direkt als dieser User zu starten nimmt den Nicht-Root-Zweig des Entrypoints, der den rekursiven chown von `/data` und den Schreibzugriff auf `/etc/nsswitch.conf` überspringt — letzterer würde auf einem read-only Root-Dateisystem scheitern. Es ist ausserdem die uid, der die vorhandenen Welt-Daten auf dem PVC gehören.
- **`fsGroupChangePolicy: OnRootMismatch`**, nicht `Always`: ein rekursiver chown einer 32Gi-Welt bei jedem Pod-Start kostet Minuten.
- die explizit leere `capabilities.add`-Liste neben `drop: [ALL]`.
- **alle drei Probes als exec-Probes** auf das `mc-health`-Skript des Images. Dieses Image hat keinen HTTP-Endpunkt — ein als `httpGet` nachgebauter Probe-Default liesse den Workload **ganz ohne funktionierende Probe** zurück. Das Startup-Budget bleibt 15s × 80 = 20 Minuten.

`server.resources` läuft durch denselben Helfer, lässt den Memory-Request aber weiterhin bewusst ungesetzt, damit er wie bisher aus dem JVM-Heap abgeleitet wird.

**Dieselbe Klasse eine Ebene tiefer**, mitgefunden: `init.sh` chownte den migrierten Serverpack auf ein hartkodiertes `1000:1000`, während die uid, zu der es passen muss, überschreibbar war. Beide Lesungen gehen jetzt durch denselben Helfer, können also nicht mehr auseinanderlaufen. Mit den Chart-Defaults ist das gerenderte Skript unverändert — `checksum/config` bewegt sich nicht, es rollt kein bestehender Pod.

`minecraft.resources.storage` und `.memory` bleiben bewusst **nicht** null-sicher: ein gelöschter Wert ergibt ein ungültiges PVC bzw. eine unparsbare Quantity — die laute Klasse, die #99 ausnimmt.

## Nachweis

Alles gegen `ci/minecraft-server/test-values.yaml`, sofern nicht anders vermerkt.

**1. Der Fehlerfall ist weg — Ausgang: Fallback, nicht Abweisung.** Derselbe Aufruf rendert jetzt die Defaults:

```yaml
securityContext:                     securityContext:
  fsGroup: 1000                        allowPrivilegeEscalation: false
  fsGroupChangePolicy: OnRootMismatch   capabilities:
  runAsGroup: 1000                        add: []
  runAsNonRoot: true                      drop: [ALL]
  runAsUser: 1000                       readOnlyRootFilesystem: true
                                        runAsNonRoot: true
```

und ist **byte-identisch** zum unveränderten Rendering.

**2. Byte-Identität bei vollständigem Nullen.** Rendering mit `securityContext`, allen drei Probes und `server.resources` auf `null` ist byte-identisch zum Rendering der Chart-Defaults. Das ist der Beleg, dass Tabelle und `values.yaml` synchron sind, statt es der Disziplin zu überlassen.

Eine Präzisierung, die dazugehört: gegen die **CI-Werte** ist die Identität nur dann gegeben, wenn `server.resources` stehen bleibt — die CI-Datei setzt darin selbst `cpu: 500m`. Das Löschen des Blocks stellt korrekt den **Chart**-Default (`cpu: "2"`) wieder her, nicht den CI-Override. Deshalb zwei Läufe: gegen Chart-Defaults mit **allen** Blöcken genullt, gegen die CI-Werte mit allen ausser `server.resources`. Beide byte-identisch.

**3. Keine Regression im Normalfall.** Rendering vor und nach der Änderung ist byte-identisch — auf den CI-Werten, auf den Chart-Defaults und mit `curseforgeServerpack.enabled=true` (der Init-Container-Pfad, den die CI-Werte nicht durchlaufen). Zusätzlich **strukturell** verglichen (Dokumente nach kind/name gepaart, rekursiv über Schlüssel statt zeilenweise): `STRUCTURALLY IDENTICAL`, null Abweichungen. Bei diesem Umbau zeigte der rohe Diff ohnehin nichts — die Struktur-Prüfung ist die Absicherung gegen den freesailarr-Fall, wo ein roher Diff eine Umsortierung wie ein verlorenes `runAsUser` aussehen liess.

**4. Teilweises Nullen — 14 Schlüssel einzeln.** Auf `3.0.1` haben **zwölf davon das Rendering lautlos verändert**:

| Gelöschter Schlüssel | 3.0.1 | 4.0.0 |
|---|---|---|
| `securityContext.container.capabilities` | lautlos verändert | identisch zum Default |
| `securityContext.container.capabilities.drop` | lautlos verändert | identisch zum Default |
| `securityContext.container.readOnlyRootFilesystem` | lautlos verändert | identisch zum Default |
| `securityContext.pod.runAsUser` | lautlos verändert | identisch zum Default |
| `securityContext.pod.fsGroupChangePolicy` | lautlos verändert | identisch zum Default |
| `securityContext.pod` | lautlos verändert | identisch zum Default |
| `securityContext.container` | lautlos verändert | identisch zum Default |
| `securityContext` | Render-Fehler | identisch zum Default |
| `livenessProbe.exec` | lautlos verändert | identisch zum Default |
| `livenessProbe` / `readinessProbe` / `startupProbe` | lautlos verändert | identisch zum Default |
| `server.resources.requests` | lautlos verändert | identisch zum Chart-Default |
| `server.resources.limitFactor` | identisch zum Default | identisch zum Default |

Der freesailarr-Fall greift hier genauso: `securityContext.container.capabilities=null` liess auf `3.0.1` den **gesamten Capability-Block** verschwinden, während der Rest der Härtung stehenblieb — der Container behielt alle Default-Capabilities, statt ALL zu droppen. Und `server.resources.requests=null` verlor auf `3.0.1` **cpu und ephemeral-storage komplett** (übrig blieb nur der aus dem Heap abgeleitete Memory-Request).

**5. Die zweite Hälfte, isoliert belegt.** `--set server.resources.limits=null` — ein Schlüssel **ohne** Chart-Default:

```
3.0.1: at '/server/resources/limits': got null, want object   (Render bricht ab)
4.0.0: exit 0, identisch zum Default-Rendering
```

**6. Negativ-Proben.** Das Schema bleibt streng: unbekannter Schlüssel (`securityContextt`) → `additional properties not allowed`; Skalar in einem Mapping-Slot → `got string, want null or object`. Ein explizites `readOnlyRootFilesystem: false` gewinnt weiterhin über den Default (wird nicht als Null-Wert verschluckt). Und ein `runAsUser`-Override erreicht jetzt **beide** Leser: Pod-Kontext **und** den chown in `init.sh` (`2000:2000` statt vorher fest `1000:1000` bei überschriebenem Kontext).

`helm lint --strict minecraft-server` → 0 Findings. `helm package` → `minecraft-server-4.0.0+up2026.8.2.java21.tgz`. CI grün auf Job-Ebene: `Detect changed charts`, `Build minecraft-server`, `Trivy config minecraft-server`, **`Install-test minecraft-server`** — der läuft für dieses Chart wirklich (keine Ausnahme in `ci/excluded-charts.txt`).

## Eine Verhaltensänderung, die ich nicht verschweige

Der Fallback führt `server.resources` durch `toYaml`/`fromYaml`. Dabei wird eine Ganzzahl zu `float64`, und `printf "%v"` in `multiplyQuantity` schreibt grosse `float64` in Exponentialschreibweise. Folge: ein **nackter ganzzahliger** Byte-Wert ab ca. `1e6` bricht das Rendering ab.

```
--set server.resources.requests.memory=1073741824
3.0.1: rendert (memory: 1073741824, limit 3221225472)
4.0.0: Error: unsupported resource quantity suffix "e+09" in "1.073741824e+09"
```

Gemessene Schwelle: `65536` rendert, `1048576` nicht.

Drei Dinge dazu:

1. **Es ist laut, nicht leise** — das Rendering bricht ab. Genau die Klasse, die #99 ausnimmt.
2. **Es ist nicht chart-spezifisch.** Dasselbe passiert auf `paperless-ngx` 12.0.0, der Referenzumsetzung, mit identischer Fehlermeldung — der Round-Trip steckt im gemeinsamen Muster, das alle 20 nachgezogenen Charts benutzen. Ich habe es hier nicht erfunden und behebe es hier **nicht einseitig**: `multiplyQuantity` ist in allen 21 Charts dieselbe Kopie, und ein Alleingang in einem davon erzeugt Drift statt einer Lösung.
3. **Die praktische Exposition ist null.** Kein `values.yaml` und kein CI-Fixture im Repo schreibt einen nackten Byte-Wert; benutzt werden Strings (`"100Mi"`, `"4Gi"`) und kleine CPU-Bruchzahlen (`0.1`, `2`) — die sind nicht betroffen, `cpu` wird nie multipliziert. Nachgeprüft: `--set server.resources.requests.cpu=0.1` rendert byte-identisch zu vorher.

Das gehört als repo-weiter Befund entschieden, nicht in diesem PR nebenbei.

## Version

**MAJOR**, `3.0.1+up2026.8.2.java21` → `4.0.0+up2026.8.2.java21`, wie der Präzedenzfall aus denselben PRs (paperless-ngx 11→12, matrix-synapse 6→7): das Löschen eines dieser Blöcke veränderte bisher den gerenderten Workload und tut es jetzt nicht mehr — eine Laufzeit-Verhaltensänderung. `appVersion` bleibt unverändert.

## Java-Linien

Dieses Chart wird einmal je Java-Linie veröffentlicht; Templates und Schema sind für alle Linien dieselben. Auf `main` liegt die **java21**-Fassung, dieser PR zieht also nur sie nach. **java8 und java17 tragen die Absicherung danach noch nicht** und werden in eigenen, aufeinander folgenden PRs nachgezogen (`4.0.0+up2026.8.2.java8`, dann `4.0.0+up2026.8.2.java17`, dann eine Rückstellung des Verzeichnisses auf java21 als `4.0.1+up2026.8.2.java21`).

Refs #99
