### PR TITLE
minecraft-server: Verzeichnis auf java21 zurückstellen (4.0.1+up2026.8.2.java21)

### DIFF
--- a/minecraft-server/Chart.yaml
+++ b/minecraft-server/Chart.yaml
@@ -13,8 +13,8 @@ type: application
 # continuously, so a pod restart could pull a different image than the last one
 # without anything being recorded anywhere. The dated tags are immutable, so the
 # image is now pinned by the chart version like every other chart in this repo.
-version: 4.0.0+up2026.8.2.java17
-appVersion: "2026.8.2-java17"
+version: 4.0.1+up2026.8.2.java21
+appVersion: "2026.8.2-java21"
 
 maintainers:
   - name: jklein

--- a/minecraft-server/values.yaml
+++ b/minecraft-server/values.yaml
@@ -226,8 +226,8 @@ minecraft:
   # This value must match the Java line of the chart version: the image tag
   # comes from .Chart.AppVersion, so the JVM is fixed per published chart
   # version. Java 8 runs Minecraft up to 1.16.5, 1.18-1.20.4 need Java 17 and
-  # 1.20.5+ need Java 21. This chart publishes appVersion "2026.8.2-java17".
-  version: "1.20.1"
+  # 1.20.5+ need Java 21. This chart publishes appVersion "2026.8.2-java21".
+  version: "1.21.1"
 
 # curseforge, ftb and curseforgeServerpack are mutually exclusive - enabling
 # more than one is rejected by the chart (before 1.0.0 it silently rendered a


### PR DESCRIPTION
Schliesst die dreiteilige Runde ab, die die Null-Absicherung aus #99 auf **jede** Java-Linie getragen hat. Reine Rückstellung des Verzeichnisses auf die neueste Linie.

```
version:            4.0.0+up2026.8.2.java17  ->  4.0.1+up2026.8.2.java21
appVersion:         "2026.8.2-java17"        ->  "2026.8.2-java21"
minecraft.version:  "1.20.1"                 ->  "1.21.1"
```

## Inhaltlich ändert sich nichts — gemessen, nicht behauptet

Gegen den java21-Stand, der aus #156 veröffentlicht wurde, unterscheidet sich der **gesamte Chart-Baum in genau einer Zeile**: der Chart-Version. `.Chart.Version` wird von keinem Template gelesen (`grep -rn "Chart.Version" minecraft-server/templates/` → nichts), also **kann** sich das Rendering nicht ändern — und tut es auch nicht:

```
4.0.0+up2026.8.2.java21 (veröffentlicht)  ->  dieses Chart
  Dateibaum:  1 abweichende Zeile (Chart.yaml version)
  Rendering:  BYTE-IDENTISCH
```

(CI-Werte, mit aktiviertem Serverpack-Init-Container.)

**Gegen `main` (java17):**

```
STRUCTURAL DIFFERENCES: 2
  containers[0].image:   ':2026.8.2-java17' -> ':2026.8.2-java21'
  containers[0].env[14]: VERSION '1.20.1'   -> '1.21.1'
```

Genau zwei, und beide **sind** die Linienwahl.

`helm lint --strict` → 0 Findings. `helm package` → `minecraft-server-4.0.1+up2026.8.2.java21.tgz`.

## Warum `4.0.1` und nicht `4.0.0`

`4.0.0+up2026.8.2.java21` liegt seit #156 in der Registry, und `helm push` überschreibt einen bestehenden OCI-Tag kommentarlos. Der Versions-Check in `validate-charts.yml` fängt das **nicht**: Er vergleicht `NEW_VERSION` nur gegen `BASE_VERSION` aus `github.base_ref` — dort stünde java17 — und schlägt nur bei Gleichstand an. Die Registry kommt in dem Check nicht vor. Ein erneut gepushtes `4.0.0` käme also grün durch das Tor und würde das veröffentlichte Artefakt still überschreiben.

Herleitung und Tragweite: **#160**.

## Der eigentliche Ertrag dieser Runde

Über die drei veröffentlichten Linien-Stände gemessen — java8 (`f7047b8`), java17 (`2b22ce5`) und java21 (dieses Chart):

- **`templates/` und `values.schema.json` sind byte-identisch** auf allen drei Linien. Alle drei tragen dieselbe Härtung, dieselben drei exec-Probes, dieselbe Resources-Behandlung und dieselben null-sicheren Fallbacks.
- **`values.yaml` unterscheidet sich nur** in `minecraft.version` und der Kommentarzeile, die den appVersion nennt.
- **Alle drei stehen jetzt auf `initImage: alpine:3.24`.** Der Bump aus `5a35ea4` hatte nur java21 erreicht; java8 und java17 haben ihn in #159 und #162 nachgeholt.

Damit ist die Lücke geschlossen, wegen der dieses Chart überhaupt aufgefallen ist: Es war das einzige der 21, bei dem ein genullter Security-Kontext die Härtung lautlos entfernt hat — und wegen des Ein-Verzeichnis-pro-Linie-Modells hätte eine Reparatur auf `main` allein nur eine der drei Linien erreicht.

Das ist zugleich der Zustand, den **#158** künftig maschinell festhalten soll: Die Linien dürfen sich **nur** in `version`, `appVersion` und `minecraft.version` unterscheiden. Gerade gilt das — es gibt nur nichts, was es festhält.

## Nicht angefasst

- **#157** (`float64`-Quantity-Befund) — `multiplyQuantity` ist in allen 21 Charts dieselbe Kopie.
- **#161** (`seccompProfile`) — muss über alle drei Linien nachgezogen werden und hat seine eigenen Unbekannten in gosu und dem Serverpack-Init-Container. Trivy meldet weiterhin `KSV-0104` / `KSV-0030`; unverändert gegenüber vorher, Job bleibt grün.

Refs #99
