### PR TITLE
freesailarr: one volume entry per media claim (2.0.2+up1.0.0)

### DIFF
--- a/freesailarr/Chart.yaml
+++ b/freesailarr/Chart.yaml
@@ -8,7 +8,7 @@ description: A Helm chart to deploy a Wireguard-tunneled media automation stack 
 
 type: application
 
-version: 2.0.1+up1.0.0
+version: 2.0.2+up1.0.0
 # The chart's own version marker, freely chosen and tied to no upstream. The
 # stack bundles nine independently versioned projects, so there is no single
 # "app version" to track here.

--- a/freesailarr/templates/NOTES.txt
+++ b/freesailarr/templates/NOTES.txt
@@ -87,10 +87,12 @@ THE MEDIA CLAIMS ARE YOURS, THE CONFIG VOLUMES ARE THE CHART'S
   Kubernetes makes every volumeMount its own bind mount and link() across two
   mount points fails with EXDEV regardless of subPath, so an import copies.
 
-  The containers write as {{ .Values.puid }}:{{ .Values.pgid }}. If the claims already hold data
-  owned by someone else, fix the ownership before the first start — the pod
-  will not do it for you (fsGroupChangePolicy is OnRootMismatch, deliberately,
-  so a large library is not recursively re-chowned on every start).
+  The containers write as {{ .Values.puid }}:{{ .Values.pgid }}. The claim's root directory has to be
+  writable for them, and a subPath directory the kubelet creates inherits that
+  root's mode — so fix the ownership before the first start. The pod will not
+  do it for you: fsGroupChangePolicy is OnRootMismatch so a large library is
+  not re-chowned on every start, and on an RWX claim a driver like Longhorn
+  (fsGroupPolicy ReadWriteOnceWithFSType) ignores fsGroup altogether.
 {{- if eq $replicas "0" }}
 
 SCALED TO ZERO

--- a/freesailarr/templates/_helpers.tpl
+++ b/freesailarr/templates/_helpers.tpl
@@ -220,6 +220,96 @@ alive. It is not what opens the ports today.
 {{- end -}}
 
 {{/*
+Whether a media category is mounted at all, i.e. whether at least one app that
+mounts it is enabled. "true" when it is, the empty string when it is not (an
+empty string is falsy in a template "if", so the result can be used directly).
+
+  downloads: qbittorrent, radarr, sonarr
+  movies:    radarr, bazarr
+  tv:        sonarr, bazarr
+
+Input: dict "root" $ "category" <"downloads"|"movies"|"tv">.
+*/}}
+{{- define "freesailarr.mediaCategoryEnabled" -}}
+{{- $v := .root.Values -}}
+{{- if eq .category "downloads" -}}
+{{- if or $v.qbittorrent.enabled $v.radarr.enabled $v.sonarr.enabled -}}true{{- end -}}
+{{- else if eq .category "movies" -}}
+{{- if or $v.radarr.enabled $v.bazarr.enabled -}}true{{- end -}}
+{{- else if eq .category "tv" -}}
+{{- if or $v.sonarr.enabled $v.bazarr.enabled -}}true{{- end -}}
+{{- else -}}
+{{- fail (printf "unknown media category %q" .category) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+The pod volume name a media category mounts (issue #164).
+
+Several categories may point at the same existingClaim - one library volume with
+the categories as sub-directories is the intended layout. A pod may reference
+such a claim only ONCE: two volume entries with the same claimName leave the pod
+in Init:0/1 forever, without a single kubelet event (measured on RKE2/Longhorn,
+with RWO as well as RWX). The claim therefore gets exactly one volume entry and
+the categories differ only in the subPath of their mounts.
+
+This helper names the owner of that entry: the FIRST ENABLED category, in the
+fixed order
+
+  downloads, movies, tv
+
+that carries the same claim. Two properties of that rule are load-bearing:
+
+  - The order is fixed and defined here, not derived from the values. A rule
+    like "the alphabetically smallest" or "whichever comes first in the values"
+    would move the volume name when an unrelated flag changes, and a moved
+    volume name is a pod restart.
+  - Only ENABLED categories can own the entry, because the three entries are
+    rendered under different conditions (see mediaCategoryEnabled above). A
+    disabled owner renders no entry, so its name would be a dangling reference
+    and the pod would be rejected by the API server. Example: with qbittorrent,
+    radarr and sonarr off and bazarr on, "downloads" is not mounted at all -
+    "movies" owns a claim shared by all three categories.
+
+A category with no claim owns itself, so the required() message for the missing
+claim still fires at the category the user actually configured.
+
+Input: dict "root" $ "category" <"downloads"|"movies"|"tv">.
+Usage (mount) : name: {{ include "freesailarr.mediaVolumeName" (dict "root" $ "category" "movies") }}
+Usage (volume): render the entry only for a category that owns itself.
+*/}}
+{{- define "freesailarr.mediaVolumeName" -}}
+{{- $root := .root -}}
+{{- $claim := (index $root.Values.media .category).existingClaim | default "" -}}
+{{- $owner := "" -}}
+{{- if $claim -}}
+{{- range $candidate := list "downloads" "movies" "tv" -}}
+{{- if not $owner -}}
+{{- if include "freesailarr.mediaCategoryEnabled" (dict "root" $root "category" $candidate) -}}
+{{- if eq ((index $root.Values.media $candidate).existingClaim | default "") $claim -}}
+{{- $owner = $candidate -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if not $owner -}}
+{{- $owner = .category -}}
+{{- end -}}
+media-{{ $owner }}
+{{- end -}}
+
+{{/*
+Whether a media category owns its volume entry, i.e. whether the volumes block
+renders an entry for it. "true" or the empty string, see mediaVolumeName above.
+
+Input: dict "root" $ "category" <"downloads"|"movies"|"tv">.
+*/}}
+{{- define "freesailarr.mediaVolumeOwned" -}}
+{{- if eq (include "freesailarr.mediaVolumeName" .) (printf "media-%s" .category) -}}true{{- end -}}
+{{- end -}}
+
+{{/*
 Recursive merge of an override onto defaults where null never deletes and set
 values always win, including false and 0 (issue #99).
 

--- a/freesailarr/templates/freesailarr.sfs.yaml
+++ b/freesailarr/templates/freesailarr.sfs.yaml
@@ -223,7 +223,7 @@ spec:
             - mountPath: /config
               name: qbittorrent-config
             - mountPath: /downloads
-              name: media-downloads
+              name: {{ include "freesailarr.mediaVolumeName" (dict "root" $ "category" "downloads") }}
               {{- with .Values.media.downloads.subPath }}
               subPath: {{ . | quote }}
               {{- end }}
@@ -319,12 +319,12 @@ spec:
             - mountPath: /config
               name: radarr-config
             - mountPath: /movies
-              name: media-movies
+              name: {{ include "freesailarr.mediaVolumeName" (dict "root" $ "category" "movies") }}
               {{- with .Values.media.movies.subPath }}
               subPath: {{ . | quote }}
               {{- end }}
             - mountPath: /downloads
-              name: media-downloads
+              name: {{ include "freesailarr.mediaVolumeName" (dict "root" $ "category" "downloads") }}
               {{- with .Values.media.downloads.subPath }}
               subPath: {{ . | quote }}
               {{- end }}
@@ -387,12 +387,12 @@ spec:
             - mountPath: /config
               name: sonarr-config
             - mountPath: /tv
-              name: media-tv
+              name: {{ include "freesailarr.mediaVolumeName" (dict "root" $ "category" "tv") }}
               {{- with .Values.media.tv.subPath }}
               subPath: {{ . | quote }}
               {{- end }}
             - mountPath: /downloads
-              name: media-downloads
+              name: {{ include "freesailarr.mediaVolumeName" (dict "root" $ "category" "downloads") }}
               {{- with .Values.media.downloads.subPath }}
               subPath: {{ . | quote }}
               {{- end }}
@@ -455,12 +455,12 @@ spec:
             - mountPath: /config
               name: bazarr-config
             - mountPath: /movies
-              name: media-movies
+              name: {{ include "freesailarr.mediaVolumeName" (dict "root" $ "category" "movies") }}
               {{- with .Values.media.movies.subPath }}
               subPath: {{ . | quote }}
               {{- end }}
             - mountPath: /tv
-              name: media-tv
+              name: {{ include "freesailarr.mediaVolumeName" (dict "root" $ "category" "tv") }}
               {{- with .Values.media.tv.subPath }}
               subPath: {{ . | quote }}
               {{- end }}
@@ -475,20 +475,37 @@ spec:
         # Writable /tmp/gluetun for gluetun's public-IP cache (see the mount).
         - name: gluetun-tmp
           emptyDir: {}
+        {{- /*
+        One volume entry per distinct media claim, not per category: several
+        categories may point at the same existingClaim, and a pod that
+        references one claim twice never starts (#164). The entry belongs to the
+        first enabled category that carries the claim; the others mount the same
+        entry with their own subPath - see the mediaVolumeName helper for the
+        ordering rule. Deliberately a template comment and not a "#" one like
+        its neighbours: it must not appear in the rendered manifest, so that a
+        setup with three separate claims still renders byte-identically to
+        2.0.1 and the diff itself proves the change is inert there.
+        */}}
         {{- if or .Values.qbittorrent.enabled .Values.radarr.enabled .Values.sonarr.enabled }}
+        {{- if include "freesailarr.mediaVolumeOwned" (dict "root" $ "category" "downloads") }}
         - name: media-downloads
           persistentVolumeClaim:
             claimName: {{ required "media.downloads.existingClaim is required when qbittorrent, radarr or sonarr is enabled" .Values.media.downloads.existingClaim }}
         {{- end }}
+        {{- end }}
         {{- if or .Values.radarr.enabled .Values.bazarr.enabled }}
+        {{- if include "freesailarr.mediaVolumeOwned" (dict "root" $ "category" "movies") }}
         - name: media-movies
           persistentVolumeClaim:
             claimName: {{ required "media.movies.existingClaim is required when radarr or bazarr is enabled" .Values.media.movies.existingClaim }}
         {{- end }}
+        {{- end }}
         {{- if or .Values.sonarr.enabled .Values.bazarr.enabled }}
+        {{- if include "freesailarr.mediaVolumeOwned" (dict "root" $ "category" "tv") }}
         - name: media-tv
           persistentVolumeClaim:
             claimName: {{ required "media.tv.existingClaim is required when sonarr or bazarr is enabled" .Values.media.tv.existingClaim }}
+        {{- end }}
         {{- end }}
         {{- if .Values.flaresolverr.enabled }}
         - name: flaresolverr-tmp

--- a/freesailarr/values.yaml
+++ b/freesailarr/values.yaml
@@ -54,6 +54,13 @@ securityContext:
   # group-writable for the non-root containers; fsGroupChangePolicy
   # OnRootMismatch avoids recursively re-chowning the (large, shared) media
   # claims on every pod start.
+  # How far that reaches is the CSI driver's decision, not this chart's, and the
+  # media claims are the case where it stops short: a driver whose fsGroupPolicy
+  # is ReadWriteOnceWithFSType - Longhorn's setting - applies fsGroup to RWO
+  # volumes only, so on an RWX media claim fsGroup is ignored outright and
+  # OnRootMismatch never even gets a say. The config claims are RWO and are
+  # covered normally. Consequence for the media claims: their root directory has
+  # to be writable for PUID/PGID by itself, see the media block below (#164).
   # seccompProfile RuntimeDefault applies the container runtime's default
   # syscall filter to every container in the pod, init containers included, and
   # is set at pod level so a container added later inherits it without the
@@ -82,9 +89,46 @@ storage:
 #   tv:        sonarr, bazarr
 #
 # subPath mounts a sub-directory of the claim instead of its root (null = the
-# claim root, i.e. one claim per category). The same existingClaim may back all
-# three categories with different subPaths - one library volume, one
-# sub-directory per category, e.g. downloads / movies / tv-shows.
+# claim root, i.e. one claim per category). The same existingClaim may back two
+# or all three categories, which is what makes the one-library-volume layout
+# possible - one claim, one sub-directory per category:
+#
+#   media:
+#     downloads: { existingClaim: media-library, subPath: downloads }
+#     movies:    { existingClaim: media-library, subPath: movies }
+#     tv:        { existingClaim: media-library, subPath: tv-shows }
+#
+# Categories sharing a claim get exactly ONE pod volume entry and differ only in
+# the subPath of their mounts (#164). That is not cosmetic: a pod that lists the
+# same claim twice never starts - it stays in Init:0/1 forever without a single
+# kubelet event (measured on RKE2/Longhorn, with RWO as well as RWX). The entry
+# is named after the first ENABLED category in the fixed order downloads,
+# movies, tv that carries the claim, so the name does not wander when an
+# unrelated app flag changes (see the mediaVolumeName helper).
+#
+# The subPath directories do NOT have to exist beforehand - the kubelet creates
+# a missing one. What it does not do is give it usable permissions: the created
+# directory belongs to root and inherits the mode of the CLAIM ROOT. So the one
+# thing that has to hold is:
+#
+#   the root directory of the claim must be writable for PUID/PGID.
+#
+# Do not count on fsGroup for that. Whether the kubelet applies fsGroup to a
+# volume at all is the CSI driver's decision (its fsGroupPolicy), not the pod's:
+# Longhorn ships ReadWriteOnceWithFSType, so fsGroup applies to its RWO volumes
+# and is silently ignored on an RWX claim - measured by the reporter of #164 on
+# the target cluster (kubectl get csidriver driver.longhorn.io -o
+# jsonpath='{.spec.fsGroupPolicy}').
+#
+# In practice this works out on Longhorn because Longhorn hands out its volume
+# root as mode 777, and a subPath directory created under it inherits those 777
+# - root-owned, but writable for everyone. That is a property of the driver, not
+# of Kubernetes. Measured in k3d against a claim whose root is 0755 and with no
+# fsGroup in effect: the kubelet creates /movies as root:root 0755 and the
+# container's `touch` fails with EPERM. On such a driver, prepare the claim root
+# once (chown 1000:1000 or chmod g+w with the right group) before the first
+# start - the chart deliberately does not chown anything: a multi-TB library
+# must not be walked on every pod start.
 #
 # What this buys and what it does NOT buy - measured in a k3d cluster against
 # this chart, because the usual argument for a shared volume is hardlinking:


### PR DESCRIPTION
Fixes #164

Two media categories on the same `existingClaim` produced two pod volumes with an identical `claimName`, and such a pod never starts. The volume list is now deduplicated by claim name: a shared claim gets exactly **one** entry, and the categories differ only in the `subPath` of their mounts.

## What changed

- **`_helpers.tpl`** — `freesailarr.mediaVolumeName` returns the volume name a category mounts: the **first enabled** category in the fixed, documented order `downloads, movies, tv` that carries the same claim. A sibling helper `freesailarr.mediaCategoryEnabled` encodes the three activation conditions (`downloads`: qbittorrent|radarr|sonarr, `movies`: radarr|bazarr, `tv`: sonarr|bazarr), and `freesailarr.mediaVolumeOwned` answers "does this category render its own entry".

  The order is fixed in the helper rather than derived from the values, because a rule like "whichever comes first in the values" would move the volume name when an unrelated flag changes — and a moved volume name is a pod restart. The restriction to *enabled* categories is what keeps the owner from being a category whose entry is never rendered (see test case D2 below).

- **`freesailarr.sfs.yaml`** — the three volume entries render only for a category that owns itself. The three `required` messages are untouched and still fire at the category the user configured: a category with no claim owns itself, so it always reaches its own `required`.

- **mounts** — all six media mounts (qbittorrent, radarr ×2, sonarr ×2, bazarr ×2) go through the helper. **Deviation from the plan**, which named only the four `movies`/`tv` mounts: `downloads` is first in the fixed order, so it always owns its own entry and the literal name would be correct today — but only *because* of that ordering. Routing all six through the helper means the order is load-bearing in exactly one place instead of being silently assumed in three others. The rendered output is identical either way.

- **`values.yaml` / `NOTES.txt`** — documentation, see the directory question below.

- **`Chart.yaml`** — `2.0.2+up1.0.0`, `appVersion` unchanged. Patch, because with distinct claims the render is byte-identical (proof below), and a shared claim could not start at all before, so no running state changes shape.

One implementation detail worth flagging: the explanatory comment in the volumes block is a template comment (`{{/* … */}}`), not a `#` comment like its neighbours, so it does not land in the rendered manifest — that is what keeps the byte-identity proof a literal zero-line diff.

## Rendering proof

Values used: `secrets.gluetunSecretRef` set, `ingress.enabled: false`, everything else default. "before" = chart at 2.0.1 (`git stash`-clean tree), "after" = this branch.

**(a) One claim for all three categories** (`media-library` + subPaths `downloads` / `movies` / `tv-shows`) — three entries collapse into one, all six mounts point at it:

```diff
             - mountPath: /movies
-              name: media-movies
+              name: media-downloads
               subPath: "movies"
             - mountPath: /tv
-              name: media-tv
+              name: media-downloads
               subPath: "tv-shows"
...
         - name: media-downloads
           persistentVolumeClaim:
             claimName: media-library
-        - name: media-movies
-          persistentVolumeClaim:
-            claimName: media-library
-        - name: media-tv
-          persistentVolumeClaim:
-            claimName: media-library
```

Result: exactly **one** entry (`media-downloads` → `media-library`), and every `/downloads`, `/movies`, `/tv` mount in qbittorrent, radarr, sonarr and bazarr references it.

**(b) Two shared, one separate** (`downloads-claim` for downloads, `media-library` for movies+tv) — `media-tv` disappears, its mounts move to `media-movies`, `media-downloads` stays untouched:

```diff
             - mountPath: /tv
-              name: media-tv
+              name: media-movies
               subPath: "tv-shows"
...
-        - name: media-tv
-          persistentVolumeClaim:
-            claimName: media-library
```

**(c) Three distinct claims** — byte-identical to 2.0.1:

```
$ diff before-c.yaml after-c.yaml && echo IDENTICAL
IDENTICAL
```

(The chart version does not appear anywhere in the rendered manifests, so this is the whole comparison, not "identical except the version".)

**(d) The activation case.** Two variants, because the second is the one that would break a naive implementation:

- **D1** — the case from the plan: `radarr` off, `bazarr` on, movies and tv on one claim. `movies` is still enabled (through bazarr), owns the entry, and sonarr's `/tv` plus bazarr's `/movies` + `/tv` all point at `media-movies`.
- **D2** — qbittorrent, radarr **and** sonarr off, bazarr on, and **all three** categories on the same claim. `downloads` is not mounted by anything, so it renders no entry and must not own one. Rendered result:

  ```
  $ grep -n "name: media" after-d2.yaml
  508:              name: media-movies      # bazarr /movies
  511:              name: media-movies      # bazarr /tv
  523:        - name: media-movies          # the single volume entry
  $ grep -c "media-downloads" after-d2.yaml
  0
  ```

  A canonical owner picked without the enabled check would have produced `media-downloads` here — a reference to a volume that does not exist, and the API server would reject the pod.

`required` messages still fire per category — e.g. `movies` set, `tv` null with sonarr enabled:

```
Error: execution error at (freesailarr/templates/freesailarr.sfs.yaml:507:26): media.tv.existingClaim is required when sonarr or bazarr is enabled
```

`helm lint --strict freesailarr`: `1 chart(s) linted, 0 chart(s) failed` (only the known `icon is recommended` INFO).

## The directory question — measured

The original report said the `subPath` directories must exist on a fresh volume. They do not, and the ownership problem suspected in the plan is **not** what happens either. Measured in k3d (three throwaway claims, busybox pods), and independently by the reporter on the target cluster (Longhorn, RWX, encrypted):

1. **Fresh claim, directory missing** — the kubelet creates it. On a claim whose root is `0777` (both local-path and Longhorn hand out `0777`), the created directory inherits that mode and the app user writes into it, even though the directory belongs to root:

   ```
   $ kubectl exec subpath-probe -c asroot -- ls -ldn /all /movies /tv
   drwxrwsrwx 4 0 1000 4096 /all
   drwxrwsrwx 2 0 1000 4096 /movies
   drwxrwsrwx 2 0 1000 4096 /tv
   $ kubectl exec subpath-probe -c asuser -- sh -c 'id; touch /movies/probe && echo OK'
   uid=1000 gid=1000 groups=1000
   OK
   ```

2. **The raw provisioner mode** — asked for explicitly, and it is the limit of this cluster as a test bed:

   ```
   $ kubectl logs raw-root-mode          # pod with NO fsGroup, root container
   /all uid=0 gid=0 mode=777
   ```

   local-path hands out `0777` exactly like Longhorn, so **k3d cannot show a difference between the two backends here**. The measurement above therefore confirms the mechanism, not a backend distinction.

3. **A `0755` root, with fsGroup not in effect** — the case a stricter driver (or Longhorn's `fsGroupPolicy: ReadWriteOnceWithFSType` on an RWX claim, where fsGroup is ignored) actually produces:

   ```
   $ kubectl logs seed-strict
   /all uid=0 gid=0 mode=755
   $ kubectl exec strict-root-probe -c asuser -- sh -c 'id; stat -c "%n uid=%u gid=%g mode=%a" /all /movies; touch /movies/probe'
   uid=1000 gid=1000 groups=1000
   /all uid=0 gid=0 mode=755
   /movies uid=0 gid=0 mode=755
   touch: /movies/probe: Permission denied
   ```

   The kubelet still **creates** `/movies` — it did not exist before — but it inherits `0755 root:root` and the app user cannot write.

**Conclusion: document, do not build.** No init container, no chown, nothing added to the chart. What the documentation now says is the invariant that actually holds — *the claim root must be writable for PUID/PGID*; the kubelet creates the subPath directories and they inherit the root's mode — plus the explicit warning that the `0777` behaviour is a property of Longhorn and local-path, not of Kubernetes.

I also straightened the existing `securityContext` comment, because it promised more than it holds: it presented `fsGroupChangePolicy: OnRootMismatch` as what protects the large media claims from a recursive chown, while on an RWX Longhorn claim fsGroup is not applied at all (`fsGroupPolicy: ReadWriteOnceWithFSType`) and the policy never gets a say. The **values themselves are unchanged** — `fsGroup: 1000` and `OnRootMismatch` stay exactly as they were, and they still do their job for the eight RWO config claims. Same correction, one sentence, in `NOTES.txt`.

## k3d run — and what it does not prove

Throwaway `k3d` cluster, stub `OnePasswordItem` CRD, **dummy** gluetun secret, `downloads-claim` separate and `media-library` shared between movies and tv:

```
$ kubectl get pod fs-freesailarr-sfs-0 -o wide
NAME                   READY   STATUS    RESTARTS   AGE     IP
fs-freesailarr-sfs-0   0/9     Running   1          3m48s   10.42.0.27

$ kubectl get pod fs-freesailarr-sfs-0 -o jsonpath='{range .status.conditions[*]}{.type}={.status}{"\n"}{end}'
PodReadyToStartContainers=True
Initialized=True
Ready=False
ContainersReady=False
PodScheduled=True

$ kubectl get pod fs-freesailarr-sfs-0 -o jsonpath='...spec.volumes...'
media-downloads -> downloads-claim
media-movies    -> media-library        # one entry, not two

$ kubectl exec fs-freesailarr-sfs-0 -c bazarr -- grep -E " /movies | /tv " /proc/mounts
/dev/vda1 /movies ext4 rw,relatime,discard 0 0
/dev/vda1 /tv ext4 rw,relatime,discard 0 0
```

All nine containers were created and started, zero `FailedMount` events, and the shared claim appears once with `/movies` and `/tv` bind-mounted out of it. `Ready=False` is expected and unrelated: gluetun's health server never goes green with a dummy Wireguard key, which is exactly why `freesailarr` sits in `ci/excluded-charts.txt`. The cluster was deleted afterwards.

**The limit of this run, plainly:** k3d uses local-path, not Longhorn. A green k3d run shows that the generated pod spec is valid and that the pod starts and mounts. It does **not** show that the `Init:0/1` hang on RKE2/Longhorn is gone — that runtime proof can only come from the target cluster. Since `freesailarr` is excluded from the CI install-test, this run is the only runtime evidence in the pipeline, and it is worth no more than what is written here.

`README.md` needs no change: its `freesailarr` row already describes the one-claim-serves-all-categories layout — this PR is what makes that description true.
