### PR TITLE
minecraft-server: java17-Linie nachziehen (4.0.0+up2026.8.2.java17)

### DIFF
--- a/minecraft-server/Chart.yaml
+++ b/minecraft-server/Chart.yaml
@@ -13,8 +13,8 @@ type: application
 # continuously, so a pod restart could pull a different image than the last one
 # without anything being recorded anywhere. The dated tags are immutable, so the
 # image is now pinned by the chart version like every other chart in this repo.
-version: 4.0.0+up2026.8.2.java8
-appVersion: "2026.8.2-java8"
+version: 4.0.0+up2026.8.2.java17
+appVersion: "2026.8.2-java17"
 
 maintainers:
   - name: jklein

--- a/minecraft-server/values.yaml
+++ b/minecraft-server/values.yaml
@@ -226,8 +226,8 @@ minecraft:
   # This value must match the Java line of the chart version: the image tag
   # comes from .Chart.AppVersion, so the JVM is fixed per published chart
   # version. Java 8 runs Minecraft up to 1.16.5, 1.18-1.20.4 need Java 17 and
-  # 1.20.5+ need Java 21. This chart publishes appVersion "2026.8.2-java8".
-  version: "1.12.2"
+  # 1.20.5+ need Java 21. This chart publishes appVersion "2026.8.2-java17".
+  version: "1.20.1"
 
 # curseforge, ftb and curseforgeServerpack are mutually exclusive - enabling
 # more than one is rejected by the chart (before 1.0.0 it silently rendered a


### PR DESCRIPTION
Dritte und letzte der drei Linien-Veröffentlichungen, die die Null-Absicherung aus #99 auf **jede** Java-Linie tragen. Templates und Schema sind für alle drei Linien dieselben; geändert werden nur die linienwählenden Felder.

```
version:            4.0.0+up2026.8.2.java8  ->  4.0.0+up2026.8.2.java17
appVersion:         "2026.8.2-java8"        ->  "2026.8.2-java17"
minecraft.version:  "1.12.2"                ->  "1.20.1"
```

`1.20.1`, weil Java 17 Minecraft 1.18–1.20.4 fährt — der Wert, mit dem die Linie zuletzt veröffentlicht wurde.

## ⚠️ Was der Diff nicht zeigt: alpine 3.22 → 3.24

Wie bei java8 (#159): Der PR-Diff umfasst vier Zeilen, und das ist irreführend, wenn man wissen will, **was sich für ein java17-Release tatsächlich ändert.**

Die java17-Linie liegt zuletzt als `3.0.0+up2026.8.2.java17` draussen. Seitdem hat `main` das Init-Image des Serverpacks von `alpine:3.22` auf `alpine:3.24` gehoben (Commit `5a35ea4`, damals nur auf der java21-Linie gelandet). Der Bump fährt hier mit.

Gegen `main` ist er unsichtbar, weil dort schon `3.24` steht — die java8-Veröffentlichung hat ihn dorthin gebracht. Gegenüber dem, was ein java17-Release **heute läuft**, ist es ein Basis-Image-Wechsel. Deshalb steht er hier und im Commit, statt entdeckt werden zu müssen.

## Nachweis

Gerendert gegen `ci/minecraft-server/test-values.yaml`, mit aktiviertem Serverpack-Init-Container, **strukturell** verglichen (Dokumente nach kind/name gepaart, rekursiv über die Schlüssel) statt zeilenweise.

**1. Was die java17-Cluster-Seite bekommt** (`3.0.0+up2026.8.2.java17` → dieses Chart):

```
STRUCTURAL DIFFERENCES: 1
  initContainers[0].image: 'alpine:3.22' -> 'alpine:3.24'
```

Genau eine Abweichung, und es ist der oben benannte Bump.

**2. Gegenüber `main` (java8):**

```
STRUCTURAL DIFFERENCES: 2
  containers[0].image:   ':2026.8.2-java8' -> ':2026.8.2-java17'
  containers[0].env[14]: VERSION '1.12.2'  -> '1.20.1'
```

Genau zwei, und beide **sind** die Linienwahl. Härtung, die drei exec-Probes, Resources und der `init.sh`-chown stehen unverändert.

**3. Linien-Invariante auf Dateiebene.** Gegen den Baum von `main` unterscheiden sich **nur** `Chart.yaml` und `values.yaml`, und dort nur die drei Linienfelder plus die Kommentarzeile, die den appVersion nennt. `_helpers.tpl`, `values.schema.json` und beide Templates sind **byte-identisch**. Das ist die Invariante aus #158, und nach diesem PR gilt sie über alle drei Linien.

**4. Null-Absicherung trägt auf diesem Build.** Nicht erneut durchgesweept — #156 hat sie auf identischen Templates belegt. Einmal bestätigt: beide Security-Kontexte genullt → byte-identisch zum Default.

**5.** `helm lint --strict minecraft-server` → 0 Findings. `helm package` → `minecraft-server-4.0.0+up2026.8.2.java17.tgz`.

## Nicht angefasst

- **#157** (`float64`-Quantity-Befund): `multiplyQuantity` ist in allen 21 Charts dieselbe Kopie, ein Einzelfix erzeugt Drift statt Lösung.
- **`seccompProfile`** (#84): ändert Laufzeitverhalten und gehört in eine eigene Änderung. Trivy meldet das weiterhin als `KSV-0104` / `KSV-0030` — unverändert gegenüber vorher, der Job bleibt grün.

## Danach

Nach dem Merge steht das Verzeichnis auf java17. Es fehlt die Rückstellung auf java21 als **`4.0.1+up2026.8.2.java21`** — `4.0.1`, nicht `4.0.0`, weil `4.0.0+up2026.8.2.java21` seit #156 schon in der Registry liegt und `helm push` einen bestehenden OCI-Tag kommentarlos überschreiben würde. Der Versions-Check in `validate-charts.yml` fängt das nicht: er vergleicht nur gegen `main`, die Registry kommt darin nicht vor.

Refs #99
