### PR TITLE
minecraft-server: java8-Linie nachziehen (4.0.0+up2026.8.2.java8)

### DIFF
--- a/minecraft-server/Chart.yaml
+++ b/minecraft-server/Chart.yaml
@@ -13,8 +13,8 @@ type: application
 # continuously, so a pod restart could pull a different image than the last one
 # without anything being recorded anywhere. The dated tags are immutable, so the
 # image is now pinned by the chart version like every other chart in this repo.
-version: 4.0.0+up2026.8.2.java21
-appVersion: "2026.8.2-java21"
+version: 4.0.0+up2026.8.2.java8
+appVersion: "2026.8.2-java8"
 
 maintainers:
   - name: jklein

--- a/minecraft-server/values.yaml
+++ b/minecraft-server/values.yaml
@@ -226,8 +226,8 @@ minecraft:
   # This value must match the Java line of the chart version: the image tag
   # comes from .Chart.AppVersion, so the JVM is fixed per published chart
   # version. Java 8 runs Minecraft up to 1.16.5, 1.18-1.20.4 need Java 17 and
-  # 1.20.5+ need Java 21. This chart publishes appVersion "2026.8.2-java21".
-  version: "1.21.1"
+  # 1.20.5+ need Java 21. This chart publishes appVersion "2026.8.2-java8".
+  version: "1.12.2"
 
 # curseforge, ftb and curseforgeServerpack are mutually exclusive - enabling
 # more than one is rejected by the chart (before 1.0.0 it silently rendered a


### PR DESCRIPTION
Zweite von drei Linien-Veröffentlichungen, die die Null-Absicherung aus #99 auf **jede** Java-Linie tragen. Templates und Schema sind für alle drei Linien dieselben; geändert werden nur die linienwählenden Felder.

```
version:            4.0.0+up2026.8.2.java21  ->  4.0.0+up2026.8.2.java8
appVersion:         "2026.8.2-java21"        ->  "2026.8.2-java8"
minecraft.version:  "1.21.1"                 ->  "1.12.2"
```

`1.12.2`, weil Java 8 Minecraft nur bis 1.16.5 fährt — der Wert, mit dem die Linie zuletzt veröffentlicht wurde.

## ⚠️ Was der Diff nicht zeigt: alpine 3.22 → 3.24

Der PR-Diff umfasst vier Zeilen. Das ist irreführend, wenn man wissen will, **was sich für ein java8-Release tatsächlich ändert.**

Die java8-Linie liegt zuletzt als `3.0.0+up2026.8.2.java8` draussen. Seitdem hat `main` das Init-Image des Serverpacks von `alpine:3.22` auf `alpine:3.24` gehoben (Commit `5a35ea4`) — und dieser Commit ist **nur auf der java21-Linie** gelandet. Der Bump fährt hier mit.

Gegenüber `main` ist er unsichtbar, weil in der Datei schon `3.24` steht. Gegenüber dem, was ein java8-Release **heute läuft**, ist er ein Basis-Image-Wechsel. Die Cluster-Seite muss das wissen, deshalb steht es hier und im Commit.

## Nachweis

Gerendert gegen `ci/minecraft-server/test-values.yaml`, mit aktiviertem Serverpack-Init-Container (den die CI-Werte sonst nicht durchlaufen), und **strukturell** verglichen — Dokumente nach kind/name gepaart, rekursiv über die Schlüssel — statt zeilenweise.

**1. Was die java8-Cluster-Seite bekommt** (`3.0.0+up2026.8.2.java8` → dieses Chart):

```
STRUCTURAL DIFFERENCES: 1
  initContainers[0].image: 'alpine:3.22' -> 'alpine:3.24'
```

Genau eine Abweichung, und es ist der oben benannte Bump. Die Null-Absicherung ändert erwartungsgemäss **nichts** am Default-Rendering — sie ändert, was ein *gelöschter* Block rendert.

**2. Was gegenüber `main` (java21) anders ist:**

```
STRUCTURAL DIFFERENCES: 2
  containers[0].image:   ':2026.8.2-java21' -> ':2026.8.2-java8'
  containers[0].env[14]: VERSION '1.21.1'   -> '1.12.2'
```

Genau zwei, und beide **sind** die Linienwahl. Härtung, die drei exec-Probes, Resources und der `init.sh`-chown stehen unverändert — kein Kollateralschaden beim Linienwechsel.

**3. Null-Absicherung trägt auf diesem Build.** Nicht erneut durchgesweept — #156 hat das auf identischen Templates belegt. Einmal bestätigt, dass sie mitkommt: `--set securityContext.pod=null --set securityContext.container=null` rendert byte-identisch zum Default.

**4.** `helm lint --strict minecraft-server` → 0 Findings. `helm package` → `minecraft-server-4.0.0+up2026.8.2.java8.tgz`.

## Warum `4.0.0` und nicht `4.0.1`

Gleiche Chart-Semver wie java21, anderer Build-Metadaten-Suffix — das ist das etablierte Muster dieses Charts (`3.0.0+up…java8` / `…java17` / `…java21` liefen genauso). Die Linien sind Geschwister derselben Chart-Version, keine Nachfolger. Der Versions-Check in `validate-charts.yml` vergleicht die Strings, nicht die Semver-Präzedenz, und `+`-Metadaten werden im OCI-Tag zu `_`, also kollidiert nichts.

## Nicht angefasst

Der `float64`-Quantity-Befund (#157) bleibt bewusst liegen — `multiplyQuantity` ist in allen 21 Charts dieselbe Kopie, ein Einzelfix erzeugt Drift statt Lösung.

Refs #99
